### PR TITLE
Fix add_leave so that elifs work.

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -157,6 +157,9 @@ class IRBuilder(NodeVisitor[int]):
         assert False, 'Unsupported lvalue: %r' % lvalue
 
     def visit_if_stmt(self, stmt: IfStmt) -> int:
+        # If statements are normalized
+        assert len(stmt.expr) == 1
+
         branches = self.process_conditional(stmt.expr[0])
         if_body = self.new_block()
         self.set_branches(branches, True, if_body)
@@ -179,7 +182,7 @@ class IRBuilder(NodeVisitor[int]):
         return -1
 
     def add_leave(self) -> Optional[Goto]:
-        if self.blocks[-1][-1].ops and not isinstance(self.blocks[-1][-1].ops[-1], Return):
+        if not self.blocks[-1][-1].ops or not isinstance(self.blocks[-1][-1].ops[-1], Return):
             leave = Goto(-1)
             self.add(leave)
             return leave

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -306,3 +306,33 @@ def f(x: List[int]) -> None: pass # E: Name 'List' is not defined
 [case testReportSemanticaAnalysisError2]
 def f() -> None:
     x # E: Name 'x' is not defined
+
+[case testElif]
+def f(n: int) -> int:
+    if n < 0:
+        x = 1
+    elif n == 0:
+        x = 1
+    else:
+        x = 2
+    return x
+[out]
+def f(n):
+    n, r0, x, r1 :: int
+L0:
+    r0 = 0
+    if n < r0 goto L1 else goto L2 :: int
+L1:
+    x = 1
+    goto L6
+L2:
+    r1 = 0
+    if n == r1 goto L3 else goto L4 :: int
+L3:
+    x = 1
+    goto L5
+L4:
+    x = 2
+L5:
+L6:
+    return x


### PR DESCRIPTION
Somehow or other elifs are already normalized in the AST that
we are receiving, so we only need to fix add_leave to work in
a scenario where the current block is empty.

Add an assert to ensure that elif is normalized.