### PR TITLE
Support unary minus

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -256,6 +256,21 @@ class IRBuilder(NodeVisitor[int]):
         '>>': PrimitiveOp.INT_SHR,
     }
 
+    def visit_unary_expr(self, expr: UnaryExpr) -> int:
+        if expr.op != '-':
+            assert False, 'Unsupported unary operation'
+
+        etype = type_to_rttype(self.types[expr.expr])
+        reg = self.accept(expr.expr)
+        if etype.name != 'int':
+            assert False, 'Unsupported unary operation'
+        
+        target = self.alloc_target(RTType('int'))
+        zero = self.accept(IntExpr(0))
+        self.add(PrimitiveOp(target, PrimitiveOp.INT_SUB, zero, reg))
+
+        return target
+
     def visit_op_expr(self, expr: OpExpr) -> int:
         ltype = type_to_rttype(self.types[expr.left])
         rtype = type_to_rttype(self.types[expr.right])

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -336,3 +336,15 @@ L4:
 L5:
 L6:
     return x
+
+[case testUnaryMinus]
+def f(n: int) -> int:
+    return -1
+[out]
+def f(n):
+    n, r0, r1, r2 :: int
+L0:
+    r0 = 1
+    r2 = 0
+    r1 = r2 - r0 :: int
+    return r1


### PR DESCRIPTION
Implement visit_op_expr but only for unary minus on ints for now.

Reuse 0-x to avoid creating a new primitive C operation.