### PR TITLE
Add .travis.yml for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: false
+language: python
+cache: pip
+
+python:
+  - "3.5"
+  - "3.6"
+
+install:
+  - pip install -U pip setuptools wheel
+  - pip install -r mypy/test-requirements.txt
+
+script:
+  - export PYTHONPATH=`pwd`/mypy
+  - export PYTHONVERSION=`python --version | awk '{ print $2 }'`
+  - export PYTHONCONFIG="/opt/python/$PYTHONVERSION/bin/python-config"
+  - export LD_LIBRARY_PATH="/opt/python/$PYTHONVERSION/lib"
+  - pytest -n4 mypyc

--- a/lib-rt/Makefile
+++ b/lib-rt/Makefile
@@ -3,6 +3,7 @@
 .PHONY: clean test
 
 OS := $(shell uname)
+PYTHONCONFIG ?= python3-config
 
 CFLAGS += -I ../googletest -I ../googletest/include -std=c++11
 
@@ -10,7 +11,7 @@ ifeq ($(OS),Darwin)
     CFLAGS += -I /Library/Frameworks/Python.framework/Versions/3.6/include/python3.6m
     CFLAGS += -mmacosx-version-min=10.10
 else
-    CFLAGS += $(shell python3-config --cflags)
+    CFLAGS += $(shell $(PYTHONCONFIG) --cflags)
 endif
 
 ifeq ($(OS),Darwin)
@@ -18,7 +19,7 @@ ifeq ($(OS),Darwin)
     LDFLAGS += -L/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/config-3.6m-darwin
     LDFLAGS += -lpython3.6m -lcrt1.o -mmacosx-version-min=10.10
 else
-    LDFLAGS += $(shell python3-config --ldflags)
+    LDFLAGS += $(shell $(PYTHONCONFIG) --ldflags)
 endif
 
 test_capi.o: test_capi.cc CPy.h


### PR DESCRIPTION
I had to use some workarounds to get things to work:

- Find the right python-config from outside virtualenv since
  otherwise we'd call the wrong one belonging to system Python.

- Explicitly set LD_LIBRARY_PATH (not sure why this is needed).