### PR TITLE
Add support for tuples.

### DIFF
--- a/test-data/run.test
+++ b/test-data/run.test
@@ -148,3 +148,13 @@ print(f(False))
 [out]
 False
 True
+
+[case testTuple]
+from typing import Tuple
+def f(x: Tuple[int, int]) -> Tuple[int,int]:
+    return x
+[file driver.py]
+from native import f
+print(f((1,2)))
+[out]
+(1, 2)


### PR DESCRIPTION
This had to reorganize a lot of the emitters code because the parts
outside of Emitter got too complicated and we needed to share code
between visit_box and the return result boxing and so forth.

NOTE: The tuples have basically nothing supported (indexing does
not work and no time to figure out why). However, the code generation
and unboxing/inner unboxing IS functional.