### PR TITLE
Disable automatic `return None` for non-Nonetype.

### DIFF
--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -6,7 +6,7 @@ from typing import Dict, Tuple, List, Set, TypeVar, Iterator
 
 from mypyc.ops import (
     BasicBlock, OpVisitor, PrimitiveOp, Assign, LoadInt, RegisterOp, Goto,
-    Branch, Return, Call, Environment, Box, Unbox, Cast, Op
+    Branch, Return, Call, Environment, Box, Unbox, Cast, Op, Unreachable
 )
 
 
@@ -97,6 +97,9 @@ class MaybeDefinedVisitor(BaseAnalysisVisitor):
     def visit_return(self, op: Return) -> GenAndKill:
         return set(), set()
 
+    def visit_unreachable(self, op: Unreachable) -> GenAndKill:
+        return set(), set()
+
     def visit_register_op(self, op: RegisterOp) -> GenAndKill:
         if op.dest is not None:
             return {op.dest}, set()
@@ -127,6 +130,9 @@ class MustDefinedVisitor(BaseAnalysisVisitor):
         return set(), set()
 
     def visit_return(self, op: Return) -> GenAndKill:
+        return set(), set()
+
+    def visit_unreachable(self, op: Unreachable) -> GenAndKill:
         return set(), set()
 
     def visit_register_op(self, op: RegisterOp) -> GenAndKill:
@@ -165,6 +171,9 @@ class BorrowedArgumentsVisitor(BaseAnalysisVisitor):
     def visit_return(self, op: Return) -> GenAndKill:
         return set(), set()
 
+    def visit_unreachable(self, op: Unreachable) -> GenAndKill:
+        return set(), set()
+
     def visit_register_op(self, op: RegisterOp) -> GenAndKill:
         if op.dest in self.args:
             return set(), {op.dest}
@@ -196,6 +205,9 @@ class UndefinedVisitor(BaseAnalysisVisitor):
     def visit_return(self, op: Return) -> GenAndKill:
         return set(), set()
 
+    def visit_unreachable(self, op: Unreachable) -> GenAndKill:
+        return set(), set()
+
     def visit_register_op(self, op: RegisterOp) -> GenAndKill:
         return set(), {op.dest}
 
@@ -225,6 +237,9 @@ class LivenessVisitor(BaseAnalysisVisitor):
 
     def visit_return(self, op: Return) -> GenAndKill:
         return {op.reg}, set()
+
+    def visit_unreachable(self, op: Unreachable) -> GenAndKill:
+        return set(), set()
 
     def visit_register_op(self, op: RegisterOp) -> GenAndKill:
         gen = set(op.sources())

--- a/test-data/analysis.test
+++ b/test-data/analysis.test
@@ -46,16 +46,14 @@ L1:
 L2:
     return x
 L3:
-    r1 = None
-    return r1
+    unreachable
 
 (0, 0)   {a}                     {a, x}
 (0, 1)   {a, x}                  {a, x, r0}
 (0, 2)   {a, x, r0}              {a, x}
 (1, 0)   {a}                     {}
 (2, 0)   {x}                     {}
-(3, 0)   {}                      {r1}
-(3, 1)   {r1}                    {}
+(3, 0)   {}                      {}
 
 [case testSpecial_Liveness]
 def f() -> int:

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -276,7 +276,6 @@ def f(n: int) -> int:
 [out]
 def f(n):
     n, r0, r1, r2, r3, r4, r5, r6, r7, r8 :: int
-    r9 :: None
 L0:
     r0 = 1
     if n <= r0 goto L1 else goto L2 :: int
@@ -293,8 +292,7 @@ L2:
     r8 = r2 + r5 :: int
     return r8
 L3:
-    r9 = None
-    return r9
+    unreachable
 
 [case testReportTypeCheckError]
 def f() -> None:
@@ -409,7 +407,6 @@ def f(x: bool) -> bool:
 [out]
 def f(x):
     x, r0, r1 :: bool
-    r2 :: None
 L0:
     if x goto L1 else goto L2 :: bool
 L1:
@@ -419,5 +416,4 @@ L2:
     r1 = True
     return r1
 L3:
-    r2 = None
-    return r2
+    unreachable


### PR DESCRIPTION
We don't need it since mypy won't let us write code that doesn't
return in the first place (if the type is not None). But this creates
another problem - we will end up with a basic block with no branching
at the end.

To get around this, add 'Unreachable' whose only job is to signal the
block formatter that its okay for there to not be a leave in the block.
It is completely ignored by all visitors except analysis, for which it
acts (most of the time) like a Return.

Fixes #29