### PR TITLE
Add support for dict update

### DIFF
--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -110,7 +110,8 @@ class FunctionEmitterVisitor(OpVisitor):
         dest = self.reg(op.dest) if op.dest is not None else None
 
         if op.desc.kind == OP_BINARY:
-            assert dest is not None
+            if not op.desc.is_void:
+                assert dest is not None
             left = self.reg(op.args[0])
             right = self.reg(op.args[1])
             if op.desc in FunctionEmitterVisitor.OP_MAP:
@@ -145,6 +146,13 @@ class FunctionEmitterVisitor(OpVisitor):
                                 'if (%s < 0)' % temp,
                                 '    abort();',
                                 '%s = %s;' % (dest, temp))
+            elif op.desc is PrimitiveOp.DICT_UPDATE:
+                # NOTE: PyDict_Update is technically not equivalent to update, but the cases where it
+                # differs (when the second argument has no keys) should never typecheck for us, so the
+                # difference is irrelevant.
+                self.emit_lines(
+                    'if (PyDict_Update(%s, %s) == -1)' % (self.reg(op.args[0]), self.reg(op.args[1])),
+                    '    abort();')
             else:
                 assert False, op.desc
 
@@ -198,6 +206,7 @@ class FunctionEmitterVisitor(OpVisitor):
             self.emit_lines(
                 'if (PyList_Append(%s, %s) == -1)' % (self.reg(op.args[0]), self.reg(op.args[1])),
                 '    abort();')
+
         else:
             assert len(op.args) == 1
             assert dest is not None

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -628,6 +628,7 @@ VAR_ARG = -1
 # Primitive op inds
 OP_MISC = 0    # No specific kind
 OP_BINARY = 1  # Regular binary operation such as +
+OP_SPECIAL_METHOD_CALL = 2
 
 OpDesc = NamedTuple('OpDesc', [('name', str),        # Symbolic name of the operation
                                ('num_args', int),    # Number of args (or VAR_ARG for any number)
@@ -647,10 +648,14 @@ def make_op(name: str, num_args: int, typ: str, format_str: str = None,
             assert is_void
             format_str = '{args[0]}[{args[1]}] = {args[2]} :: %s' % typ
         elif kind == OP_BINARY:
+            assert not is_void
+            format_str = '{dest} = {args[0]} %s {args[1]} :: %s' % (name, typ)
+        elif kind == OP_SPECIAL_METHOD_CALL:
+            args_joined = ', '.join(['{args[%d]}' % i for i in range (1, num_args)])
             if is_void:
-                format_str = '{args[0]} %s {args[1]} :: %s' % (name, typ)
+                format_str = ('{args[0]}.%s ' + args_joined + ' :: %s') % (name, typ)
             else:
-                format_str = '{dest} = {args[0]} %s {args[1]} :: %s' % (name, typ)
+                format_str = ('{dest} = {args[0]}.%s ' + args_joined + ' :: %s') % (name, typ)
         elif num_args == 1:
             if name[-1].isalpha():
                 name += ' '
@@ -703,7 +708,7 @@ class PrimitiveOp(RegisterOp):
     DICT_SET = make_op('[]=', 3, 'dict', is_void=True)
     NEW_DICT = make_op('new', 0, 'dict', format_str='{dest} = {{}}')
     DICT_CONTAINS = make_op('in', 2, 'dict', kind=OP_BINARY)
-    DICT_UPDATE = make_op('update', 2, 'dict', kind=OP_BINARY, is_void=True)
+    DICT_UPDATE = make_op('update', 2, 'dict', kind=OP_SPECIAL_METHOD_CALL, is_void=True)
 
     # Sequence Tuple
     HOMOGENOUS_TUPLE_GET = make_op('[]', 2, 'sequence_tuple', kind=OP_BINARY)

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -647,7 +647,10 @@ def make_op(name: str, num_args: int, typ: str, format_str: str = None,
             assert is_void
             format_str = '{args[0]}[{args[1]}] = {args[2]} :: %s' % typ
         elif kind == OP_BINARY:
-            format_str = '{dest} = {args[0]} %s {args[1]} :: %s' % (name, typ)
+            if is_void:
+                format_str = '{args[0]} %s {args[1]} :: %s' % (name, typ)
+            else:
+                format_str = '{dest} = {args[0]} %s {args[1]} :: %s' % (name, typ)
         elif num_args == 1:
             if name[-1].isalpha():
                 name += ' '
@@ -700,6 +703,7 @@ class PrimitiveOp(RegisterOp):
     DICT_SET = make_op('[]=', 3, 'dict', is_void=True)
     NEW_DICT = make_op('new', 0, 'dict', format_str='{dest} = {{}}')
     DICT_CONTAINS = make_op('in', 2, 'dict', kind=OP_BINARY)
+    DICT_UPDATE = make_op('update', 2, 'dict', kind=OP_BINARY, is_void=True)
 
     # Sequence Tuple
     HOMOGENOUS_TUPLE_GET = make_op('[]', 2, 'sequence_tuple', kind=OP_BINARY)

--- a/mypyc/refcount.py
+++ b/mypyc/refcount.py
@@ -27,7 +27,7 @@ from mypyc.analysis import (
 )
 from mypyc.ops import (
     FuncIR, BasicBlock, Assign, RegisterOp, DecRef, IncRef, Branch, Goto, Environment,
-    Return, Op, Register, Label, Cast, Box, Unbox
+    Return, Op, Register, Label, Cast, Box, Unbox, PrimitiveOp
 )
 
 

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -203,6 +203,12 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                                 abort();
                          """)
 
+    def test_dict_update(self) -> None:
+        self.assert_emit(PrimitiveOp(None, PrimitiveOp.DICT_UPDATE, self.d, self.o),
+                        """if (PyDict_Update(cpy_r_d, cpy_r_o) == -1)
+                               abort();
+                        """)
+
     def test_new_dict(self) -> None:
         self.assert_emit(PrimitiveOp(self.d, PrimitiveOp.NEW_DICT),
                          """cpy_r_d = PyDict_New();

--- a/test-data/fixtures/ir.py
+++ b/test-data/fixtures/ir.py
@@ -1,7 +1,7 @@
 # These builtins stubs are used implicitly in AST to IR generation
 # test cases.
 
-from typing import TypeVar, Generic, List, Iterator, Iterable, Sized
+from typing import TypeVar, Generic, List, Iterator, Iterable, Sized, Dict
 
 T = TypeVar('T')
 S = TypeVar('S')
@@ -52,6 +52,7 @@ class dict(Generic[T, S]):
     def __getitem__(self, x: T) -> S: pass
     def __setitem__(self, x: T, y: S) -> None: pass
     def __contains__(self, x: T) -> bool: pass
+    def update(self, x: Dict[T, S]) -> None: pass
 
 def len(o: Sized) -> int: pass
 def print(*object) -> None: pass

--- a/test-data/genops-dict.test
+++ b/test-data/genops-dict.test
@@ -114,6 +114,6 @@ def f(a, b):
     a, b :: dict
     r0 :: None
 L0:
-    a update b :: dict
+    a.update b :: dict
     r0 = None
     return r0

--- a/test-data/genops-dict.test
+++ b/test-data/genops-dict.test
@@ -104,3 +104,16 @@ L2:
     return r4
 L3:
     unreachable
+
+[case testDictUpdate]
+from typing import Dict
+def f(a: Dict[int, int], b: Dict[int, int]) -> None:
+    a.update(b)
+[out]
+def f(a, b):
+    a, b :: dict
+    r0 :: None
+L0:
+    a update b :: dict
+    r0 = None
+    return r0

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -279,3 +279,17 @@ assert f(None) is None
 assert f(a) is a
 assert g(None) == 1
 assert g(a) == 2
+
+[case testDictUpdate]
+from typing import Dict
+def f(x: int) -> int:
+    dict1 = {} # type: Dict[int, int]
+    dict1[1] = 1
+    dict2 = {} # type: Dict[int, int]
+    dict2[x] = 2
+    dict1.update(dict2)
+    return dict1[1]
+[file driver.py]
+from native import f
+assert f(1) == 2
+assert f(2) == 1


### PR DESCRIPTION
Originally I thought this would be a simple change to get
reacustomed to the codebase. Turns out I had to go down a
rabbithole because is_void binary ops don't work. Originally
I fixed them to work but the second commit gets rid of this
and just adds a new kind which is designed for special method
calls.

As a side note, I saw an instance where we pass INVALID_REGISTER
as an argument to a function which takes Optional[Register].
I *think* this is a bug, because in refcount.py we only avoid
dealing with the dest register if its None; we don't have a
INVALID_REGISTER check. It errored when I passed in INVALID_REGISTER
(because I was cargo culting). I'm not sure why the other usage
isn't failing but I can send in another PR to fix that to None
if it doesn't break anything...