### PR TITLE
Add support for unicode type/literals

### DIFF
--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -7,7 +7,7 @@ from typing import Dict, Tuple, List, Set, TypeVar, Iterator, Generic
 from mypyc.ops import (
     BasicBlock, OpVisitor, PrimitiveOp, Assign, LoadInt, RegisterOp, Goto,
     Branch, Return, Call, Environment, Box, Unbox, Cast, Op, Unreachable,
-    TupleGet, GetAttr, SetAttr, PyCall, LoadStatic, PyGetAttr, Label, Register
+    TupleGet, GetAttr, SetAttr, PyCall, LoadStatic, PyGetAttr, Label, Register,
 )
 
 

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -21,7 +21,7 @@ from mypy.nodes import (
     IfStmt, Node, UnaryExpr, ComparisonExpr, WhileStmt, Argument, CallExpr, IndexExpr, Block,
     Expression, ListExpr, ExpressionStmt, MemberExpr, ForStmt, RefExpr, Lvalue, BreakStmt,
     ContinueStmt, ConditionalExpr, OperatorAssignmentStmt, TupleExpr, ClassDef, TypeInfo,
-    Import, ImportFrom, ImportAll, DictExpr, ARG_POS, MODULE_REF
+    Import, ImportFrom, ImportAll, DictExpr, StrExpr, ARG_POS, MODULE_REF
 )
 from mypy.types import Type, Instance, CallableType, NoneTyp, TupleType, UnionType
 from mypy.visitor import NodeVisitor
@@ -32,7 +32,7 @@ from mypyc.ops import (
     PrimitiveOp, Branch, Goto, RuntimeArg, Call, Box, Unbox, Cast, TupleRType,
     Unreachable, TupleGet, ClassIR, UserRType, ModuleIR, GetAttr, SetAttr, LoadStatic,
     PyGetAttr, PyCall, IntRType, BoolRType, ListRType, SequenceTupleRType, ObjectRType, NoneRType,
-    OptionalRType, DictRType, c_module_name, INVALID_REGISTER, INVALID_LABEL
+    OptionalRType, DictRType, UnicodeRType, c_module_name, INVALID_REGISTER, INVALID_LABEL
 )
 
 
@@ -42,7 +42,7 @@ def build_ir(module: MypyFile,
     builder = IRBuilder(types, mapper)
     module.accept(builder)
 
-    return ModuleIR(builder.imports, builder.functions, builder.classes)
+    return ModuleIR(builder.imports, builder.unicode_literals, builder.functions, builder.classes)
 
 
 class Mapper:
@@ -55,6 +55,8 @@ class Mapper:
         if isinstance(typ, Instance):
             if typ.type.fullname() == 'builtins.int':
                 return IntRType()
+            elif typ.type.fullname() == 'builtins.str':
+                return UnicodeRType()
             elif typ.type.fullname() == 'builtins.bool':
                 return BoolRType()
             elif typ.type.fullname() == 'builtins.list':
@@ -124,6 +126,9 @@ class IRBuilder(NodeVisitor[Register]):
 
         self.mapper = mapper
         self.imports = [] # type: List[str]
+
+        # Maps unicode literals to the static c name for that literal
+        self.unicode_literals = {} # type: Dict[str, str]
 
         self.current_module_name = None # type: Optional[str]
 
@@ -242,6 +247,7 @@ class IRBuilder(NodeVisitor[Register]):
 
     def visit_return_stmt(self, stmt: ReturnStmt) -> Register:
         if stmt.expr:
+            print(stmt.expr)
             retval = self.accept(stmt.expr)
         else:
             retval = self.environment.add_temp(NoneRType())
@@ -839,6 +845,9 @@ class IRBuilder(NodeVisitor[Register]):
         '>=': Branch.INT_GE,
     }
 
+    def visit_str_expr(self, expr: StrExpr) -> Register:
+        return self.load_static_unicode(expr.value) 
+
     def process_conditional(self, e: Node) -> List[Branch]:
         if isinstance(e, ComparisonExpr):
             # TODO: Verify operand types.
@@ -992,3 +1001,16 @@ class IRBuilder(NodeVisitor[Register]):
     def box_expr(self, expr: Expression) -> Register:
         typ = self.node_type(expr)
         return self.box(self.accept(expr), typ)
+
+    def load_static_unicode(self, value: str) -> Register:
+        """Loads a static unicode value into a register.
+
+        This is useful for more than just unicode literals; for example, method calls
+        also require a PyObject * form for the name of the method.
+        """
+        if value not in self.unicode_literals:
+            self.unicode_literals[value] = '__unicode_' + str(len(self.unicode_literals))
+        static_symbol = self.unicode_literals[value]
+        target = self.alloc_target(UnicodeRType())
+        self.add(LoadStatic(target, static_symbol))
+        return target

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -132,7 +132,6 @@ class BoolRType(RType):
     def is_refcounted(self) -> bool:
         return False
 
-
 class TupleRType(RType):
     """Fixed-length tuple."""
 
@@ -240,6 +239,15 @@ class ListRType(PyObjectRType):
 class DictRType(PyObjectRType):
     def __init__(self) -> None:
         self.name = 'dict'
+
+
+class UnicodeRType(PyObjectRType):
+    """str in python 3; but at the c layer, its refered to as unicode (PyUnicode)
+
+    Referring to these as Unicode and as Bytes leaves zero room for confusion.
+    """
+    def __init__(self) -> None:
+        self.name = 'unicode'
 
 
 class UserRType(PyObjectRType):
@@ -976,8 +984,13 @@ class ClassIR:
 class ModuleIR:
     """Intermediate representation of a module."""
 
-    def __init__(self, imports: List[str], functions: List[FuncIR], classes: List[ClassIR]) -> None:
+    def __init__(self,
+            imports: List[str],
+            unicode_literals: Dict[str, str],
+            functions: List[FuncIR],
+            classes: List[ClassIR]) -> None:
         self.imports = imports[:]
+        self.unicode_literals = unicode_literals
         self.functions = functions
         self.classes = classes
 

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -483,3 +483,13 @@ L0:
     r5 = cast(None, r2)
     r6 = None
     return r6
+
+[case testUnicodeLiteral]
+def f() -> str:
+    return "some string"
+[out]
+def f():
+    r0 :: unicode
+L0:
+    r0 = __unicode_0 :: static
+    return r0

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -279,3 +279,10 @@ assert f(None) is None
 assert f(a) is a
 assert g(None) == 1
 assert g(a) == 2
+
+[case testUnicodeLiteral]
+def f() -> str:
+    return 'some string'
+[file driver.py]
+from native import f
+assert f() == 'some string'


### PR DESCRIPTION
This is a very minimal support for unicode strings (not actually
support unicode in the literals right now) which shares all literals
used by the same module as static globals.

I debated between calling it string and calling it unicode, and decided
on unicode because:

(1) Its more explicit about what it actually contains, which is good

(2) The C API calls it PyUnicode so its not inconsistent with that
layer, which is what we are actually interoperating with in this
case.