### PR TITLE
Implement arbitrary python method calls

### DIFF
--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -8,6 +8,7 @@ from mypyc.ops import (
     BasicBlock, OpVisitor, PrimitiveOp, Assign, LoadInt, RegisterOp, Goto,
     Branch, Return, Call, Environment, Box, Unbox, Cast, Op, Unreachable,
     TupleGet, GetAttr, SetAttr, PyCall, LoadStatic, PyGetAttr, Label, Register,
+    PyMethodCall,
 )
 
 
@@ -79,6 +80,9 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill]):
         return self.visit_register_op(op)
 
     def visit_py_call(self, op: PyCall) -> GenAndKill:
+        return self.visit_register_op(op)
+
+    def visit_py_method_call(self, op: PyMethodCall) -> GenAndKill:
         return self.visit_register_op(op)
 
     def visit_primitive_op(self, op: PrimitiveOp) -> GenAndKill:

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -5,7 +5,7 @@ from mypyc.emit import Emitter
 from mypyc.ops import (
     FuncIR, OpVisitor, Goto, Branch, Return, PrimitiveOp, Assign, LoadInt, GetAttr, SetAttr,
     LoadStatic, TupleGet, Call, PyCall, PyGetAttr, IncRef, DecRef, Box, Cast, Unbox, Label,
-    Register, RType, OP_BINARY, TupleRType
+    Register, RType, OP_BINARY, TupleRType, PyMethodCall
 )
 
 
@@ -290,7 +290,24 @@ class FunctionEmitterVisitor(OpVisitor):
 
         function = self.reg(op.function)
         args = ', '.join(self.reg(arg) for arg in op.args)
-        self.emit_line('{}PyObject_CallFunctionObjArgs({}, {}, NULL);'.format(dest, function, args))
+        if args:
+            args += ', '
+        self.emit_line('{}PyObject_CallFunctionObjArgs({}, {}NULL);'.format(dest, function, args))
+
+    def visit_py_method_call(self, op: PyMethodCall) -> None:
+        if op.dest is not None:
+            dest = self.reg(op.dest) + ' = '
+        else:
+            dest = ''
+
+        obj = self.reg(op.obj)
+        method = self.reg(op.method)
+        args = ', '.join(self.reg(arg) for arg in op.args)
+        if args:
+            args += ', '
+        else:
+            self.emit_line('{}PyObject_CallMethodObjArgs({}, {}, {}NULL);'.format(
+                dest, obj, method, args))
 
     def visit_inc_ref(self, op: IncRef) -> None:
         dest = self.reg(op.dest)

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -305,9 +305,8 @@ class FunctionEmitterVisitor(OpVisitor):
         args = ', '.join(self.reg(arg) for arg in op.args)
         if args:
             args += ', '
-        else:
-            self.emit_line('{}PyObject_CallMethodObjArgs({}, {}, {}NULL);'.format(
-                dest, obj, method, args))
+        self.emit_line('{}PyObject_CallMethodObjArgs({}, {}, {}NULL);'.format(
+            dest, obj, method, args))
 
     def visit_inc_ref(self, op: IncRef) -> None:
         dest = self.reg(op.dest)

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -618,7 +618,7 @@ class PyMethodCall(RegisterOp):
 
     All registers must be unboxed. Corresponds to PyObject_CallMethodObjArgs in C.
     """
-    def __init__(self, 
+    def __init__(self,
             dest: Optional[Register],
             obj: Register,
             method: Register,
@@ -636,7 +636,7 @@ class PyMethodCall(RegisterOp):
         return s + ' :: py'
 
     def sources(self) -> List[Register]:
-        return self.args[:] + [self.obj]
+        return self.args[:] + [self.obj, self.method]
 
     def accept(self, visitor: 'OpVisitor[T]') -> T:
         return visitor.visit_py_method_call(self)

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -592,7 +592,7 @@ class Call(RegisterOp):
 class PyCall(RegisterOp):
     """Python call f(arg, ...).
 
-    All registers must be unboxed.
+    All registers must be unboxed. Corresponds to PyObject_CallFunctionObjArgs in C.
     """
     def __init__(self, dest: Optional[Register], function: Register, args: List[Register]) -> None:
         self.dest = dest
@@ -611,6 +611,35 @@ class PyCall(RegisterOp):
 
     def accept(self, visitor: 'OpVisitor[T]') -> T:
         return visitor.visit_py_call(self)
+
+
+class PyMethodCall(RegisterOp):
+    """Python method call obj.m(arg, ...)
+
+    All registers must be unboxed. Corresponds to PyObject_CallMethodObjArgs in C.
+    """
+    def __init__(self, 
+            dest: Optional[Register],
+            obj: Register,
+            method: Register,
+            args: List[Register]) -> None:
+        self.dest = dest
+        self.obj = obj
+        self.method = method
+        self.args = args
+
+    def to_str(self, env: Environment) -> str:
+        args = ', '.join(env.format('%r', arg) for arg in self.args)
+        s = env.format('%r.%r(%s)', self.obj, self.method, args)
+        if self.dest is not None:
+            s = env.format('%r = ', self.dest) + s
+        return s + ' :: py'
+
+    def sources(self) -> List[Register]:
+        return self.args[:] + [self.obj]
+
+    def accept(self, visitor: 'OpVisitor[T]') -> T:
+        return visitor.visit_py_method_call(self)
 
 
 class PyGetAttr(RegisterOp):
@@ -1058,6 +1087,9 @@ class OpVisitor(Generic[T]):
         pass
 
     def visit_py_call(self, op: PyCall) -> T:
+        pass
+
+    def visit_py_method_call(self, op: PyMethodCall) -> T:
         pass
 
     def visit_cast(self, op: Cast) -> T:

--- a/mypyc/refcount.py
+++ b/mypyc/refcount.py
@@ -27,7 +27,7 @@ from mypyc.analysis import (
 )
 from mypyc.ops import (
     FuncIR, BasicBlock, Assign, RegisterOp, DecRef, IncRef, Branch, Goto, Environment,
-    Return, Op, Register, Label, Cast, Box, Unbox, PrimitiveOp
+    Return, Op, Register, Label, Cast, Box, Unbox, PrimitiveOp, LoadStatic,
 )
 
 
@@ -87,6 +87,9 @@ def transform_block(block: BasicBlock,
                 if src not in post_live[key] and src not in pre_borrow[key]:
                     if src != op.dest:
                         ops.append(DecRef(src, env.types[src]))
+            # TODO: Analyze LoadStatics as being borrowed!
+            if isinstance(op, LoadStatic):
+                ops.append(IncRef(op.dest, env.types[op.dest]))
             if op.dest is not None and op.dest not in post_live[key]:
                 ops.append(DecRef(op.dest, env.types[op.dest]))
             if tmp_reg is not None:

--- a/mypyc/refcount.py
+++ b/mypyc/refcount.py
@@ -87,7 +87,7 @@ def transform_block(block: BasicBlock,
                 if src not in post_live[key] and src not in pre_borrow[key]:
                     if src != op.dest:
                         ops.append(DecRef(src, env.types[src]))
-            # TODO: Analyze LoadStatics as being borrowed!
+            # TODO: Analyze LoadStatics as being borrowed! (#66)
             if isinstance(op, LoadStatic):
                 ops.append(IncRef(op.dest, env.types[op.dest]))
             if op.dest is not None and op.dest not in post_live[key]:

--- a/test-data/fixtures/ir.py
+++ b/test-data/fixtures/ir.py
@@ -47,6 +47,7 @@ class list(Generic[T], Iterable[T], Sized):
     def __iter__(self) -> Iterator[T]: pass
     def __len__(self) -> int: pass
     def append(self, x: T) -> None: pass
+    def pop(self) -> T: pass
 
 class dict(Generic[T, S]):
     def __getitem__(self, x: T) -> S: pass

--- a/test-data/fixtures/ir.py
+++ b/test-data/fixtures/ir.py
@@ -48,6 +48,7 @@ class list(Generic[T], Iterable[T], Sized):
     def __len__(self) -> int: pass
     def append(self, x: T) -> None: pass
     def pop(self) -> T: pass
+    def extend(self, l: Iterable[T]) -> None: pass
 
 class dict(Generic[T, S]):
     def __getitem__(self, x: T) -> S: pass

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -493,3 +493,20 @@ def f():
 L0:
     r0 = __unicode_0 :: static
     return r0
+
+[case testPyMethodCall]
+from typing import List
+def f(x: List[int]) -> int:
+    return x.pop()
+[out]
+def f(x):
+    x :: list
+    r0 :: unicode
+    r1 :: object
+    r2 :: int
+L0:
+    r0 = __unicode_0 :: static
+    r1 = x.r0() :: py
+    r2 = unbox(int, r1)
+    return r2
+

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -494,7 +494,7 @@ L0:
     r0 = __unicode_0 :: static
     return r0
 
-[case testPyMethodCall]
+[case testPyMethodCall1]
 from typing import List
 def f(x: List[int]) -> int:
     return x.pop()

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -559,3 +559,28 @@ L1:
 L2:
     r1 = 2
     return r1
+
+[case testUnicodeLiteral]
+def f() -> str:
+    return "some string"
+[out]
+L0:
+    r0 = __unicode_0 :: static
+    inc_ref r0
+    return r0
+
+[case testPyMethodCall]
+from typing import List
+def g(x: List[int], y: List[int]) -> None:
+    x.extend(y)
+[out]
+L0:
+    r0 = __unicode_0 :: static
+-- TODO: these incref and decrefs are bummers
+    inc_ref r0
+    r1 = x.r0(y) :: py
+    dec_ref r0
+    r2 = cast(None, r1)
+    dec_ref r2
+    r3 = None
+    return r3

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -576,7 +576,6 @@ def g(x: List[int], y: List[int]) -> None:
 [out]
 L0:
     r0 = __unicode_0 :: static
--- TODO: these incref and decrefs are bummers
     inc_ref r0
     r1 = x.r0(y) :: py
     dec_ref r0

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -308,6 +308,13 @@ assert f(2) == 1
 from typing import List
 def f(x: List[int]) -> int:
     return x.pop()
+def g(x: List[int], y: List[int]) -> None:
+    x.extend(y)
 [file driver.py]
-from native import f
-assert f([1, 2]) == 2
+from native import f, g
+l = [1, 2]
+assert f(l) == 2
+g(l, [10])
+assert l == [1, 10]
+assert f(l) == 10
+assert f(l) == 1

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -318,3 +318,5 @@ g(l, [10])
 assert l == [1, 10]
 assert f(l) == 10
 assert f(l) == 1
+g(l, [11, 12])
+assert l == [11, 12]

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -303,3 +303,11 @@ def f(x: int) -> int:
 from native import f
 assert f(1) == 2
 assert f(2) == 1
+
+[case testPyMethodCall]
+from typing import List
+def f(x: List[int]) -> int:
+    return x.pop()
+[file driver.py]
+from native import f
+assert f([1, 2]) == 2


### PR DESCRIPTION
Test using list.pop(), which seemingly works. This gets us a lot
of python compatibility at once - with this, we have builtin functions
and arbitrary methods, which covers just about anything we'd need for
basic (but not efficient) compatibility.

Depends on the unicode literals PR.