### PR TITLE
Fix emit/refcount of LIST_APPEND

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -824,7 +824,7 @@ class IRBuilder(NodeVisitor[Register]):
         if callee.name == 'append' and base_type.name == 'list':
             target = INVALID_REGISTER  # TODO: Do we sometimes need to allocate a register?
             arg = self.box_expr(expr.args[0])
-            self.add(PrimitiveOp(target, PrimitiveOp.LIST_APPEND, base, arg))
+            self.add(PrimitiveOp(None, PrimitiveOp.LIST_APPEND, base, arg))
         elif callee.name == 'update' and base_type.name == 'dict':
             target = INVALID_REGISTER
             other_list_reg = self.accept(expr.args[0])

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -505,6 +505,7 @@ class RegisterOp(Op):
     """
 
     def __init__(self, dest: Optional[Register]) -> None:
+        assert dest != INVALID_REGISTER
         self.dest = dest
 
     @abstractmethod
@@ -566,7 +567,7 @@ class Call(RegisterOp):
     """
 
     def __init__(self, dest: Optional[Register], fn: str, args: List[Register]) -> None:
-        self.dest = dest
+        super().__init__(dest)
         self.fn = fn
         self.args = args
 
@@ -595,7 +596,7 @@ class PyCall(RegisterOp):
     All registers must be unboxed. Corresponds to PyObject_CallFunctionObjArgs in C.
     """
     def __init__(self, dest: Optional[Register], function: Register, args: List[Register]) -> None:
-        self.dest = dest
+        super().__init__(dest)
         self.function = function
         self.args = args
 
@@ -646,7 +647,7 @@ class PyGetAttr(RegisterOp):
     """dest = left.right :: py"""
 
     def __init__(self, dest: Register, left: Register, right: str) -> None:
-        self.dest = dest
+        super().__init__(dest)
         self.left = left
         self.right = right
 
@@ -758,9 +759,9 @@ class PrimitiveOp(RegisterOp):
 
         If desc.is_void is true, dest should be None.
         """
+        super().__init__(dest)
         if desc.num_args != VAR_ARG:
             assert len(args) == desc.num_args
-        self.dest = dest
         self.desc = desc
         self.args = args
 
@@ -784,7 +785,7 @@ class Assign(RegisterOp):
     """dest = int"""
 
     def __init__(self, dest: Register, src: Register) -> None:
-        self.dest = dest
+        super().__init__(dest)
         self.src = src
 
     def sources(self) -> List[Register]:
@@ -801,7 +802,7 @@ class LoadInt(RegisterOp):
     """dest = int"""
 
     def __init__(self, dest: Register, value: int) -> None:
-        self.dest = dest
+        super().__init__(dest)
         self.value = value
 
     def sources(self) -> List[Register]:
@@ -818,7 +819,7 @@ class GetAttr(RegisterOp):
     """dest = obj.attr (for a native object)"""
 
     def __init__(self, dest: Register, obj: Register, attr: str, rtype: UserRType) -> None:
-        self.dest = dest
+        super().__init__(dest)
         self.obj = obj
         self.attr = attr
         self.rtype = rtype
@@ -837,7 +838,7 @@ class SetAttr(RegisterOp):
     """obj.attr = src (for a native object)"""
 
     def __init__(self, obj: Register, attr: str, src: Register, rtype: UserRType) -> None:
-        self.dest = None
+        super().__init__(None)
         self.obj = obj
         self.attr = attr
         self.src = src
@@ -857,7 +858,7 @@ class LoadStatic(RegisterOp):
     """dest = name :: static"""
 
     def __init__(self, dest: Register, identifier: str) -> None:
-        self.dest = dest
+        super().__init__(dest)
         self.identifier = identifier
 
     def sources(self) -> List[Register]:
@@ -874,7 +875,7 @@ class TupleGet(RegisterOp):
     """dest = src[n]"""
 
     def __init__(self, dest: Register, src: Register, index: int, target_type: RType) -> None:
-        self.dest = dest
+        super().__init__(dest)
         self.src = src
         self.index = index
         self.target_type = target_type
@@ -899,7 +900,7 @@ class Cast(RegisterOp):
     # TODO: Error checking
 
     def __init__(self, dest: Register, src: Register, typ: RType) -> None:
-        self.dest = dest
+        super().__init__(dest)
         self.src = src
         self.typ = typ
 
@@ -921,7 +922,7 @@ class Box(RegisterOp):
     """
 
     def __init__(self, dest: Register, src: Register, typ: RType) -> None:
-        self.dest = dest
+        super().__init__(dest)
         self.src = src
         self.type = typ
 
@@ -944,7 +945,7 @@ class Unbox(RegisterOp):
     # TODO: Error checking
 
     def __init__(self, dest: Register, src: Register, typ: RType) -> None:
-        self.dest = dest
+        super().__init__(dest)
         self.src = src
         self.type = typ
 

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -583,3 +583,16 @@ L0:
     dec_ref r2
     r3 = None
     return r3
+
+[case testListAppend]
+from typing import List
+def f(a: List[int], x: int) -> None:
+    a.append(x)
+[out]
+L0:
+    inc_ref x :: int
+    r0 = box(int, x)
+    a.append(r0)
+    dec_ref r0
+    r1 = None
+    return r1

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -125,6 +125,20 @@ print(primes(13))
 [[0, 0, 1, 1]
 [[0, 0, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1]
 
+[case testListAppend]
+from typing import List
+def f(x: List[int], n: int) -> None:
+    x.append(n)
+[file driver.py]
+from native import f
+l = [1, 2]
+f(l, 10)
+assert l == [1, 2, 10]
+f(l, 3)
+f(l, 4)
+f(l, 5)
+assert l == [1, 2, 10, 3, 4, 5]
+
 [case testTrue]
 def f() -> bool:
     return True


### PR DESCRIPTION
INVALID_REGISTER is used as a return value for visitors for things
that don't actually use registers, but ops that don't write to
a register need to use None as their dest.