### PR TITLE
Add a travis build that uses a debug build of python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,24 @@ sudo: false
 language: python
 cache: pip
 
-python:
-  - "3.5"
-  - "3.6"
+matrix:
+  include:
+  - python: "3.5"
+  - python: "3.6"
+  - python: "3.6"
+    env: USE_PYTHON_DEBUG_BUILD=1
 
 install:
+  - if [[ $USE_PYTHON_DEBUG_BUILD == 1 ]]; then wget https://www.msully.net/travis-python-archives/python-3.6-debug.tar.bz2; tar xjf python-3.6-debug.tar.bz2 --directory /; source ~/virtualenv/python-3.6-debug/bin/activate; fi
   - pip install -U pip setuptools wheel
   - pip install -r external/mypy/test-requirements.txt
 
 script:
   - export PYTHONPATH=`pwd`/external/mypy
   - export PYTHONVERSION=`python --version | awk '{ print $2 }'`
-  - export PYTHONCONFIG="/opt/python/$PYTHONVERSION/bin/python-config"
-  - export LD_LIBRARY_PATH="/opt/python/$PYTHONVERSION/lib"
-  - pytest -n4 mypyc
+
+  - if [[ $USE_PYTHON_DEBUG_BUILD == 1 ]]; then export PYTHONDIR="/home/travis/python-3.6-debug"; else export PYTHONDIR="/opt/python/$PYTHONVERSION"; fi
+  - export PYTHONCONFIG="$PYTHONDIR/bin/python-config"
+  - export LD_LIBRARY_PATH="$PYTHONDIR/lib"
+  - if [[ $USE_PYTHON_DEBUG_BUILD != 1 ]]; then pytest -n4 mypyc; fi
+  - if [[ $USE_PYTHON_DEBUG_BUILD == 1 ]]; then pytest -n4 mypyc/test/test_run.py mypyc/test/test_external.py -k 'not test_self_type_check'; fi


### PR DESCRIPTION
Debug builds of python are more likely to crash or assert in response
to memory errors such as refcounting mistakes, which will make it easier
to catch errors.

Since the debug build of python is slower, we only run tests involving
C code that we are responsible for: unit tests of our runtime and the
`run` tests.

Unfortunately the process for getting a debug build of python into our
travis environment is unbelievably janky:
 * Build Python 3.6.5 with: `./configure CFLAGS='-DPy_DEBUG -DPy_TRACE_REFS -DPYMALLOC_DEBUG' --with-pydebug --prefix=/home/travis/python-3.6.5-debug`
 * Install that python and create a virtualenv in
   `/home/travis/virtualenv/python-3.6-debug/', which mimics what the
   official travis Pythons do and makes it easy use the right python
   version.
 * Tar up /home/travis and stick it up on a web server
   somewhere. Right now I am just personally hosting it because it was
   the most expedient thing, but there are certainly better places to
   host it.
 * In the travis build, wget the tarball and unpack it.