### PR TITLE
Add travis builds that use debug builds of python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,27 @@
 sudo: false
 language: python
 cache: pip
+cache:
+  directories:
+    - /home/travis/python-debug
 
 python:
   - "3.5"
   - "3.6"
+env:
+  - PYTHON_DEBUG_BUILD=0
+  - PYTHON_DEBUG_BUILD=1
 
 install:
+  - export PYTHONVERSION=`python --version | awk '{ print $2 }'`
+  - if [[ $PYTHON_DEBUG_BUILD == 1 ]]; then export PYTHONDIR=~/python-debug/python-$PYTHONVERSION; else export PYTHONDIR="/opt/python/$PYTHONVERSION"; fi
+  - if [[ $PYTHON_DEBUG_BUILD == 1 ]]; then VENV=$PYTHONDIR/env; scripts/build-debug-python.sh $PYTHONVERSION $PYTHONDIR $VENV; source $VENV/bin/activate; fi
   - pip install -U pip setuptools wheel
   - pip install -r external/mypy/test-requirements.txt
 
 script:
   - export PYTHONPATH=`pwd`/external/mypy
-  - export PYTHONVERSION=`python --version | awk '{ print $2 }'`
-  - export PYTHONCONFIG="/opt/python/$PYTHONVERSION/bin/python-config"
-  - export LD_LIBRARY_PATH="/opt/python/$PYTHONVERSION/lib"
-  - pytest -n4 mypyc
+  - export PYTHONCONFIG="$PYTHONDIR/bin/python-config"
+  - export LD_LIBRARY_PATH="$PYTHONDIR/lib"
+  - if [[ $PYTHON_DEBUG_BUILD != 1 ]]; then pytest -n4 mypyc; fi
+  - if [[ $PYTHON_DEBUG_BUILD == 1 ]]; then pytest -n4 mypyc/test/test_run.py mypyc/test/test_external.py -k 'not test_self_type_check'; fi

--- a/scripts/build-debug-python.sh
+++ b/scripts/build-debug-python.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eux
+
+# Build a debug build of python, install it, and create a venv for it
+# This is mainly intended for use in our travis builds but there's no
+# reason it couldn't be used locally.
+# Usage: build-debug-python.sh <version> <install prefix> <venv location>
+
+VERSION=$1
+PREFIX=$2
+VENV=$3
+if [[ -f $PREFIX/bin/python3 ]]; then
+    exit
+fi
+
+wget https://www.python.org/ftp/python/$VERSION/Python-$VERSION.tgz
+tar zxf Python-$VERSION.tgz
+cd Python-$VERSION
+./configure CFLAGS='-DPy_DEBUG -DPy_TRACE_REFS -DPYMALLOC_DEBUG' --with-pydebug --prefix=$PREFIX
+make -j4
+make install
+$PREFIX/bin/pip3 install virtualenv
+$PREFIX/bin/python3 -m virtualenv $VENV
+ln -s python3-config $PREFIX/bin/python-config


### PR DESCRIPTION
Debug builds of python are more likely to crash or assert in response
to memory errors such as refcounting mistakes, which will make it easier
to catch errors.

Since the debug build of python is slower, we only run tests involving
C code that we are responsible for: unit tests of our runtime and the
`run` tests.

It operates by downloading a python source tarball and building it on
travis.  While this is not as slow as one might imagine (about 5m), it
is still too slow to be reasonable, so Travis's caching is used to
avoid needing to repeat the build.