### PR TITLE
Minimal exception support

### DIFF
--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -423,19 +423,22 @@ static PyObject *CPySequenceTuple_GetItem(PyObject *tuple, CPyTagged index) {
         Py_ssize_t size = PyTuple_GET_SIZE(tuple);
         if (n >= 0) {
             if (n >= size) {
-                abort();
+                PyErr_SetString(PyExc_IndexError, "tuple index out of range");
+                return NULL;
             }
         } else {
             n += size;
             if (n < 0) {
-                abort();
+                PyErr_SetString(PyExc_IndexError, "tuple index out of range");
+                return NULL;
             }
         }
         PyObject *result = PyTuple_GET_ITEM(tuple, n);
         Py_INCREF(result);
         return result;
     } else {
-        abort(); // TODO: Generate exception
+        PyErr_SetString(PyExc_IndexError, "tuple index out of range");
+        return NULL;
     }
 }
 

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -394,19 +394,22 @@ static bool CPyList_SetItem(PyObject *list, CPyTagged index, PyObject *value) {
         Py_ssize_t size = PyList_GET_SIZE(list);
         if (n >= 0) {
             if (n >= size) {
-                abort();
+                // TODO: Exception
+                return false;
             }
         } else {
             n += size;
             if (n < 0) {
-                abort();
+                // TODO: Exception
+                return false;
             }
         }
         Py_INCREF(value); // TODO: Move this outside the function to allow optimizing it away
         PyList_SET_ITEM(list, n, value);
         return true;
     } else {
-        abort(); // TODO: Generate exception
+        // TODO: Exception
+        return false;
     }
 }
 

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -37,7 +37,7 @@ static void CPyDebug_Print(const char *msg) {
 // Set attribute value using vtable
 #define CPY_SET_ATTR(obj, vtable_index, value, object_type, attr_type) \
     ((void (*)(object_type *, attr_type))((object_type *)obj)->vtable[vtable_index])( \
-        (object_type *)obj, value);
+        (object_type *)obj, value)
 
 static void CPyError_OutOfMemory(void) {
     fprintf(stderr, "fatal: out of memory\n");

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -373,19 +373,22 @@ static PyObject *CPyList_GetItem(PyObject *list, CPyTagged index) {
         Py_ssize_t size = PyList_GET_SIZE(list);
         if (n >= 0) {
             if (n >= size) {
-                abort();
+                PyErr_SetString(PyExc_IndexError, "list index out of range");
+                return NULL;
             }
         } else {
             n += size;
             if (n < 0) {
-                abort();
+                PyErr_SetString(PyExc_IndexError, "list index out of range");
+                return NULL;
             }
         }
         PyObject *result = PyList_GET_ITEM(list, n);
         Py_INCREF(result);
         return result;
     } else {
-        abort(); // TODO: Generate exception
+        PyErr_SetString(PyExc_IndexError, "list index out of range");
+        return NULL;
     }
 }
 

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -37,7 +37,7 @@ static void CPyDebug_Print(const char *msg) {
 
 // Set attribute value using vtable
 #define CPY_SET_ATTR(obj, vtable_index, value, object_type, attr_type) \
-    ((void (*)(object_type *, attr_type))((object_type *)obj)->vtable[vtable_index])( \
+    ((bool (*)(object_type *, attr_type))((object_type *)obj)->vtable[vtable_index])( \
         (object_type *)obj, value)
 
 static void CPyError_OutOfMemory(void) {

--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -55,6 +55,10 @@ def get_cfg(blocks: List[BasicBlock]) -> CFG:
         else:
             succ = []
             exits.add(label)
+        for op in block.ops:
+            err = op.error_label
+            if err is not None and err not in succ:
+                succ.append(err)
         succ_map[label] = succ
         pred_map[label] = []
     for prev, nxt in succ_map.items():

--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -72,6 +72,9 @@ class AnalysisResult(Generic[T]):
         self.before = before
         self.after = after
 
+    def __str__(self) -> str:
+        return 'before: %s\nafter: %s\n' % (self.before, self.after)
+
 GenAndKill = Tuple[Set[Register], Set[Register]]
 
 
@@ -389,7 +392,7 @@ def run_analysis(blocks: List[BasicBlock],
         else:
             new_before = set(initial)
         before[label] = new_before
-        new_after = (new_before | block_gen[label]) - block_kill[label]
+        new_after = (new_before - block_kill[label]) | block_gen[label]
         if new_after != after[label]:
             for succ in succ_map[label]:
                 if succ not in workset:

--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -260,7 +260,9 @@ def analyze_undefined_regs(blocks: List[BasicBlock],
     A register is undefined if there is some path from initial block
     where it has an undefined value.
     """
-    initial_undefined = {Register(reg) for reg in range(len(env.names)) if Register(reg) not in initial_defined}
+    initial_undefined = {Register(reg)
+                         for reg in range(len(env.names))
+                         if Register(reg) not in initial_defined}
     return run_analysis(blocks=blocks,
                         cfg=cfg,
                         gen_and_kill=UndefinedVisitor(),

--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -26,6 +26,13 @@ class CFG:
         self.pred = pred
         self.exits = exits
 
+    def __str__(self) -> str:
+        lines = []
+        lines.append('exits: %s' % sorted(self.exits))
+        lines.append('succ: %s' % self.succ)
+        lines.append('pred: %s' % self.pred)
+        return '\n'.join(lines)
+
 
 def get_cfg(blocks: List[BasicBlock]) -> CFG:
     """Calculate basic block control-flow graph.

--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -55,10 +55,6 @@ def get_cfg(blocks: List[BasicBlock]) -> CFG:
         else:
             succ = []
             exits.add(label)
-        for op in block.ops:
-            err = op.error_label
-            if err is not None and err not in succ:
-                succ.append(err)
         succ_map[label] = succ
         pred_map[label] = []
     for prev, nxt in succ_map.items():

--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 from typing import Dict, Tuple, List, Set, TypeVar, Iterator, Generic
 
 from mypyc.ops import (
-    BasicBlock, OpVisitor, PrimitiveOp, Assign, LoadInt, RegisterOp, Goto,
+    BasicBlock, OpVisitor, PrimitiveOp, Assign, LoadInt, LoadErrorValue, RegisterOp, Goto,
     Branch, Return, Call, Environment, Box, Unbox, Cast, Op, Unreachable,
     TupleGet, GetAttr, SetAttr, PyCall, LoadStatic, PyGetAttr, Label, Register
 )
@@ -88,6 +88,9 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill]):
         return self.visit_register_op(op)
 
     def visit_load_int(self, op: LoadInt) -> GenAndKill:
+        return self.visit_register_op(op)
+
+    def visit_load_error_value(self, op: LoadErrorValue) -> GenAndKill:
         return self.visit_register_op(op)
 
     def visit_get_attr(self, op: GetAttr) -> GenAndKill:

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -1,5 +1,6 @@
 """Utilities for emitting C code."""
 
+from collections import OrderedDict
 from typing import List, Set, Dict, Optional
 
 from mypyc.common import REG_PREFIX
@@ -24,7 +25,7 @@ class EmitterContext:
         # A map of a C identifier to whatever the C identifier declares. Currently this is
         # used for declaring structs and the key corresponds to the name of the struct.
         # The declaration contains the body of the struct.
-        self.declarations = {} # type: Dict[str, HeaderDeclaration]
+        self.declarations = OrderedDict()  # type: Dict[str, HeaderDeclaration]
 
 
 class Emitter:

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -149,7 +149,7 @@ def generate_native_getters_and_setters(cl: ClassIR,
         emitter.emit_line()
 
         # Native setter
-        emitter.emit_line('void {}({} *self, {}value)'.format(native_setter_name(cl.name, attr),
+        emitter.emit_line('bool {}({} *self, {}value)'.format(native_setter_name(cl.name, attr),
                                                           cl.struct_name,
                                                           rtype.ctype_spaced))
         emitter.emit_line('{')
@@ -158,8 +158,9 @@ def generate_native_getters_and_setters(cl: ClassIR,
             emitter.emit_dec_ref('self->{}'.format(attr), rtype)
             emitter.emit_line('}')
         emitter.emit_inc_ref('value'.format(attr), rtype)
-        emitter.emit_line('self->{} = value;'.format(attr))
-        emitter.emit_line('}')
+        emitter.emit_lines('self->{} = value;'.format(attr),
+                           'return 1;',
+                           '}')
         emitter.emit_line()
 
 

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -310,7 +310,8 @@ def generate_setter(cl: ClassIR,
     if rtype.supports_unbox:
         emitter.emit_unbox('value', 'tmp', rtype, 'abort();',declare_dest=True)
     else:
-        emitter.emit_cast('value', 'tmp', rtype, 'abort();',declare_dest=True)
+        emitter.emit_cast('value', 'tmp', rtype, declare_dest=True)
+        # TODO: Handle error (tmp == NULL)
         emitter.emit_inc_ref('tmp', rtype)
     emitter.emit_line('self->{} = tmp;'.format(attr))
     emitter.emit_line('} else')

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -288,7 +288,7 @@ def generate_getter(cl: ClassIR,
     emitter.emit_line('return NULL;')
     emitter.emit_line('}')
     emitter.emit_inc_ref('self->{}'.format(attr), rtype)
-    emitter.emit_box('self->{}'.format(attr), 'retval', rtype, 'abort();', declare_dest=True)
+    emitter.emit_box('self->{}'.format(attr), 'retval', rtype, declare_dest=True)
     emitter.emit_line('return retval;')
     emitter.emit_line('}')
 

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -179,7 +179,7 @@ def generate_constructor_for_class(cl: ClassIR,
                                                                  cl.type_struct,
                                                                  cl.type_struct))
     emitter.emit_line('if (self == NULL)')
-    emitter.emit_line('    abort(); // TODO')
+    emitter.emit_line('    return NULL;')
     emitter.emit_line('self->vtable = {};'.format(vtable_name))
     for attr, rtype in cl.attributes:
         emitter.emit_line('self->{} = {};'.format(attr, rtype.c_undefined_value))

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -350,7 +350,7 @@ class FunctionEmitterVisitor(OpVisitor):
         self.emit_dec_ref(dest, op.target_type)
 
     def visit_box(self, op: Box) -> None:
-        self.emitter.emit_box(self.reg(op.src), self.reg(op.dest), op.type, 'abort();')
+        self.emitter.emit_box(self.reg(op.src), self.reg(op.dest), op.type)
 
     def visit_cast(self, op: Cast) -> None:
         self.emitter.emit_cast(self.reg(op.src), self.reg(op.dest), op.typ)

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -3,8 +3,8 @@
 from mypyc.common import REG_PREFIX, NATIVE_PREFIX
 from mypyc.emit import Emitter
 from mypyc.ops import (
-    FuncIR, OpVisitor, Goto, Branch, Return, PrimitiveOp, Assign, LoadInt, GetAttr, SetAttr,
-    LoadStatic, TupleGet, Call, PyCall, PyGetAttr, IncRef, DecRef, Box, Cast, Unbox, Label,
+    FuncIR, OpVisitor, Goto, Branch, Return, PrimitiveOp, Assign, LoadInt, LoadErrorValue, GetAttr,
+    SetAttr, LoadStatic, TupleGet, Call, PyCall, PyGetAttr, IncRef, DecRef, Box, Cast, Unbox, Label,
     Register, RType, OP_BINARY, TupleRType
 )
 
@@ -204,6 +204,10 @@ class FunctionEmitterVisitor(OpVisitor):
     def visit_load_int(self, op: LoadInt) -> None:
         dest = self.reg(op.dest)
         self.emit_line('%s = %d;' % (dest, op.value * 2))
+
+    def visit_load_error_value(self, op: LoadErrorValue) -> None:
+        self.emit_line('%s = %s;' % (self.reg(op.dest),
+                                     op.rtype.c_error_value))
 
     def visit_get_attr(self, op: GetAttr) -> None:
         dest = self.reg(op.dest)

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -162,7 +162,7 @@ class FunctionEmitterVisitor(OpVisitor):
                 temp = self.temp_name()
                 self.emit_lines('int %s = PyDict_Contains(%s, %s);' % (temp, right, left),
                                 'if (%s < 0)' % temp,
-                                '    abort();',
+                                '    abort();',  # TODO: Error handling
                                 '%s = %s;' % (dest, temp))
             else:
                 assert False, op.desc
@@ -356,7 +356,7 @@ class FunctionEmitterVisitor(OpVisitor):
         self.emitter.emit_cast(self.reg(op.src), self.reg(op.dest), op.typ)
 
     def visit_unbox(self, op: Unbox) -> None:
-        self.emitter.emit_unbox(self.reg(op.src), self.reg(op.dest), op.type, 'abort();')
+        self.emitter.emit_unbox(self.reg(op.src), self.reg(op.dest), op.type)
 
     # Helpers
 

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -154,14 +154,10 @@ class FunctionEmitterVisitor(OpVisitor):
                 self.emit_lines(
                     '%s = CPyTagged_AsLongLong(%s);' % (temp, right),
                     'if (%s == -1 && PyErr_Occurred())' % temp,
-                    '    abort();',
-                    '%s = PySequence_Repeat(%s, %s);' % (dest, left, temp),
-                    'if (!%s)' % dest,
-                    '    abort();')
+                    '    CPyError_OutOfMemory();',
+                    '%s = PySequence_Repeat(%s, %s);' % (dest, left, temp))
             elif op.desc is PrimitiveOp.HOMOGENOUS_TUPLE_GET:
-                self.emit_lines('%s = CPySequenceTuple_GetItem(%s, %s);' % (dest, left, right),
-                                'if (!%s)' % dest,
-                                '    abort();')
+                self.emit_line('%s = CPySequenceTuple_GetItem(%s, %s);' % (dest, left, right))
             elif op.desc is PrimitiveOp.DICT_CONTAINS:
                 temp = self.temp_name()
                 self.emit_lines('int %s = PyDict_Contains(%s, %s);' % (temp, right, left),

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -239,8 +239,14 @@ class FunctionEmitterVisitor(OpVisitor):
         self.emit_line('%s = %d;' % (dest, op.value * 2))
 
     def visit_load_error_value(self, op: LoadErrorValue) -> None:
-        self.emit_line('%s = %s;' % (self.reg(op.dest),
-                                     op.rtype.c_error_value))
+        if isinstance(op.rtype, TupleRType):
+            values = [item.c_undefined_value for item in op.rtype.types]
+            tmp = self.temp_name()
+            self.emit_line('%s %s = { %s };' % (op.rtype.ctype, tmp, ', '.join(values)))
+            self.emit_line('%s = %s;' % (self.reg(op.dest), tmp))
+        else:
+            self.emit_line('%s = %s;' % (self.reg(op.dest),
+                                         op.rtype.c_error_value))
 
     def visit_get_attr(self, op: GetAttr) -> None:
         dest = self.reg(op.dest)

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -284,13 +284,13 @@ class FunctionEmitterVisitor(OpVisitor):
         src = self.reg(op.src)
         rtype = op.rtype
         # TODO: Track errors
-        self.emit_line('CPY_SET_ATTR(%s, %d, %s, %s, %s), %s = 1;' % (
+        self.emit_line('%s = CPY_SET_ATTR(%s, %d, %s, %s, %s);' % (
+            dest,
             obj,
             rtype.setter_index(op.attr),
             src,
             rtype.struct_name,
-            rtype.attr_type(op.attr).ctype,
-            dest))
+            rtype.attr_type(op.attr).ctype))
 
     def visit_load_static(self, op: LoadStatic) -> None:
         dest = self.reg(op.dest)

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -143,10 +143,11 @@ class FunctionEmitterVisitor(OpVisitor):
             elif op.desc is PrimitiveOp.LIST_GET:
                 self.emit_line('%s = CPyList_GetItem(%s, %s);' % (dest, left, right))
             elif op.desc is PrimitiveOp.DICT_GET:
-                self.emit_lines('%s = PyDict_GetItem(%s, %s);' % (dest, left, right),
+                self.emit_lines('%s = PyDict_GetItemWithError(%s, %s);' % (dest, left, right),
                                 'if (!%s)' % dest,
-                                '    abort();',
-                                'Py_INCREF(%s);' % dest)
+                                '    PyErr_SetObject(PyExc_KeyError, %s);' % right,
+                                'else',
+                                '    Py_INCREF(%s);' % dest)
             elif op.desc is PrimitiveOp.LIST_REPEAT:
                 temp = self.temp_name()
                 self.declarations.emit_line('long long %s;' % temp)

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -77,7 +77,6 @@ class FunctionEmitterVisitor(OpVisitor):
             compare = '!=' if op.negated else '=='
             self.emit_line('if ({} {} Py_None)'.format(self.reg(op.left), compare))
         elif op.op == Branch.IS_ERROR:
-            # TODO: Tuple error values
             typ = self.env.types[op.left]
             compare = '!=' if op.negated else '=='
             if isinstance(typ, TupleRType):

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -1,6 +1,7 @@
 """Generate C code for a Python C extension module from Python source code."""
 
-from typing import List, Tuple
+from collections import OrderedDict
+from typing import List, Tuple, Dict
 
 from mypy.build import BuildSource, build
 from mypy.errors import CompileError
@@ -172,8 +173,9 @@ class ModuleGenerator:
         This runs in O(V + E).
         """
         result = []
-        marked_declarations = {k: MarkedDeclaration(v, False)
-                               for k, v in self.context.declarations.items()}
+        marked_declarations = OrderedDict()  # type: Dict[str, MarkedDeclaration]
+        for k, v in self.context.declarations.items():
+            marked_declarations[k] = MarkedDeclaration(v, False)
 
         def _toposort_visit(name):
             decl = marked_declarations[name]

--- a/mypyc/emitwrapper.py
+++ b/mypyc/emitwrapper.py
@@ -41,7 +41,7 @@ def generate_wrapper_function(fn: FuncIR, emitter: Emitter) -> None:
                                                         NATIVE_PREFIX, fn.name,
                                                         native_args))
         emitter.emit_error_check('retval', ret_type, 'return NULL;')
-        emitter.emit_box('retval', 'retbox', ret_type, 'return NULL;', declare_dest=True)
+        emitter.emit_box('retval', 'retbox', ret_type, declare_dest=True)
         emitter.emit_lines('return retbox;')
     else:
         emitter.emit_line('return {}{}({});'.format(NATIVE_PREFIX, fn.name, native_args))

--- a/mypyc/emitwrapper.py
+++ b/mypyc/emitwrapper.py
@@ -61,5 +61,6 @@ def generate_arg_check(name: str, typ: RType, emitter: Emitter) -> None:
         emitter.emit_unbox('obj_{}'.format(name), 'arg_{}'.format(name), typ,
                            'return NULL;', declare_dest=True, borrow=True)
     else:
-        emitter.emit_cast('obj_{}'.format(name), 'arg_{}'.format(name), typ, 'return NULL;',
+        emitter.emit_cast('obj_{}'.format(name), 'arg_{}'.format(name), typ,
                           declare_dest=True)
+        emitter.emit_line('if (arg_{} == NULL) return NULL;'.format(name))

--- a/mypyc/exceptions.py
+++ b/mypyc/exceptions.py
@@ -1,11 +1,12 @@
-from typing import Optional
+from typing import Optional, List
 
-from mypyc.ops import FuncIR, BasicBlock, Label, LoadErrorValue, Return
+from mypyc.ops import FuncIR, BasicBlock, Label, LoadErrorValue, Return, Goto, Branch
 
 
 def insert_exception_handling(ir: FuncIR) -> None:
     for block in ir.blocks:
         insert_exception_handling_to_block(block, ir)
+    ir.blocks = split_blocks_at_errors(ir.blocks)
 
 
 def insert_exception_handling_to_block(block: BasicBlock, ir: FuncIR) -> None:
@@ -25,3 +26,41 @@ def add_handler_block(ir: FuncIR) -> Label:
     block.ops.append(Return(reg))
     ir.blocks.append(block)
     return block.label
+
+
+def split_blocks_at_errors(blocks: List[BasicBlock]) -> List[BasicBlock]:
+    new_blocks = []
+    mapping = {}
+    # First split blocks.
+    for block in blocks:
+        ops = block.ops
+        i0 = 0
+        i = 0
+        new_ops = []
+        while i < len(ops) - 1:
+            if ops[i].error_label is not None:
+                # Split
+                new_block = BasicBlock(len(new_blocks))
+                new_block.ops.extend(ops[i0:i + 1])
+                new_block.ops[-1].ok_label = new_block.label + 1
+                mapping[block.label] = new_block.label
+                new_blocks.append(new_block)
+                i += 1
+                i0 = i
+            else:
+                i += 1
+        new_block = BasicBlock(len(new_blocks))
+        new_block.ops.extend(ops[i0:i + 1])
+        mapping[block.label] = new_block.label
+        new_blocks.append(new_block)
+    # Adjust all labels to reflect the new blocks.
+    for block in new_blocks:
+        for op in block.ops:
+            if op.error_label is not None:
+                op.error_label = mapping[op.error_label]
+            elif isinstance(op, Goto):
+                op.label = mapping[op.label]
+            elif isinstance(op, Branch):
+                op.true = mapping[op.true]
+                op.false = mapping[op.false]
+    return new_blocks

--- a/mypyc/exceptions.py
+++ b/mypyc/exceptions.py
@@ -1,0 +1,27 @@
+from typing import Optional
+
+from mypyc.ops import FuncIR, BasicBlock, Label, LoadErrorValue, Return
+
+
+def insert_exception_handling(ir: FuncIR) -> None:
+    for block in ir.blocks:
+        insert_exception_handling_to_block(block, ir)
+
+
+def insert_exception_handling_to_block(block: BasicBlock, ir: FuncIR) -> None:
+    handler_block = None  # type: Optional[Label]
+    for op in block.ops:
+        if op.can_raise():
+            if not handler_block:
+                handler_block = add_handler_block(ir)
+            op.error_label = handler_block
+
+
+def add_handler_block(ir: FuncIR) -> Label:
+    block = BasicBlock(Label(len(ir.blocks)))
+    rtype = ir.ret_type
+    reg = ir.env.add_temp(rtype)
+    block.ops.append(LoadErrorValue(reg, rtype))
+    block.ops.append(Return(reg))
+    ir.blocks.append(block)
+    return block.label

--- a/mypyc/exceptions.py
+++ b/mypyc/exceptions.py
@@ -1,21 +1,23 @@
 from typing import Optional, List
 
-from mypyc.ops import FuncIR, BasicBlock, Label, LoadErrorValue, Return, Goto, Branch
+from mypyc.ops import (
+    FuncIR, BasicBlock, Label, LoadErrorValue, Return, Goto, Branch, ERR_NEVER, ERR_MAGIC,
+    ERR_FALSE, INVALID_REGISTER, RegisterOp
+)
 
 
 def insert_exception_handling(ir: FuncIR) -> None:
+    can_raise = False
     for block in ir.blocks:
-        insert_exception_handling_to_block(block, ir)
-    ir.blocks = split_blocks_at_errors(ir.blocks)
+        can_raise = any(op.can_raise() for op in block.ops)
+        if can_raise:
+            error_label = add_handler_block(ir)
+            break
+    ir.blocks = split_blocks_at_errors(ir.blocks, error_label, ir.name)
 
 
-def insert_exception_handling_to_block(block: BasicBlock, ir: FuncIR) -> None:
-    handler_block = None  # type: Optional[Label]
-    for op in block.ops:
-        if op.can_raise():
-            if not handler_block:
-                handler_block = add_handler_block(ir)
-            op.error_label = handler_block
+def can_raise(block: BasicBlock) -> bool:
+    return any(op.can_raise() for op in block.ops)
 
 
 def add_handler_block(ir: FuncIR) -> Label:
@@ -28,39 +30,61 @@ def add_handler_block(ir: FuncIR) -> Label:
     return block.label
 
 
-def split_blocks_at_errors(blocks: List[BasicBlock]) -> List[BasicBlock]:
-    new_blocks = []
+def split_blocks_at_errors(blocks: List[BasicBlock],
+                           error_label: Label,
+                           func: str) -> List[BasicBlock]:
+    new_blocks = []  # type: List[BasicBlock]
     mapping = {}
-    # First split blocks.
+    partial_ops = set()
+    # First split blocks on ops that may raise.
     for block in blocks:
         ops = block.ops
         i0 = 0
         i = 0
-        new_ops = []
         while i < len(ops) - 1:
-            if ops[i].error_label is not None:
+            op = ops[i]
+            if isinstance(op, RegisterOp) and op.error_kind != ERR_NEVER:
                 # Split
-                new_block = BasicBlock(len(new_blocks))
+                new_block = BasicBlock(Label(len(new_blocks)))
                 new_block.ops.extend(ops[i0:i + 1])
-                new_block.ops[-1].ok_label = new_block.label + 1
+
+                if op.error_kind == ERR_MAGIC:
+                    variant = Branch.IS_ERROR
+                    negated = False
+                elif op.error_kind == ERR_FALSE:
+                    variant = Branch.BOOL_EXPR
+                    negated = True
+                else:
+                    assert False, 'unknown error kind %d' % op.error_kind
+
+                # Void ops can't generate errors.
+                assert op.dest is not None, op
+
+                branch = Branch(op.dest, INVALID_REGISTER,
+                                true_label=error_label,
+                                false_label=Label(new_block.label + 1),
+                                op=variant)
+                branch.negated = negated
+                branch.traceback_entry = (func, op.line)
+                partial_ops.add(branch)  # Only tweak false of these
+                new_block.ops.append(branch)
                 mapping[block.label] = new_block.label
                 new_blocks.append(new_block)
                 i += 1
                 i0 = i
             else:
                 i += 1
-        new_block = BasicBlock(len(new_blocks))
+        new_block = BasicBlock(Label(len(new_blocks)))
         new_block.ops.extend(ops[i0:i + 1])
         mapping[block.label] = new_block.label
         new_blocks.append(new_block)
     # Adjust all labels to reflect the new blocks.
     for block in new_blocks:
         for op in block.ops:
-            if op.error_label is not None:
-                op.error_label = mapping[op.error_label]
-            elif isinstance(op, Goto):
+            if isinstance(op, Goto):
                 op.label = mapping[op.label]
             elif isinstance(op, Branch):
+                if op not in partial_ops:
+                    op.false = mapping[op.false]
                 op.true = mapping[op.true]
-                op.false = mapping[op.false]
     return new_blocks

--- a/mypyc/exceptions.py
+++ b/mypyc/exceptions.py
@@ -7,7 +7,7 @@ from mypyc.ops import (
 
 
 def insert_exception_handling(ir: FuncIR) -> None:
-    can_raise = False
+    error_label = None
     for block in ir.blocks:
         can_raise = any(op.can_raise() for op in block.ops)
         if can_raise:

--- a/mypyc/exceptions.py
+++ b/mypyc/exceptions.py
@@ -66,9 +66,10 @@ def split_blocks_at_errors(blocks: List[BasicBlock],
                                 op=variant)
                 branch.negated = negated
                 branch.traceback_entry = (func, op.line)
-                partial_ops.add(branch)  # Only tweak false of these
+                partial_ops.add(branch)  # Only tweak true label of these
                 new_block.ops.append(branch)
-                mapping[block.label] = new_block.label
+                if i0 == 0:
+                    mapping[block.label] = new_block.label
                 new_blocks.append(new_block)
                 i += 1
                 i0 = i
@@ -76,7 +77,8 @@ def split_blocks_at_errors(blocks: List[BasicBlock],
                 i += 1
         new_block = BasicBlock(Label(len(new_blocks)))
         new_block.ops.extend(ops[i0:i + 1])
-        mapping[block.label] = new_block.label
+        if i0 == 0:
+            mapping[block.label] = new_block.label
         new_blocks.append(new_block)
     # Adjust all labels to reflect the new blocks.
     for block in new_blocks:

--- a/mypyc/exceptions.py
+++ b/mypyc/exceptions.py
@@ -77,7 +77,8 @@ def split_blocks_at_errors(blocks: List[BasicBlock],
                 branch = Branch(op.dest, INVALID_REGISTER,
                                 true_label=error_label,
                                 false_label=Label(new_block.label + 1),
-                                op=variant)
+                                op=variant,
+                                line=op.line)
                 branch.negated = negated
                 branch.traceback_entry = (func, op.line)
                 partial_ops.add(branch)  # Only tweak true label of these

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -348,9 +348,10 @@ class IRBuilder(NodeVisitor[Register]):
                 op = PrimitiveOp.DICT_SET
             else:
                 assert False, target.rtype
-            self.add(PrimitiveOp(None, op,
+            target_reg = self.alloc_temp(BoolRType())
+            self.add(PrimitiveOp(target_reg, op,
                                  [target.base_reg, target.index_reg, boxed_item_reg], rvalue.line))
-            return INVALID_REGISTER
+            return target_reg
 
         assert False, 'Unsupported assignment target'
 
@@ -829,9 +830,9 @@ class IRBuilder(NodeVisitor[Register]):
         result_type = self.node_type(expr)
         base = self.accept(callee.expr)
         if callee.name == 'append' and base_type.name == 'list':
-            target = INVALID_REGISTER  # TODO: Do we sometimes need to allocate a register?
+            target = self.alloc_target(BoolRType())
             arg = self.box_expr(expr.args[0])
-            self.add(PrimitiveOp(None, PrimitiveOp.LIST_APPEND, [base, arg], expr.line))
+            self.add(PrimitiveOp(target, PrimitiveOp.LIST_APPEND, [base, arg], expr.line))
         elif callee.name == 'update' and base_type.name == 'dict':
             target = INVALID_REGISTER
             other_list_reg = self.accept(expr.args[0])

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -337,8 +337,10 @@ class IRBuilder(NodeVisitor[Register]):
             rvalue_reg = self.accept(rvalue)
             if needs_box:
                 rvalue_reg = self.box(rvalue_reg, rvalue_type)
-            self.add(SetAttr(target.obj_reg, target.attr, rvalue_reg, target.obj_type, rvalue.line))
-            return INVALID_REGISTER
+            target_reg = self.alloc_temp(BoolRType())
+            self.add(SetAttr(target_reg, target.obj_reg, target.attr, rvalue_reg, target.obj_type,
+                             rvalue.line))
+            return target_reg
         elif isinstance(target, AssignmentTargetIndex):
             item_reg = self.accept(rvalue)
             boxed_item_reg = self.box(item_reg, rvalue_type)
@@ -834,9 +836,10 @@ class IRBuilder(NodeVisitor[Register]):
             arg = self.box_expr(expr.args[0])
             self.add(PrimitiveOp(target, PrimitiveOp.LIST_APPEND, [base, arg], expr.line))
         elif callee.name == 'update' and base_type.name == 'dict':
-            target = INVALID_REGISTER
+            target = self.alloc_target(BoolRType())
             other_list_reg = self.accept(expr.args[0])
-            self.add(PrimitiveOp(None, PrimitiveOp.DICT_UPDATE, [base, other_list_reg], expr.line))
+            self.add(PrimitiveOp(target, PrimitiveOp.DICT_UPDATE, [base, other_list_reg],
+                                 expr.line))
         else:
             return None
         return target

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -846,6 +846,12 @@ class PrimitiveOp(RegisterOp):
     def sources(self) -> List[Register]:
         return list(self.args)
 
+    def __str__(self) -> str:
+        return '<PrimiveOp name=%r type=%s dest=%d args=%s>' % (self.desc.name,
+                                                                self.desc.type,
+                                                                self.dest,
+                                                                self.args)
+
     def to_str(self, env: Environment) -> str:
         params = {}  # type: Dict[str, Any]
         if self.dest is not None and self.dest != INVALID_REGISTER:

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -551,7 +551,6 @@ class IncRef(RegisterOp):
     def __init__(self, dest: Register, typ: RType, line: int = -1) -> None:
         super().__init__(dest, line)
         self.target_type = typ
-        self.line = line
 
     def to_str(self, env: Environment) -> str:
         s = env.format('inc_ref %r', self.dest)
@@ -575,7 +574,6 @@ class DecRef(RegisterOp):
     def __init__(self, dest: Register, typ: RType, line: int = -1) -> None:
         super().__init__(dest, line)
         self.target_type = typ
-        self.line = line
 
     def to_str(self, env: Environment) -> str:
         s = env.format('dec_ref %r', self.dest)
@@ -600,10 +598,9 @@ class Call(RegisterOp):
     """
 
     def __init__(self, dest: Optional[Register], fn: str, args: List[Register], line: int) -> None:
-        super().__init__(dest)
+        super().__init__(dest, line)
         self.fn = fn
         self.args = args
-        self.line = line
 
     def to_str(self, env: Environment) -> str:
         args = ', '.join(env.format('%r', arg) for arg in self.args)
@@ -634,10 +631,9 @@ class PyCall(RegisterOp):
     """
     def __init__(self, dest: Optional[Register], function: Register, args: List[Register],
                  line: int) -> None:
-        super().__init__(dest)
+        super().__init__(dest, line)
         self.function = function
         self.args = args
-        self.line = line
 
     def to_str(self, env: Environment) -> str:
         args = ', '.join(env.format('%r', arg) for arg in self.args)
@@ -678,6 +674,9 @@ class PyMethodCall(RegisterOp):
             s = env.format('%r = ', self.dest) + s
         return s + ' :: py'
 
+    def can_raise(self) -> bool:
+        return True
+
     def sources(self) -> List[Register]:
         return self.args[:] + [self.obj, self.method]
 
@@ -689,10 +688,9 @@ class PyGetAttr(RegisterOp):
     """dest = left.right :: py"""
 
     def __init__(self, dest: Register, left: Register, right: str, line: int) -> None:
-        super().__init__(dest)
+        super().__init__(dest, line)
         self.left = left
         self.right = right
-        self.line = line
 
     def sources(self) -> List[Register]:
         return [self.left]
@@ -808,12 +806,11 @@ class PrimitiveOp(RegisterOp):
 
         If desc.is_void is true, dest should be None.
         """
-        super().__init__(dest)
+        super().__init__(dest, line)
         if desc.num_args != VAR_ARG:
             assert len(args) == desc.num_args
         self.desc = desc
         self.args = args
-        self.line = line
 
     def sources(self) -> List[Register]:
         return list(self.args)
@@ -838,9 +835,8 @@ class Assign(RegisterOp):
     """dest = int"""
 
     def __init__(self, dest: Register, src: Register, line: int = -1) -> None:
-        super().__init__(dest)
+        super().__init__(dest, line)
         self.src = src
-        self.line = line
 
     def sources(self) -> List[Register]:
         return [self.src]
@@ -859,9 +855,8 @@ class LoadInt(RegisterOp):
     """dest = int"""
 
     def __init__(self, dest: Register, value: int, line: int = -1) -> None:
-        super().__init__(dest)
+        super().__init__(dest, line)
         self.value = value
-        self.line = line
 
     def sources(self) -> List[Register]:
         return []
@@ -901,11 +896,10 @@ class GetAttr(RegisterOp):
 
     def __init__(self, dest: Register, obj: Register, attr: str, rtype: UserRType,
                  line: int) -> None:
-        super().__init__(dest)
+        super().__init__(dest, line)
         self.obj = obj
         self.attr = attr
         self.rtype = rtype
-        self.line = line
 
     def sources(self) -> List[Register]:
         return [self.obj]
@@ -925,12 +919,11 @@ class SetAttr(RegisterOp):
 
     def __init__(self, obj: Register, attr: str, src: Register, rtype: UserRType,
                  line: int) -> None:
-        super().__init__(None)
+        super().__init__(None, line)
         self.obj = obj
         self.attr = attr
         self.src = src
         self.rtype = rtype
-        self.line = line
 
     def sources(self) -> List[Register]:
         return [self.obj, self.src]
@@ -949,9 +942,8 @@ class LoadStatic(RegisterOp):
     """dest = name :: static"""
 
     def __init__(self, dest: Register, identifier: str, line: int = -1) -> None:
-        super().__init__(dest)
+        super().__init__(dest, line)
         self.identifier = identifier
-        self.line = line
 
     def sources(self) -> List[Register]:
         return []
@@ -971,11 +963,10 @@ class TupleGet(RegisterOp):
 
     def __init__(self, dest: Register, src: Register, index: int, target_type: RType,
                  line: int) -> None:
-        super().__init__(dest)
+        super().__init__(dest, line)
         self.src = src
         self.index = index
         self.target_type = target_type
-        self.line = line
 
     def sources(self) -> List[Register]:
         return [self.src]
@@ -1000,10 +991,9 @@ class Cast(RegisterOp):
     # TODO: Error checking
 
     def __init__(self, dest: Register, src: Register, typ: RType, line: int) -> None:
-        super().__init__(dest)
+        super().__init__(dest, line)
         self.src = src
         self.typ = typ
-        self.line = line
 
     def sources(self) -> List[Register]:
         return [self.src]
@@ -1026,10 +1016,9 @@ class Box(RegisterOp):
     """
 
     def __init__(self, dest: Register, src: Register, typ: RType, line: int = -1) -> None:
-        super().__init__(dest)
+        super().__init__(dest, line)
         self.src = src
         self.type = typ
-        self.line = line
 
     def sources(self) -> List[Register]:
         return [self.src]
@@ -1053,10 +1042,9 @@ class Unbox(RegisterOp):
     # TODO: Error checking
 
     def __init__(self, dest: Register, src: Register, typ: RType, line: int) -> None:
-        super().__init__(dest)
+        super().__init__(dest, line)
         self.src = src
         self.type = typ
-        self.line = line
 
     def sources(self) -> List[Register]:
         return [self.src]

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -145,8 +145,11 @@ class TupleRType(RType):
 
     @property
     def c_undefined_value(self) -> str:
-        # TODO: Implement this
-        raise RuntimeError('Not implemented yet')
+        # This doesn't work since this is expected to return a C expression, but
+        # defining an undefined tuple requires declaring a temp variable, such as:
+        #
+        #    struct foo _tmp = { <item0-undefined>, <item1-undefined>, ... };
+        assert False, "Tuple undefined value can't be represented as a C expression"
 
     @property
     def ctype(self) -> str:
@@ -1095,6 +1098,9 @@ class FuncIR:
         self.blocks = blocks
         self.env = env
 
+    def __str__(self) -> str:
+        return '\n'.join(format_func(self))
+
 
 class ClassIR:
     """Intermediate representation of a class.
@@ -1219,7 +1225,7 @@ def format_blocks(blocks: List[BasicBlock], env: Environment) -> List[str]:
         for op in ops:
             line = '    ' + op.to_str(env)
             if op.error_label is not None:
-                line += env.format(' [error %l]', op.error_label)
+                line += env.format(' <err %l>', op.error_label)
             lines.append(line)
 
         if not isinstance(block.ops[-1], (Goto, Branch, Return, Unreachable)):

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -411,6 +411,9 @@ class Goto(Op):
         super().__init__(line)
         self.label = label
 
+    def __repr__(self) -> str:
+        return '<Goto %d>' % self.label
+
     def to_str(self, env: Environment) -> str:
         return env.format('goto %l', self.label)
 
@@ -601,6 +604,9 @@ class DecRef(RegisterOp):
         assert typ.is_refcounted
         super().__init__(dest, line)
         self.target_type = typ
+
+    def __repr__(self) -> str:
+        return '<DecRef %d>' % self.dest
 
     def to_str(self, env: Environment) -> str:
         s = env.format('dec_ref %r', self.dest)
@@ -846,7 +852,7 @@ class PrimitiveOp(RegisterOp):
     def sources(self) -> List[Register]:
         return list(self.args)
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         return '<PrimiveOp name=%r type=%s dest=%d args=%s>' % (self.desc.name,
                                                                 self.desc.type,
                                                                 self.dest,

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -575,6 +575,7 @@ class IncRef(RegisterOp):
     error_kind = ERR_NEVER
 
     def __init__(self, dest: Register, typ: RType, line: int = -1) -> None:
+        assert typ.is_refcounted
         super().__init__(dest, line)
         self.target_type = typ
 
@@ -597,6 +598,7 @@ class DecRef(RegisterOp):
     error_kind = ERR_NEVER
 
     def __init__(self, dest: Register, typ: RType, line: int = -1) -> None:
+        assert typ.is_refcounted
         super().__init__(dest, line)
         self.target_type = typ
 

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1096,9 +1096,9 @@ class BasicBlock:
     the middle of a basic block, but the exceptions aren't checked.
     Afterwards we perform a transform that inserts explicit checks for
     all error conditions and splits basic blocks accordingly to preserve
-    the invariant that only a jump, branch or return can only ever appear
-    as the final op in a block. The motivation is that manually inserting
-    error checking ops is error-prone and is better automated.
+    the invariant that a jump, branch or return can only ever appear
+    as the final op in a block. Manually inserting error checking ops
+    would be boring and error-prone.
 
     Ops that may terminate the program aren't treated as exits.
     """

--- a/mypyc/refcount.py
+++ b/mypyc/refcount.py
@@ -37,6 +37,7 @@ def insert_ref_count_opcodes(ir: FuncIR) -> None:
     This is the entry point to this module.
     """
     cfg = get_cfg(ir.blocks)
+    print(cfg)
     args = set([Register(i) for i in range(len(ir.args))])
     live = analyze_live_regs(ir.blocks, cfg)
     borrow = analyze_borrowed_arguments(ir.blocks, cfg, args)

--- a/mypyc/refcount.py
+++ b/mypyc/refcount.py
@@ -37,7 +37,6 @@ def insert_ref_count_opcodes(ir: FuncIR) -> None:
     This is the entry point to this module.
     """
     cfg = get_cfg(ir.blocks)
-    print(cfg)
     args = set([Register(i) for i in range(len(ir.args))])
     live = analyze_live_regs(ir.blocks, cfg)
     borrow = analyze_borrowed_arguments(ir.blocks, cfg, args)

--- a/mypyc/refcount.py
+++ b/mypyc/refcount.py
@@ -164,7 +164,9 @@ def after_branch_decrefs(label: Label,
     target_pre_live = pre_live[label, 0]
     decref = source_live_regs - target_pre_live - source_borrowed
     if decref:
-        return [DecRef(reg, env.types[reg]) for reg in sorted(decref)]
+        return [DecRef(reg, env.types[reg])
+                for reg in sorted(decref)
+                if env.types[reg].is_refcounted]
     return []
 
 
@@ -175,7 +177,9 @@ def after_branch_increfs(label: Label,
     target_borrowed = pre_borrow[label, 0]
     incref = source_borrowed - target_borrowed
     if incref:
-        return [IncRef(reg, env.types[reg]) for reg in sorted(incref)]
+        return [IncRef(reg, env.types[reg])
+                for reg in sorted(incref)
+                if env.types[reg].is_refcounted]
     return []
 
 

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -182,7 +182,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                            ('y', IntRType())])
         rtype = UserRType(ir)
         self.assert_emit(SetAttr(self.b, self.n, 'y', self.m, rtype, 1),
-                         """CPY_SET_ATTR(cpy_r_n, 3, cpy_r_m, AObject, CPyTagged), cpy_r_b = 1;""")
+                         """cpy_r_b = CPY_SET_ATTR(cpy_r_n, 3, cpy_r_m, AObject, CPyTagged);""")
 
     def test_dict_get_item(self) -> None:
         self.assert_emit(PrimitiveOp(self.o, PrimitiveOp.DICT_GET, [self.d, self.o2], 1),

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -151,7 +151,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                                 cpy_r_n = CPyTagged_FromObject(cpy_r_m);
                             else {
                                 PyErr_SetString(PyExc_TypeError, "int object expected");
-                                abort();
+                                cpy_r_n = CPY_INT_TAG;
                             }
                          """)
 

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -39,34 +39,34 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          "cpy_r_m = 10;")
 
     def test_tuple_get(self) -> None:
-        self.assert_emit(TupleGet(self.m, self.n, 1, BoolRType()), 'cpy_r_m = cpy_r_n.f1;')
+        self.assert_emit(TupleGet(self.m, self.n, 1, BoolRType(), 0), 'cpy_r_m = cpy_r_n.f1;')
 
     def test_load_None(self) -> None:
-        self.assert_emit(PrimitiveOp(self.m, PrimitiveOp.NONE),
+        self.assert_emit(PrimitiveOp(self.m, PrimitiveOp.NONE, [], 0),
                          """cpy_r_m = Py_None;
                             Py_INCREF(cpy_r_m);
                          """)
 
     def test_load_True(self) -> None:
-        self.assert_emit(PrimitiveOp(self.m, PrimitiveOp.TRUE), "cpy_r_m = 1;")
+        self.assert_emit(PrimitiveOp(self.m, PrimitiveOp.TRUE, [], 0), "cpy_r_m = 1;")
 
     def test_load_False(self) -> None:
-        self.assert_emit(PrimitiveOp(self.m, PrimitiveOp.FALSE), "cpy_r_m = 0;")
+        self.assert_emit(PrimitiveOp(self.m, PrimitiveOp.FALSE, [], 0), "cpy_r_m = 0;")
 
     def test_assign_int(self) -> None:
         self.assert_emit(Assign(self.m, self.n),
                          "cpy_r_m = cpy_r_n;")
 
     def test_int_add(self) -> None:
-        self.assert_emit(PrimitiveOp(self.n, PrimitiveOp.INT_ADD, self.m, self.k),
+        self.assert_emit(PrimitiveOp(self.n, PrimitiveOp.INT_ADD, [self.m, self.k], 55),
                          "cpy_r_n = CPyTagged_Add(cpy_r_m, cpy_r_k);")
 
     def test_int_sub(self) -> None:
-        self.assert_emit(PrimitiveOp(self.n, PrimitiveOp.INT_SUB, self.m, self.k),
+        self.assert_emit(PrimitiveOp(self.n, PrimitiveOp.INT_SUB, [self.m, self.k], 55),
                          "cpy_r_n = CPyTagged_Subtract(cpy_r_m, cpy_r_k);")
 
     def test_list_repeat(self) -> None:
-        self.assert_emit(PrimitiveOp(self.ll, PrimitiveOp.LIST_REPEAT, self.l, self.n),
+        self.assert_emit(PrimitiveOp(self.ll, PrimitiveOp.LIST_REPEAT, [self.l, self.n], 55),
                          """long long __tmp1;
                             __tmp1 = CPyTagged_AsLongLong(cpy_r_n);
                             if (__tmp1 == -1 && PyErr_Occurred())
@@ -77,11 +77,11 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """)
 
     def test_int_neg(self) -> None:
-        self.assert_emit(PrimitiveOp(self.n, PrimitiveOp.INT_NEG, self.m),
+        self.assert_emit(PrimitiveOp(self.n, PrimitiveOp.INT_NEG, [self.m], 55),
                          "cpy_r_n = CPy_NegateInt(cpy_r_m);")
 
     def test_list_len(self) -> None:
-        self.assert_emit(PrimitiveOp(self.n, PrimitiveOp.LIST_LEN, self.l),
+        self.assert_emit(PrimitiveOp(self.n, PrimitiveOp.LIST_LEN, [self.l], 55),
                          """long long __tmp1;
                             __tmp1 = PyList_GET_SIZE(cpy_r_l);
                             cpy_r_n = CPyTagged_ShortFromLongLong(__tmp1);
@@ -104,15 +104,15 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """)
 
     def test_call(self) -> None:
-        self.assert_emit(Call(self.n, 'myfn', [self.m]),
+        self.assert_emit(Call(self.n, 'myfn', [self.m], 55),
                          "cpy_r_n = CPyDef_myfn(cpy_r_m);")
 
     def test_call_two_args(self) -> None:
-        self.assert_emit(Call(self.n, 'myfn', [self.m, self.k]),
+        self.assert_emit(Call(self.n, 'myfn', [self.m, self.k], 55),
                          "cpy_r_n = CPyDef_myfn(cpy_r_m, cpy_r_k);")
 
     def test_call_no_return(self) -> None:
-        self.assert_emit(Call(None, 'myfn', [self.m, self.k]),
+        self.assert_emit(Call(None, 'myfn', [self.m, self.k], 55),
                          "CPyDef_myfn(cpy_r_m, cpy_r_k);")
 
     def test_inc_ref(self) -> None:
@@ -132,14 +132,14 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.assert_emit(DecRef(self.m, tuple_type), 'CPyTagged_DecRef(cpy_r_m.f0.f0);')
 
     def test_list_get_item(self) -> None:
-        self.assert_emit(PrimitiveOp(self.n, PrimitiveOp.LIST_GET, self.m, self.k),
+        self.assert_emit(PrimitiveOp(self.n, PrimitiveOp.LIST_GET, [self.m, self.k], 55),
                          """cpy_r_n = CPyList_GetItem(cpy_r_m, cpy_r_k);
                             if (!cpy_r_n)
                                 abort();
                          """)
 
     def test_list_set_item(self) -> None:
-        self.assert_emit(PrimitiveOp(None, PrimitiveOp.LIST_SET, self.l, self.n, self.o),
+        self.assert_emit(PrimitiveOp(None, PrimitiveOp.LIST_SET, [self.l, self.n, self.o], 55),
                          """if (!CPyList_SetItem(cpy_r_l, cpy_r_n, cpy_r_o))
                                 abort();
                          """)
@@ -149,7 +149,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """cpy_r_o = CPyTagged_StealAsObject(cpy_r_n);""")
 
     def test_unbox(self) -> None:
-        self.assert_emit(Unbox(self.n, self.m, IntRType()),
+        self.assert_emit(Unbox(self.n, self.m, IntRType(), 55),
                          """if (PyLong_Check(cpy_r_m))
                                 cpy_r_n = CPyTagged_FromObject(cpy_r_m);
                             else
@@ -157,7 +157,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """)
 
     def test_new_list(self) -> None:
-        self.assert_emit(PrimitiveOp(self.l, PrimitiveOp.NEW_LIST, self.n, self.m),
+        self.assert_emit(PrimitiveOp(self.l, PrimitiveOp.NEW_LIST, [self.n, self.m], 55),
                          """cpy_r_l = PyList_New(2);
                             Py_INCREF(cpy_r_n);
                             PyList_SET_ITEM(cpy_r_l, 0, cpy_r_n);
@@ -166,7 +166,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """)
 
     def test_list_append(self) -> None:
-        self.assert_emit(PrimitiveOp(None, PrimitiveOp.LIST_APPEND, self.l, self.o),
+        self.assert_emit(PrimitiveOp(None, PrimitiveOp.LIST_APPEND, [self.l, self.o], 1),
                          """if (PyList_Append(cpy_r_l, cpy_r_o) == -1)
                                 abort();
                          """)
@@ -175,14 +175,14 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         ir = ClassIR('A', [('x', BoolRType()),
                            ('y', IntRType())])
         rtype = UserRType(ir)
-        self.assert_emit(GetAttr(self.n, self.m, 'y', rtype),
+        self.assert_emit(GetAttr(self.n, self.m, 'y', rtype, 1),
                          """cpy_r_n = CPY_GET_ATTR(cpy_r_m, 2, AObject, CPyTagged);""")
 
     def test_set_attr(self) -> None:
         ir = ClassIR('A', [('x', BoolRType()),
                            ('y', IntRType())])
         rtype = UserRType(ir)
-        self.assert_emit(SetAttr(self.n, 'y', self.m, rtype),
+        self.assert_emit(SetAttr(self.n, 'y', self.m, rtype, 1),
                          """CPY_SET_ATTR(cpy_r_n, 3, cpy_r_m, AObject, CPyTagged);""")
 
     def assert_emit(self, op: Op, expected: str) -> None:

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -74,10 +74,8 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """long long __tmp1;
                             __tmp1 = CPyTagged_AsLongLong(cpy_r_n);
                             if (__tmp1 == -1 && PyErr_Occurred())
-                                abort();
+                                CPyError_OutOfMemory();
                             cpy_r_ll = PySequence_Repeat(cpy_r_l, __tmp1);
-                            if (!cpy_r_ll)
-                                abort();
                          """)
 
     def test_int_neg(self) -> None:

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -190,7 +190,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """CPY_SET_ATTR(cpy_r_n, 3, cpy_r_m, AObject, CPyTagged);""")
 
     def test_dict_get_item(self) -> None:
-        self.assert_emit(PrimitiveOp(self.o, PrimitiveOp.DICT_GET, self.d, self.o2),
+        self.assert_emit(PrimitiveOp(self.o, PrimitiveOp.DICT_GET, [self.d, self.o2], 1),
                          """cpy_r_o = PyDict_GetItem(cpy_r_d, cpy_r_o2);
                             if (!cpy_r_o)
                                 abort();
@@ -198,26 +198,26 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """)
 
     def test_dict_set_item(self) -> None:
-        self.assert_emit(PrimitiveOp(None, PrimitiveOp.DICT_SET, self.d, self.o, self.o2),
+        self.assert_emit(PrimitiveOp(None, PrimitiveOp.DICT_SET, [self.d, self.o, self.o2], 1),
                          """if (PyDict_SetItem(cpy_r_d, cpy_r_o, cpy_r_o2) < 0)
                                 abort();
                          """)
 
     def test_dict_update(self) -> None:
-        self.assert_emit(PrimitiveOp(None, PrimitiveOp.DICT_UPDATE, self.d, self.o),
+        self.assert_emit(PrimitiveOp(None, PrimitiveOp.DICT_UPDATE, [self.d, self.o], 1),
                         """if (PyDict_Update(cpy_r_d, cpy_r_o) == -1)
                                abort();
                         """)
 
     def test_new_dict(self) -> None:
-        self.assert_emit(PrimitiveOp(self.d, PrimitiveOp.NEW_DICT),
+        self.assert_emit(PrimitiveOp(self.d, PrimitiveOp.NEW_DICT, [], 1),
                          """cpy_r_d = PyDict_New();
                             if (!cpy_r_d)
                                 abort();
                          """)
 
     def test_dict_contains(self) -> None:
-        self.assert_emit(PrimitiveOp(self.b, PrimitiveOp.DICT_CONTAINS, self.o, self.d),
+        self.assert_emit(PrimitiveOp(self.b, PrimitiveOp.DICT_CONTAINS, [self.o, self.d], 1),
                          """int __tmp1 = PyDict_Contains(cpy_r_d, cpy_r_o);
                             if (__tmp1 < 0)
                                 abort();

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -28,7 +28,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.context = EmitterContext()
         self.emitter = Emitter(self.context, self.env)
         self.declarations = Emitter(self.context, self.env)
-        self.visitor = FunctionEmitterVisitor(self.emitter, self.declarations)
+        self.visitor = FunctionEmitterVisitor(self.emitter, self.declarations, 'func', 'prog.py')
 
     def test_goto(self) -> None:
         self.assert_emit(Goto(Label(2)),
@@ -93,17 +93,17 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
 
     def test_branch_eq(self) -> None:
         self.assert_emit(Branch(self.n, self.m, Label(8), Label(9), Branch.INT_EQ),
-                         """if (CPyTagged_IsEq(cpy_r_n, cpy_r_m))
+                         """if (CPyTagged_IsEq(cpy_r_n, cpy_r_m)) {
                                 goto CPyL8;
-                            else
+                            } else
                                 goto CPyL9;
                          """)
         b = Branch(self.n, self.m, Label(8), Label(9), Branch.INT_LT)
         b.negated = True
         self.assert_emit(b,
-                         """if (!CPyTagged_IsLt(cpy_r_n, cpy_r_m))
+                         """if (!CPyTagged_IsLt(cpy_r_n, cpy_r_m)) {
                                 goto CPyL8;
-                            else
+                            } else
                                 goto CPyL9;
                          """)
 
@@ -239,7 +239,7 @@ class TestGenerateFunction(unittest.TestCase):
         self.block.ops.append(Return(self.reg))
         fn = FuncIR('myfunc', [self.arg], IntRType(), [self.block], self.env)
         emitter = Emitter(EmitterContext())
-        generate_native_function(fn, emitter)
+        generate_native_function(fn, emitter, 'prog.py')
         result = emitter.fragments
         assert_string_arrays_equal(
             [
@@ -255,7 +255,7 @@ class TestGenerateFunction(unittest.TestCase):
         self.block.ops.append(LoadInt(self.temp, 5))
         fn = FuncIR('myfunc', [self.arg], ListRType(), [self.block], self.env)
         emitter = Emitter(EmitterContext())
-        generate_native_function(fn, emitter)
+        generate_native_function(fn, emitter, 'prog.py')
         result = emitter.fragments
         assert_string_arrays_equal(
             [

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -154,8 +154,10 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.assert_emit(Unbox(self.n, self.m, IntRType(), 55),
                          """if (PyLong_Check(cpy_r_m))
                                 cpy_r_n = CPyTagged_FromObject(cpy_r_m);
-                            else
+                            else {
+                                PyErr_SetString(PyExc_TypeError, "int object expected");
                                 abort();
+                            }
                          """)
 
     def test_new_list(self) -> None:

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -161,9 +161,11 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.assert_emit(PrimitiveOp(self.l, PrimitiveOp.NEW_LIST, [self.n, self.m], 55),
                          """cpy_r_l = PyList_New(2);
                             Py_INCREF(cpy_r_n);
-                            PyList_SET_ITEM(cpy_r_l, 0, cpy_r_n);
                             Py_INCREF(cpy_r_m);
-                            PyList_SET_ITEM(cpy_r_l, 1, cpy_r_m);
+                            if (cpy_r_l != NULL) {
+                                PyList_SET_ITEM(cpy_r_l, 0, cpy_r_n);
+                                PyList_SET_ITEM(cpy_r_l, 1, cpy_r_m);
+                            }
                          """)
 
     def test_list_append(self) -> None:
@@ -186,10 +188,11 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
 
     def test_dict_get_item(self) -> None:
         self.assert_emit(PrimitiveOp(self.o, PrimitiveOp.DICT_GET, [self.d, self.o2], 1),
-                         """cpy_r_o = PyDict_GetItem(cpy_r_d, cpy_r_o2);
+                         """cpy_r_o = PyDict_GetItemWithError(cpy_r_d, cpy_r_o2);
                             if (!cpy_r_o)
-                                abort();
-                            Py_INCREF(cpy_r_o);
+                                PyErr_SetObject(PyExc_KeyError, cpy_r_o2);
+                            else
+                                Py_INCREF(cpy_r_o);
                          """)
 
     def test_dict_set_item(self) -> None:

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -143,10 +143,8 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """)
 
     def test_list_set_item(self) -> None:
-        self.assert_emit(PrimitiveOp(None, PrimitiveOp.LIST_SET, [self.l, self.n, self.o], 55),
-                         """if (!CPyList_SetItem(cpy_r_l, cpy_r_n, cpy_r_o))
-                                abort();
-                         """)
+        self.assert_emit(PrimitiveOp(self.b, PrimitiveOp.LIST_SET, [self.l, self.n, self.o], 55),
+                         """cpy_r_b = CPyList_SetItem(cpy_r_l, cpy_r_n, cpy_r_o) != 0;""")
 
     def test_box(self) -> None:
         self.assert_emit(Box(self.o, self.n, IntRType()),
@@ -196,10 +194,8 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """)
 
     def test_dict_set_item(self) -> None:
-        self.assert_emit(PrimitiveOp(None, PrimitiveOp.DICT_SET, [self.d, self.o, self.o2], 1),
-                         """if (PyDict_SetItem(cpy_r_d, cpy_r_o, cpy_r_o2) < 0)
-                                abort();
-                         """)
+        self.assert_emit(PrimitiveOp(self.b, PrimitiveOp.DICT_SET, [self.d, self.o, self.o2], 1),
+                         """cpy_r_b = PyDict_SetItem(cpy_r_d, cpy_r_o, cpy_r_o2) >= 0;""")
 
     def test_dict_update(self) -> None:
         self.assert_emit(PrimitiveOp(self.b, PrimitiveOp.DICT_UPDATE, [self.d, self.o], 1),

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -170,10 +170,8 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """)
 
     def test_list_append(self) -> None:
-        self.assert_emit(PrimitiveOp(None, PrimitiveOp.LIST_APPEND, [self.l, self.o], 1),
-                         """if (PyList_Append(cpy_r_l, cpy_r_o) == -1)
-                                abort();
-                         """)
+        self.assert_emit(PrimitiveOp(self.b, PrimitiveOp.LIST_APPEND, [self.l, self.o], 1),
+                         """cpy_r_b = PyList_Append(cpy_r_l, cpy_r_o) != -1;""")
 
     def test_get_attr(self) -> None:
         ir = ClassIR('A', [('x', BoolRType()),
@@ -186,8 +184,8 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         ir = ClassIR('A', [('x', BoolRType()),
                            ('y', IntRType())])
         rtype = UserRType(ir)
-        self.assert_emit(SetAttr(self.n, 'y', self.m, rtype, 1),
-                         """CPY_SET_ATTR(cpy_r_n, 3, cpy_r_m, AObject, CPyTagged);""")
+        self.assert_emit(SetAttr(self.b, self.n, 'y', self.m, rtype, 1),
+                         """CPY_SET_ATTR(cpy_r_n, 3, cpy_r_m, AObject, CPyTagged), cpy_r_b = 1;""")
 
     def test_dict_get_item(self) -> None:
         self.assert_emit(PrimitiveOp(self.o, PrimitiveOp.DICT_GET, [self.d, self.o2], 1),
@@ -204,17 +202,12 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """)
 
     def test_dict_update(self) -> None:
-        self.assert_emit(PrimitiveOp(None, PrimitiveOp.DICT_UPDATE, [self.d, self.o], 1),
-                        """if (PyDict_Update(cpy_r_d, cpy_r_o) == -1)
-                               abort();
-                        """)
+        self.assert_emit(PrimitiveOp(self.b, PrimitiveOp.DICT_UPDATE, [self.d, self.o], 1),
+                        """cpy_r_b = PyDict_Update(cpy_r_d, cpy_r_o) != -1;""")
 
     def test_new_dict(self) -> None:
         self.assert_emit(PrimitiveOp(self.d, PrimitiveOp.NEW_DICT, [], 1),
-                         """cpy_r_d = PyDict_New();
-                            if (!cpy_r_d)
-                                abort();
-                         """)
+                         """cpy_r_d = PyDict_New();""")
 
     def test_dict_contains(self) -> None:
         self.assert_emit(PrimitiveOp(self.b, PrimitiveOp.DICT_CONTAINS, [self.o, self.d], 1),

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -137,10 +137,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
 
     def test_list_get_item(self) -> None:
         self.assert_emit(PrimitiveOp(self.n, PrimitiveOp.LIST_GET, [self.m, self.k], 55),
-                         """cpy_r_n = CPyList_GetItem(cpy_r_m, cpy_r_k);
-                            if (!cpy_r_n)
-                                abort();
-                         """)
+                         """cpy_r_n = CPyList_GetItem(cpy_r_m, cpy_r_k);""")
 
     def test_list_set_item(self) -> None:
         self.assert_emit(PrimitiveOp(self.b, PrimitiveOp.LIST_SET, [self.l, self.n, self.o], 55),

--- a/mypyc/test/test_emitwrapper.py
+++ b/mypyc/test/test_emitwrapper.py
@@ -1,4 +1,7 @@
 import unittest
+from typing import List
+
+from mypy.test.helpers import assert_string_arrays_equal
 
 from mypyc.emit import Emitter, EmitterContext
 from mypyc.emitwrapper import generate_arg_check
@@ -13,11 +16,17 @@ class TestArgCheck(unittest.TestCase):
         emitter = Emitter(self.context)
         generate_arg_check('x', ListRType(), emitter)
         lines = emitter.fragments
-        assert lines == [
-            'PyObject *arg_x;\n',
-            'if (PyList_Check(obj_x))\n',
-            '    arg_x = obj_x;\n',
-            'else\n',
-            '    arg_x = NULL;\n',
-            'if (arg_x == NULL) return NULL;\n',
-        ]
+        self.assert_lines([
+            'PyObject *arg_x;',
+            'if (PyList_Check(obj_x))',
+            '    arg_x = obj_x;',
+            'else {',
+            '    PyErr_SetString(PyExc_TypeError, "list object expected");',
+            '    arg_x = NULL;',
+            '}',
+            'if (arg_x == NULL) return NULL;',
+        ], lines)
+
+    def assert_lines(self, expected: List[str], actual: List[str]) -> None:
+        actual = [line.rstrip('\n') for line in actual]
+        assert_string_arrays_equal(expected, actual, 'Invalid output')

--- a/mypyc/test/test_emitwrapper.py
+++ b/mypyc/test/test_emitwrapper.py
@@ -18,5 +18,6 @@ class TestArgCheck(unittest.TestCase):
             'if (PyList_Check(obj_x))\n',
             '    arg_x = obj_x;\n',
             'else\n',
-            '    return NULL;\n',
+            '    arg_x = NULL;\n',
+            'if (arg_x == NULL) return NULL;\n',
         ]

--- a/mypyc/test/test_emitwrapper.py
+++ b/mypyc/test/test_emitwrapper.py
@@ -5,7 +5,7 @@ from mypy.test.helpers import assert_string_arrays_equal
 
 from mypyc.emit import Emitter, EmitterContext
 from mypyc.emitwrapper import generate_arg_check
-from mypyc.ops import ListRType
+from mypyc.ops import ListRType, IntRType
 
 
 class TestArgCheck(unittest.TestCase):
@@ -25,6 +25,20 @@ class TestArgCheck(unittest.TestCase):
             '    arg_x = NULL;',
             '}',
             'if (arg_x == NULL) return NULL;',
+        ], lines)
+
+    def test_check_int(self) -> None:
+        emitter = Emitter(self.context)
+        generate_arg_check('x', IntRType(), emitter)
+        lines = emitter.fragments
+        self.assert_lines([
+            'CPyTagged arg_x;',
+            'if (PyLong_Check(obj_x))',
+            '    arg_x = CPyTagged_BorrowFromObject(obj_x);',
+            'else {',
+            '    PyErr_SetString(PyExc_TypeError, "int object expected");',
+            '    return NULL;',
+            '}',
         ], lines)
 
     def assert_lines(self, expected: List[str], actual: List[str]) -> None:

--- a/mypyc/test/test_exceptions.py
+++ b/mypyc/test/test_exceptions.py
@@ -1,0 +1,62 @@
+"""Test runner for exception handling transform test cases.
+
+The transform inserts exception handling branch operations to IR.
+"""
+
+import os.path
+from typing import List
+
+from mypy.test.config import test_temp_dir
+from mypy.test.data import parse_test_cases, DataDrivenTestCase, DataSuite
+from mypy.errors import CompileError
+from mypy.test.helpers import assert_string_arrays_equal_wildcards
+
+from mypyc.ops import format_func
+from mypyc.exceptions import insert_exception_handling
+from mypyc.refcount import insert_ref_count_opcodes
+from mypyc.test.testutil import (
+    ICODE_GEN_BUILTINS,
+    build_ir_for_single_file,
+    use_custom_builtins,
+)
+from mypyc.test.config import test_data_prefix
+
+files = [
+    'exceptions.test'
+]
+
+
+class TestExceptionTransform(DataSuite):
+    def __init__(self, *, update_data: bool) -> None:
+        pass
+
+    @classmethod
+    def cases(cls) -> List[DataDrivenTestCase]:
+        c = []  # type: List[DataDrivenTestCase]
+        for f in files:
+            c += parse_test_cases(
+                os.path.join(test_data_prefix, f),
+                None, test_temp_dir, True)
+        return c
+
+    def run_case(self, testcase: DataDrivenTestCase) -> None:
+        """Perform a reference count opcode insertion transform test case."""
+
+        with use_custom_builtins(os.path.join(test_data_prefix, ICODE_GEN_BUILTINS), testcase):
+            try:
+                ir = build_ir_for_single_file(testcase.input)
+            except CompileError as e:
+                actual = e.messages
+            else:
+                assert len(ir) == 1, "Only 1 function definition expected per test case"
+                fn = ir[0]
+                insert_exception_handling(fn)
+                insert_ref_count_opcodes(fn)
+                actual = format_func(fn)
+                actual = actual[actual.index('L0:'):]
+
+            expected_output = testcase.output
+            assert_string_arrays_equal_wildcards(
+                expected_output, actual,
+                'Invalid source code output ({}, line {})'.format(testcase.file,
+                                                                  testcase.line))

--- a/mypyc/test/test_exceptions.py
+++ b/mypyc/test/test_exceptions.py
@@ -9,7 +9,7 @@ from typing import List
 from mypy.test.config import test_temp_dir
 from mypy.test.data import parse_test_cases, DataDrivenTestCase, DataSuite
 from mypy.errors import CompileError
-from mypy.test.helpers import assert_string_arrays_equal_wildcards
+from mypy.test.helpers import assert_string_arrays_equal
 
 from mypyc.ops import format_func
 from mypyc.exceptions import insert_exception_handling
@@ -18,6 +18,7 @@ from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS,
     build_ir_for_single_file,
     use_custom_builtins,
+    MypycDataSuite,
 )
 from mypyc.test.config import test_data_prefix
 
@@ -26,18 +27,9 @@ files = [
 ]
 
 
-class TestExceptionTransform(DataSuite):
-    def __init__(self, *, update_data: bool) -> None:
-        pass
-
-    @classmethod
-    def cases(cls) -> List[DataDrivenTestCase]:
-        c = []  # type: List[DataDrivenTestCase]
-        for f in files:
-            c += parse_test_cases(
-                os.path.join(test_data_prefix, f),
-                None, test_temp_dir, True)
-        return c
+class TestExceptionTransform(MypycDataSuite):
+    files = files
+    base_path = test_temp_dir
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         """Perform a reference count opcode insertion transform test case."""
@@ -56,7 +48,7 @@ class TestExceptionTransform(DataSuite):
                 actual = actual[actual.index('L0:'):]
 
             expected_output = testcase.output
-            assert_string_arrays_equal_wildcards(
+            assert_string_arrays_equal(
                 expected_output, actual,
                 'Invalid source code output ({}, line {})'.format(testcase.file,
                                                                   testcase.line))

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -36,7 +36,13 @@ class TestRun(MypycDataSuite):
             options.show_traceback = True
             options.strict_optional = True
             options.python_version = (3, 6)
-            source = build.BuildSource('native.py', 'native', text)
+
+            os.mkdir('tmp/py')
+            source_path = 'tmp/py/native.py'
+            with open(source_path, 'w') as f:
+                f.write(text)
+
+            source = build.BuildSource(source_path, 'native', text)
 
             try:
                 ctext = emitmodule.compile_module_to_c(

--- a/test-data/exceptions.test
+++ b/test-data/exceptions.test
@@ -1,4 +1,4 @@
-[case testListGetAndUnboxError-skip]
+[case testListGetAndUnboxError]
 from typing import List
 def f(x: List[int]) -> int:
     return x[0]

--- a/test-data/exceptions.test
+++ b/test-data/exceptions.test
@@ -3,4 +3,48 @@ from typing import List
 def f(x: List[int]) -> int:
     return x[0]
 [out]
-TODO: Output missing
+L0:
+    r0 = 0
+    r1 = x[r0] :: list
+    dec_ref r0 :: int
+    if is_error(r1) goto L4 (error at f:3) else goto L1
+L1:
+    r2 = unbox(int, r1)
+    dec_ref r1
+    if is_error(r2) goto L5 (error at f:3) else goto L2
+L2:
+    return r2
+L3:
+    r3 = <error> :: int
+    return r3
+L4:
+    dec_ref r1
+    goto L3
+L5:
+    dec_ref r2 :: int
+    goto L3
+
+[case testListAppendAndSetItemError]
+from typing import List
+def f(x: List[int], y: int, z: int) -> None:
+    x.append(y)
+    x[y] = z
+[out]
+L0:
+    inc_ref y :: int
+    r1 = box(int, y)
+    r0 = x.append(r1)
+    dec_ref r1
+    if not r0 goto L3 (error at f:3) else goto L1 :: bool
+L1:
+    inc_ref z :: int
+    r2 = box(int, z)
+    r3 = (x[y] = r2) :: list
+    dec_ref r2
+    if not r3 goto L3 (error at f:4) else goto L2 :: bool
+L2:
+    r4 = None
+    return r4
+L3:
+    r5 = <error> :: None
+    return r5

--- a/test-data/exceptions.test
+++ b/test-data/exceptions.test
@@ -39,7 +39,7 @@ L0:
 L1:
     inc_ref z :: int
     r2 = box(int, z)
-    r3 = (x[y] = r2) :: list
+    x[y] = r2 :: list; r3 = is_error
     dec_ref r2
     if not r3 goto L3 (error at f:4) else goto L2 :: bool
 L2:

--- a/test-data/exceptions.test
+++ b/test-data/exceptions.test
@@ -1,3 +1,7 @@
+-- Test cases for exception handling insertion transform.
+--
+-- The result includes refcount handling since these two transforms interact.
+
 [case testListGetAndUnboxError]
 from typing import List
 def f(x: List[int]) -> int:
@@ -48,3 +52,45 @@ L2:
 L3:
     r5 = <error> :: None
     return r5
+
+[case testOptionalHandling]
+from typing import Optional
+
+class A: pass
+
+def f(x: Optional[A]) -> int:
+    if x is None:
+        return 1
+    if x is not None:
+        return 2
+    return 3
+[out]
+L0:
+    if x is None goto L1 else goto L2 :: object
+L1:
+    r0 = 1
+    return r0
+L2:
+    inc_ref x
+    r1 = cast(A, x)
+    if is_error(r1) goto L7 (error at f:8) else goto L3
+L3:
+    if not r1 is None goto L8 else goto L9 :: object
+L4:
+    r2 = 2
+    return r2
+L5:
+    r3 = 3
+    return r3
+L6:
+    r4 = <error> :: int
+    return r4
+L7:
+    dec_ref r1
+    goto L6
+L8:
+    dec_ref r1
+    goto L4
+L9:
+    dec_ref r1
+    goto L5

--- a/test-data/exceptions.test
+++ b/test-data/exceptions.test
@@ -11,22 +11,16 @@ L0:
     r0 = 0
     r1 = x[r0] :: list
     dec_ref r0 :: int
-    if is_error(r1) goto L4 (error at f:3) else goto L1
+    if is_error(r1) goto L3 (error at f:3) else goto L1
 L1:
     r2 = unbox(int, r1)
     dec_ref r1
-    if is_error(r2) goto L5 (error at f:3) else goto L2
+    if is_error(r2) goto L3 (error at f:3) else goto L2
 L2:
     return r2
 L3:
     r3 = <error> :: int
     return r3
-L4:
-    dec_ref r1
-    goto L3
-L5:
-    dec_ref r2 :: int
-    goto L3
 
 [case testListAppendAndSetItemError]
 from typing import List
@@ -73,9 +67,9 @@ L1:
 L2:
     inc_ref x
     r1 = cast(A, x)
-    if is_error(r1) goto L7 (error at f:8) else goto L3
+    if is_error(r1) goto L6 (error at f:8) else goto L3
 L3:
-    if not r1 is None goto L8 else goto L9 :: object
+    if not r1 is None goto L7 else goto L8 :: object
 L4:
     r2 = 2
     return r2
@@ -87,11 +81,8 @@ L6:
     return r4
 L7:
     dec_ref r1
-    goto L6
-L8:
-    dec_ref r1
     goto L4
-L9:
+L8:
     dec_ref r1
     goto L5
 
@@ -139,10 +130,8 @@ L7:
 L8:
     dec_ref sum :: int
     dec_ref i :: int
-    dec_ref r0
     goto L6
 L9:
     dec_ref sum :: int
     dec_ref i :: int
-    dec_ref r1 :: int
     goto L6

--- a/test-data/exceptions.test
+++ b/test-data/exceptions.test
@@ -94,3 +94,55 @@ L8:
 L9:
     dec_ref r1
     goto L5
+
+[case testListSum]
+from typing import List
+def sum(a: List[int], l: int) -> int:
+    sum = 0
+    i = 0
+    while i < l:
+        sum = sum + a[i]
+        i = i + 1
+    return sum
+[out]
+L0:
+    sum = 0
+    i = 0
+L1:
+    if i < l goto L2 else goto L7 :: int
+L2:
+    r0 = a[i] :: list
+    if is_error(r0) goto L8 (error at sum:6) else goto L3
+L3:
+    r1 = unbox(int, r0)
+    dec_ref r0
+    if is_error(r1) goto L9 (error at sum:6) else goto L4
+L4:
+    r4 = sum
+    sum = sum + r1 :: int
+    dec_ref r1 :: int
+    dec_ref r4 :: int
+    r2 = 1
+    r5 = i
+    i = i + r2 :: int
+    dec_ref r2 :: int
+    dec_ref r5 :: int
+    goto L1
+L5:
+    return sum
+L6:
+    r3 = <error> :: int
+    return r3
+L7:
+    dec_ref i :: int
+    goto L5
+L8:
+    dec_ref sum :: int
+    dec_ref i :: int
+    dec_ref r0
+    goto L6
+L9:
+    dec_ref sum :: int
+    dec_ref i :: int
+    dec_ref r1 :: int
+    goto L6

--- a/test-data/exceptions.test
+++ b/test-data/exceptions.test
@@ -1,6 +1,6 @@
-[case testListGetAndUnboxError]
+[case testListGetAndUnboxError-skip]
 from typing import List
 def f(x: List[int]) -> int:
     return x[0]
 [out]
-.
+TODO: Output missing

--- a/test-data/exceptions.test
+++ b/test-data/exceptions.test
@@ -1,0 +1,6 @@
+[case testListGetAndUnboxError]
+from typing import List
+def f(x: List[int]) -> int:
+    return x[0]
+[out]
+.

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -22,12 +22,13 @@ def f(a: A) -> None:
 def f(a):
     a :: A
     r0 :: int
-    r1 :: None
+    r1 :: bool
+    r2 :: None
 L0:
     r0 = 1
-    a.x = r0
-    r1 = None
-    return r1
+    a.x = r0; r1 = is_error
+    r2 = None
+    return r2
 
 [case testUserClassInList]
 class C:
@@ -43,20 +44,21 @@ def f() -> int:
 def f():
     c :: C
     r0 :: int
+    r1 :: bool
     a :: list
     d :: C
-    r1 :: int
-    r2 :: object
-    r3, r4, r5 :: int
+    r2 :: int
+    r3 :: object
+    r4, r5, r6 :: int
 L0:
     c = C()
     r0 = 5
-    c.x = r0
+    c.x = r0; r1 = is_error
     a = [c]
-    r1 = 0
-    r2 = a[r1] :: list
-    d = cast(C, r2)
-    r3 = d.x
-    r4 = 1
-    r5 = r3 + r4 :: int
-    return r5
+    r2 = 0
+    r3 = a[r2] :: list
+    d = cast(C, r3)
+    r4 = d.x
+    r5 = 1
+    r6 = r4 + r5 :: int
+    return r6

--- a/test-data/genops-dict.test
+++ b/test-data/genops-dict.test
@@ -26,15 +26,16 @@ def f(d):
     r1 :: object
     r2 :: bool
     r3 :: object
-    r4 :: None
+    r4 :: bool
+    r5 :: None
 L0:
     r0 = 0
     r1 = box(int, r0)
     r2 = False
     r3 = box(bool, r2)
-    d[r1] = r3 :: dict
-    r4 = None
-    return r4
+    d[r1] = r3 :: dict; r4 = is_error
+    r5 = None
+    return r5
 
 [case testNewEmptyDict]
 from typing import Dict
@@ -112,8 +113,9 @@ def f(a: Dict[int, int], b: Dict[int, int]) -> None:
 [out]
 def f(a, b):
     a, b :: dict
-    r0 :: None
+    r0 :: bool
+    r1 :: None
 L0:
-    a.update b :: dict
-    r0 = None
-    return r0
+    r0 = a.update b :: dict
+    r1 = None
+    return r1

--- a/test-data/genops-lists.test
+++ b/test-data/genops-lists.test
@@ -61,14 +61,15 @@ def f(x):
     x :: list
     r0, r1 :: int
     r2 :: object
-    r3 :: None
+    r3 :: bool
+    r4 :: None
 L0:
     r0 = 0
     r1 = 1
     r2 = box(int, r1)
-    x[r0] = r2 :: list
-    r3 = None
-    return r3
+    x[r0] = r2 :: list; r3 = is_error
+    r4 = None
+    return r4
 
 [case testNewListEmpty]
 from typing import List

--- a/test-data/genops-lists.test
+++ b/test-data/genops-lists.test
@@ -148,10 +148,11 @@ def f(a: List[int], x: int) -> None:
 def f(a, x):
     a :: list
     x :: int
-    r0 :: object
-    r1 :: None
+    r0 :: bool
+    r1 :: object
+    r2 :: None
 L0:
-    r0 = box(int, x)
-    a.append(r0)
-    r1 = None
-    return r1
+    r1 = box(int, x)
+    r0 = a.append(r1)
+    r2 = None
+    return r2

--- a/test-data/genops-optional.test
+++ b/test-data/genops-optional.test
@@ -64,7 +64,10 @@ def f(x, y, z):
     a :: A
     r1 :: int
     r2 :: object
-    r3, r4 :: None
+    r3 :: bool
+    r4 :: None
+    r5 :: bool
+    r6 :: None
 L0:
     x = None
     x = A()
@@ -74,11 +77,11 @@ L0:
     a = A()
     r1 = 1
     r2 = box(int, r1)
-    a.a = r2
-    r3 = None
-    a.a = r3
+    a.a = r2; r3 = is_error
     r4 = None
-    return r4
+    a.a = r4; r5 = is_error
+    r6 = None
+    return r6
 
 [case testBoxOptionalListItem]
 from typing import List, Optional
@@ -91,18 +94,21 @@ def f(x):
     x :: list
     r0, r1 :: int
     r2 :: object
-    r3 :: int
-    r4, r5 :: None
+    r3 :: bool
+    r4 :: int
+    r5 :: None
+    r6 :: bool
+    r7 :: None
 L0:
     r0 = 0
     r1 = 0
     r2 = box(int, r1)
-    x[r0] = r2 :: list
-    r3 = 1
-    r4 = None
-    x[r3] = r4 :: list
+    x[r0] = r2 :: list; r3 = is_error
+    r4 = 1
     r5 = None
-    return r5
+    x[r4] = r5 :: list; r6 = is_error
+    r7 = None
+    return r7
 
 [case testNarrowDownFromOptional]
 from typing import Optional

--- a/test-data/module-output.test
+++ b/test-data/module-output.test
@@ -8,6 +8,7 @@ def f(x: int) -> int:
 #include <Python.h>
 #include <CPy.h>
 
+static PyObject *_globals;
 static CPyModule *module_builtins;
 static CPyTagged CPyDef_f(CPyTagged cpy_r_x);
 static PyObject *CPyPy_f(PyObject *self, PyObject *args, PyObject *kw);
@@ -31,6 +32,9 @@ PyMODINIT_FUNC PyInit_prog(void)
     PyObject *m;
     m = PyModule_Create(&module);
     if (m == NULL)
+        return NULL;
+    _globals = PyModule_GetDict(m);
+    if (_globals == NULL)
         return NULL;
     module_builtins = PyImport_ImportModule("builtins");
     if (module_builtins == NULL)

--- a/test-data/module-output.test
+++ b/test-data/module-output.test
@@ -57,8 +57,10 @@ static PyObject *CPyPy_f(PyObject *self, PyObject *args, PyObject *kw) {
     CPyTagged arg_x;
     if (PyLong_Check(obj_x))
         arg_x = CPyTagged_BorrowFromObject(obj_x);
-    else
+    else {
+        PyErr_SetString(PyExc_TypeError, "int object expected");
         return NULL;
+    }
     CPyTagged retval = CPyDef_f(arg_x);
     if (retval == CPY_INT_TAG) {
         return NULL;

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -492,11 +492,11 @@ L0:
     r3 = unbox(int, r2)
     dec_ref r2
     r4 = box(int, r3)
-    a[r0] = r4 :: list
+    a[r0] = r4 :: list; r5 = is_error
     dec_ref r0 :: int
     dec_ref r4
-    r5 = None
-    return r5
+    r6 = None
+    return r6
 
 [case testTupleRefcount]
 from typing import Tuple
@@ -519,11 +519,11 @@ def f() -> None:
 L0:
     c = C()
     r0 = C()
-    c.x = r0
+    c.x = r0; r1 = is_error
     dec_ref c
     dec_ref r0
-    r1 = None
-    return r1
+    r2 = None
+    return r2
 
 [case testCastRefCount]
 class C: pass

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -591,8 +591,8 @@ def f(a: List[int], x: int) -> None:
 [out]
 L0:
     inc_ref x :: int
-    r0 = box(int, x)
-    a.append(r0)
-    dec_ref r0
-    r1 = None
-    return r1
+    r1 = box(int, x)
+    r0 = a.append(r1)
+    dec_ref r1
+    r2 = None
+    return r2

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -338,20 +338,24 @@ assert l == [11, 12]
 [case testException]
 from typing import List
 def f(x: List[int]) -> None:
+    g(x)
+
+def g(x: List[int]) -> bool:
     x[5] = 2
+    return True
 [file driver.py]
 from native import f
 import traceback
-import sys
 try:
     f([])
 except IndexError:
-    s = traceback.format_exc()
-    sys.stdout.write(s)
+    traceback.print_exc()
 [out]
 Traceback (most recent call last):
-  File "tmp/driver.py", line 5, in <module>
+  File "tmp/driver.py", line 4, in <module>
     f([])
   File "tmp/py/native.py", line 3, in f
+    g(x)
+  File "tmp/py/native.py", line 6, in g
     x[5] = 2
 IndexError: list assignment index out of range

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -334,3 +334,24 @@ assert f(l) == 10
 assert f(l) == 1
 g(l, [11, 12])
 assert l == [11, 12]
+
+[case testException]
+from typing import List
+def f(x: List[int]) -> None:
+    x[5] = 2
+[file driver.py]
+from native import f
+import traceback
+import sys
+try:
+    f([])
+except IndexError:
+    s = traceback.format_exc()
+    sys.stdout.write(s)
+[out]
+Traceback (most recent call last):
+  File "tmp/driver.py", line 5, in <module>
+    f([])
+  File "tmp/py/native.py", line 3, in f
+    x[5] = 2
+IndexError: list assignment index out of range


### PR DESCRIPTION
Support propagating exceptions raised by ops to callers and generating stack traces.
Exceptions still can't be manually raised or caught.

The idea is that each op describes whether it can raise an exception. Exceptions must
be signaled through the result value of an op (either false or the undefined/error value). 
We have an extra pass which inserts error check branches after each op that may fail, 
and splits basic blocks accordingly. When initially building the IR, we generate no 
exception check ops, since they can always be inserted automatically, similar to 
reference counting ops.

This also fixes some not directly related bugs as they were needed to get tests passing.

Some special cases are not handled yet but this seems about good enough to merge,
especially since this will cause merge conflicts with pretty much any other non-trivial 
PR.