### PR TITLE
Add a mypy.ini with real strictness settings

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -8,7 +8,8 @@ disallow_any_unimported = True
 warn_unused_configs = True
 warn_unused_ignores = True
 warn_redundant_casts = True
-
-# TODO: Turn this on for everything
-[mypy-mypy.*]
 strict_optional = True
+
+# Per directory mypy.ini files sure would be nice!
+[mypy-mypy.test.testextensions]
+disallow_untyped_defs = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,14 @@
+[mypy]
+disallow_untyped_defs = True
+disallow_subclassing_any = True
+warn_no_return = True
+no_implicit_optional = True
+disallow_any_generics = True
+disallow_any_unimported = True
+warn_unused_configs = True
+warn_unused_ignores = True
+warn_redundant_casts = True
+
+# TODO: Turn this on for everything
+[mypy-mypy.*]
+strict_optional = True

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -31,7 +31,7 @@ class EmitterContext:
 class Emitter:
     """Helper for C code generation."""
 
-    def __init__(self, context: EmitterContext, env: Environment = None) -> None:
+    def __init__(self, context: EmitterContext, env: Optional[Environment] = None) -> None:
         self.context = context
         self.env = env or Environment()
         self.fragments = []  # type: List[str]

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -46,7 +46,7 @@ def generate_native_function(fn: FuncIR, emitter: Emitter, source_path: str) -> 
     emitter.emit_from_emitter(body)
 
 
-class FunctionEmitterVisitor(OpVisitor):
+class FunctionEmitterVisitor(OpVisitor[None]):
     def __init__(self,
                  emitter: Emitter,
                  declarations: Emitter,

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -130,11 +130,17 @@ class FunctionEmitterVisitor(OpVisitor[None]):
     }
 
     def visit_primitive_op(self, op: PrimitiveOp) -> None:
-        dest = self.reg(op.dest) if op.dest is not None else None
+        # N.B: PrimitiveOp has support for is_void ops that don't have
+        # destinations, but none currently exist.
+        # So that we can assert that op.desc isn't None, we can handle
+        # is_void ops first.
+        if op.desc.is_void:
+            assert False, "No is_void ops implemented yet"
+
+        assert op.dest is not None
+        dest = self.reg(op.dest)
 
         if op.desc.kind == OP_BINARY:
-            assert op.dest is not None
-
             left = self.reg(op.args[0])
             right = self.reg(op.args[1])
             if op.desc in FunctionEmitterVisitor.OP_MAP:
@@ -230,7 +236,6 @@ class FunctionEmitterVisitor(OpVisitor[None]):
 
         else:
             assert len(op.args) == 1
-            assert dest is not None
             src = self.reg(op.args[0])
             if op.desc is PrimitiveOp.LIST_LEN:
                 temp = self.temp_name()

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -1,7 +1,7 @@
 """Generate C code for a Python C extension module from Python source code."""
 
 from collections import OrderedDict
-from typing import List, Tuple, Dict
+from typing import List, Tuple, Dict, Iterable
 
 from mypy.build import BuildSource, build
 from mypy.errors import CompileError
@@ -177,7 +177,7 @@ class ModuleGenerator:
         for k, v in self.context.declarations.items():
             marked_declarations[k] = MarkedDeclaration(v, False)
 
-        def _toposort_visit(name):
+        def _toposort_visit(name: str) -> None:
             decl = marked_declarations[name]
             if decl.mark:
                 return
@@ -193,7 +193,7 @@ class ModuleGenerator:
 
         return result
 
-    def declare_global(self, type_spaced, name, static=True) -> None:
+    def declare_global(self, type_spaced: str, name: str, static: bool=True) -> None:
         static_str = 'static ' if static else ''
         if name not in self.context.declarations:
             self.context.declarations[name] = HeaderDeclaration(
@@ -207,11 +207,11 @@ class ModuleGenerator:
     def declare_import(self, imp: str) -> None:
         self.declare_global('CPyModule *', c_module_name(imp))
 
-    def declare_imports(self, imps) -> None:
+    def declare_imports(self, imps: Iterable[str]) -> None:
         for imp in imps:
             self.declare_import(imp)
 
-    def declare_static_pyobject(self, symbol):
+    def declare_static_pyobject(self, symbol: str) -> None:
         self.declare_global('PyObject *', symbol)
 
     def generate_imports_init_section(self, imps: List[str], emitter: Emitter) -> None:

--- a/mypyc/exceptions.py
+++ b/mypyc/exceptions.py
@@ -28,7 +28,8 @@ def insert_exception_handling(ir: FuncIR) -> None:
         if can_raise:
             error_label = add_handler_block(ir)
             break
-    ir.blocks = split_blocks_at_errors(ir.blocks, error_label, ir.name)
+    if error_label:
+        ir.blocks = split_blocks_at_errors(ir.blocks, error_label, ir.name)
 
 
 def add_handler_block(ir: FuncIR) -> Label:

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -692,7 +692,7 @@ class IRBuilder(NodeVisitor[Register]):
                 self.add(Assign(target, reg))
                 return target
 
-    def is_module_member_expr(self, expr: MemberExpr):
+    def is_module_member_expr(self, expr: MemberExpr) -> bool:
         return isinstance(expr.expr, RefExpr) and expr.expr.kind == MODULE_REF
 
     def visit_member_expr(self, expr: MemberExpr) -> Register:
@@ -866,7 +866,7 @@ class IRBuilder(NodeVisitor[Register]):
         self.add(PrimitiveOp(target, PrimitiveOp.NEW_TUPLE, items, expr.line))
         return target
 
-    def visit_dict_expr(self, expr: DictExpr):
+    def visit_dict_expr(self, expr: DictExpr) -> Register:
         assert not expr.items  # TODO
         target = self.alloc_target(DictRType())
         self.add(PrimitiveOp(target, PrimitiveOp.NEW_DICT, [], expr.line))

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -37,7 +37,7 @@ INVALID_REGISTER = Register(-99999)
 INVALID_LABEL = Label(-88888)
 
 
-def c_module_name(module_name: str):
+def c_module_name(module_name: str) -> str:
     return 'module_{}'.format(module_name.replace('.', '__dot__'))
 
 

--- a/mypyc/refcount.py
+++ b/mypyc/refcount.py
@@ -118,9 +118,9 @@ def transform_block(block: BasicBlock,
 def insert_branch_inc_and_decrefs(
         block: BasicBlock,
         blocks: List[BasicBlock],
-        pre_live: AnalysisDict,
-        pre_borrow: AnalysisDict,
-        post_borrow: AnalysisDict,
+        pre_live: AnalysisDict[Register],
+        pre_borrow: AnalysisDict[Register],
+        post_borrow: AnalysisDict[Register],
         env: Environment) -> None:
     """Insert inc_refs and/or dec_refs after a branch/goto.
 
@@ -175,7 +175,7 @@ def insert_branch_inc_and_decrefs(
 
 
 def after_branch_decrefs(label: Label,
-                         pre_live: AnalysisDict,
+                         pre_live: AnalysisDict[Register],
                          source_borrowed: Set[Register],
                          source_live_regs: Set[Register],
                          env: Environment,
@@ -190,7 +190,7 @@ def after_branch_decrefs(label: Label,
 
 
 def after_branch_increfs(label: Label,
-                         pre_borrow: AnalysisDict,
+                         pre_borrow: AnalysisDict[Register],
                          source_borrowed: Set[Register],
                          env: Environment) -> List[Op]:
     target_borrowed = pre_borrow[label, 0]

--- a/mypyc/test/test_external.py
+++ b/mypyc/test/test_external.py
@@ -10,7 +10,7 @@ base_dir = os.path.join(os.path.dirname(__file__), '..', '..')
 
 
 class TestExternal(unittest.TestCase):
-    def test_c_unit_test(self):
+    def test_c_unit_test(self) -> None:
         """Run C unit tests in a subprocess."""
         # Build Google Test, the C++ framework we use for testing C code.
         # The source code for Google Test is copied to this repository.
@@ -36,7 +36,7 @@ class TestExternal(unittest.TestCase):
         if status != 0:
             raise AssertionError("make test: C unit test failure")
 
-    def test_self_type_check(self):
+    def test_self_type_check(self) -> None:
         """Use the bundled mypy (in git submodule) to type check mypyc."""
         mypy_dir = os.path.join(base_dir, 'external', 'mypy')
         if not os.path.exists(os.path.join(mypy_dir, 'typeshed', 'stdlib')):
@@ -46,8 +46,7 @@ class TestExternal(unittest.TestCase):
         status = subprocess.call(
                 [sys.executable,
                  os.path.join(mypy_dir, 'scripts', 'mypy'),
-                 '-i', '-p', 'mypyc'],
-                cwd=mypy_dir,
+                 '--config-file', 'mypy.ini', '-p', 'mypyc'],
                 env=env)
         if status != 0:
             raise AssertionError("Self type check failure")

--- a/mypyc/test/test_genops.py
+++ b/mypyc/test/test_genops.py
@@ -71,7 +71,7 @@ class TestGenOps(MypycDataSuite):
                                                                   testcase.line))
 
 
-def get_func_names(expected):
+def get_func_names(expected: List[str]) -> List[str]:
     res = []
     for s in expected:
         m = re.match(r'def ([_a-zA-Z0-9.*$]+)\(', s)
@@ -80,7 +80,7 @@ def get_func_names(expected):
     return res
 
 
-def remove_comment_lines(a):
+def remove_comment_lines(a: List[str]) -> List[str]:
     """Return a copy of array with comments removed.
 
     Lines starting with '--' (but not with '---') are removed.

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -96,5 +96,5 @@ class TestRun(MypycDataSuite):
             assert proc.returncode == 0
 
 
-def heading(text):
+def heading(text: str) -> None:
     print('=' * 20 + ' ' + text + ' ' + '=' * 20)

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -3,12 +3,12 @@
 import contextlib
 import os.path
 import shutil
-from typing import List
+from typing import List, Callable, Iterator
 
 from mypy import build
 from mypy.errors import CompileError
 from mypy.options import Options
-from mypy.test.data import DataSuite
+from mypy.test.data import DataSuite, DataDrivenTestCase
 from mypy.test.config import test_temp_dir
 
 from mypyc import genops
@@ -25,7 +25,8 @@ class MypycDataSuite(DataSuite):
     data_prefix = test_data_prefix
 
 
-def builtins_wrapper(func, path):
+def builtins_wrapper(func: Callable[[DataDrivenTestCase], None],
+                     path: str) -> Callable[[DataDrivenTestCase], None]:
     """Decorate a function that implements a data-driven test case to copy an
     alternative builtins module implementation in place before performing the
     test case. Clean up after executing the test case.
@@ -34,7 +35,7 @@ def builtins_wrapper(func, path):
 
 
 @contextlib.contextmanager
-def use_custom_builtins(builtins_path, testcase):
+def use_custom_builtins(builtins_path: str, testcase: DataDrivenTestCase) -> Iterator[None]:
     for path, _ in testcase.files:
         if os.path.basename(path) == 'builtins.pyi':
             default_builtins = False
@@ -53,7 +54,8 @@ def use_custom_builtins(builtins_path, testcase):
         os.remove(builtins)
 
 
-def perform_test(func, builtins_path, testcase):
+def perform_test(func: Callable[[DataDrivenTestCase], None],
+                 builtins_path: str, testcase: DataDrivenTestCase) -> None:
     for path, _ in testcase.files:
         if os.path.basename(path) == 'builtins.py':
             default_builtins = False


### PR DESCRIPTION
We just use all of the settings that mypy uses right now.

Requires a handful of code fixes. The only interesting change is that
we turn the `dest` attribute of `RegisterOp` into a read-only property
and make a `StrictRegisterOp` subclass that overrides it, which allows
most `RegisterOp`s to have a non-optional `dest`