### PR TITLE
Preliminary method support

### DIFF
--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -17,7 +17,7 @@ def native_function_header(fn: FuncIR) -> str:
     return 'static {ret_type}{prefix}{name}({args})'.format(
         ret_type=fn.ret_type.ctype_spaced,
         prefix=NATIVE_PREFIX,
-        name=fn.name,
+        name=fn.cname,
         args=', '.join(args) or 'void')
 
 

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -80,11 +80,12 @@ class ModuleGenerator:
         for symbol in self.module.unicode_literals.values():
             self.declare_static_pyobject(symbol)
 
+        for fn in self.module.functions:
+            generate_function_declaration(fn, emitter)
+
         for cl in self.module.classes:
             generate_class(cl, self.module_name, emitter)
 
-        for fn in self.module.functions:
-            generate_function_declaration(fn, emitter)
 
         emitter.emit_line()
 
@@ -113,7 +114,7 @@ class ModuleGenerator:
             emitter.emit_line(
                 ('{{"{name}", (PyCFunction){prefix}{name}, METH_VARARGS | METH_KEYWORDS, '
                  'NULL /* docstring */}},').format(
-                    name=fn.name,
+                    name=fn.cname,
                     prefix=PREFIX))
         emitter.emit_line('{NULL, NULL, 0, NULL}')
         emitter.emit_line('};')

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1144,11 +1144,15 @@ class FuncIR:
 
     def __init__(self,
                  name: str,
+                 class_name: Optional[str],
                  args: List[RuntimeArg],
                  ret_type: RType,
                  blocks: List[BasicBlock],
                  env: Environment) -> None:
         self.name = name
+        self.class_name = class_name
+        # TODO: escape ___ in names
+        self.cname = name if not class_name else class_name + '___' + name
         self.args = args
         self.ret_type = ret_type
         self.blocks = blocks
@@ -1171,6 +1175,7 @@ class ClassIR:
                  attributes: List[Tuple[str, RType]]) -> None:
         self.name = name
         self.attributes = attributes
+        self.methods = []  # type: List[FuncIR]
 
     @property
     def struct_name(self) -> str:

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -237,7 +237,7 @@ class TestGenerateFunction(unittest.TestCase):
 
     def test_simple(self) -> None:
         self.block.ops.append(Return(self.reg))
-        fn = FuncIR('myfunc', [self.arg], IntRType(), [self.block], self.env)
+        fn = FuncIR('myfunc', None, [self.arg], IntRType(), [self.block], self.env)
         emitter = Emitter(EmitterContext())
         generate_native_function(fn, emitter, 'prog.py')
         result = emitter.fragments
@@ -253,7 +253,7 @@ class TestGenerateFunction(unittest.TestCase):
     def test_register(self) -> None:
         self.temp = self.env.add_temp(IntRType())
         self.block.ops.append(LoadInt(self.temp, 5))
-        fn = FuncIR('myfunc', [self.arg], ListRType(), [self.block], self.env)
+        fn = FuncIR('myfunc', None, [self.arg], ListRType(), [self.block], self.env)
         emitter = Emitter(EmitterContext())
         generate_native_function(fn, emitter, 'prog.py')
         result = emitter.fragments

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -318,6 +318,25 @@ from native import f
 assert f(1) == 2
 assert f(2) == 1
 
+[case testClass1]
+class A:
+    # Hack since __init__ doesn't work yet
+    def init(self, x: int) -> 'A':
+        self.x = x
+        return self
+    def foo(self) -> int:
+        return self.x+1
+def foo() -> int:
+    # a = A().init(20) # FIXME: this idiom doesn't work!!
+    a = A()
+    a.init(20)
+    return a.foo()
+[file driver.py]
+from native import A, foo
+a = A().init(10)
+assert a.foo() == 11
+assert foo() == 21
+
 [case testPyMethodCall]
 from typing import List
 def f(x: List[int]) -> int:


### PR DESCRIPTION
Support compiling methods declared in classes and calling them via
generic python method calling.
This does not yet support directly calling the native unboxed versions.

Still missing proper support for __init__