### PR TITLE
Add basic support for the "object" type

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -816,7 +816,6 @@ class IRBuilder(NodeVisitor[Register]):
             assert isinstance(callee_type, CallableType)
             # TODO: Argument kinds
             formal_arg_types = [self.type_to_rtype(t) for t in callee_type.arg_types]
-            print(callee_type, formal_arg_types)
             args = []
             for arg_expr, arg_type in zip(expr.args, formal_arg_types):
                 reg = self.accept(arg_expr)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -221,7 +221,7 @@ class IRBuilder(NodeVisitor[Register]):
 
         blocks, env = self.leave()
         args = self.convert_args(fdef)
-        return FuncIR(fdef.name(), class_name, args, ret_type, blocks, env)
+        return FuncIR(fdef.name(), class_name, args, self.ret_type, blocks, env)
 
     def visit_func_def(self, fdef: FuncDef) -> Register:
         self.functions.append(self.gen_func_def(fdef))

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1034,6 +1034,9 @@ class IRBuilder(NodeVisitor[Register]):
         return self.mapper.type_to_rtype(typ)
 
     def node_type(self, node: Expression) -> RType:
+        if isinstance(node, IntExpr):
+            # TODO: Don't special case IntExpr
+            return IntRType()
         mypy_type = self.types[node]
         return self.type_to_rtype(mypy_type)
 

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -66,6 +66,8 @@ class Mapper:
                 return DictRType()
             elif typ.type.fullname() == 'builtins.tuple':
                 return SequenceTupleRType()
+            elif typ.type.fullname() == 'builtins.object':
+                return ObjectRType()
             elif typ.type in self.type_to_ir:
                 return UserRType(self.type_to_ir[typ.type])
         elif isinstance(typ, TupleType):
@@ -209,10 +211,10 @@ class IRBuilder(NodeVisitor[Register]):
         for arg in fdef.arguments:
             assert arg.variable.type, "Function argument missing type"
             self.environment.add_local(arg.variable, self.type_to_rtype(arg.variable.type))
+        self.ret_type = self.convert_return_type(fdef)
         fdef.body.accept(self)
 
-        ret_type = self.convert_return_type(fdef)
-        if ret_type.name == 'None':
+        if self.ret_type.name == 'None':
             self.add_implicit_return()
         else:
             self.add_implicit_unreachable()
@@ -259,6 +261,7 @@ class IRBuilder(NodeVisitor[Register]):
     def visit_return_stmt(self, stmt: ReturnStmt) -> Register:
         if stmt.expr:
             retval = self.accept(stmt.expr)
+            retval = self.coerce(retval, self.node_type(stmt.expr), self.ret_type)
         else:
             retval = self.environment.add_temp(NoneRType())
             self.add(PrimitiveOp(retval, PrimitiveOp.NONE, [], line=-1))
@@ -804,12 +807,22 @@ class IRBuilder(NodeVisitor[Register]):
             self.add(PrimitiveOp(target, PrimitiveOp.LIST_TO_HOMOGENOUS_TUPLE, [arg], expr.line))
         else:
             target_type = self.node_type(expr)
-            if not(self.is_native_name_expr(expr.callee)):
+            if not self.is_native_name_expr(expr.callee):
                 function = self.accept(expr.callee)
                 return self.py_call(function, expr.args, target_type, expr.line)
 
             target = self.alloc_target(target_type)
-            args = [self.accept(arg) for arg in expr.args]
+            callee_type = self.types[expr.callee]
+            assert isinstance(callee_type, CallableType)
+            # TODO: Argument kinds
+            formal_arg_types = [self.type_to_rtype(t) for t in callee_type.arg_types]
+            print(callee_type, formal_arg_types)
+            args = []
+            for arg_expr, arg_type in zip(expr.args, formal_arg_types):
+                reg = self.accept(arg_expr)
+                typ = self.environment.types[reg]
+                reg = self.coerce(reg, typ, arg_type)
+                args.append(reg)
             self.add(Call(target, fn, args, expr.line))
         return target
 
@@ -1066,3 +1079,16 @@ class IRBuilder(NodeVisitor[Register]):
         target = self.alloc_target(UnicodeRType())
         self.add(LoadStatic(target, static_symbol))
         return target
+
+    def coerce(self, src: Register, src_type: RType, target_type: RType) -> Register:
+        """Generate a trivial conversion from one type to other (only if needed).
+
+        For example, int -> object boxes the source int; int -> int emits nothing.
+        All conversions preserve object value.
+
+        Returns the register with the converted value (may be same as src).
+        """
+        # TODO: Also handle object -> int and similar (unbox/cast).
+        if src_type.supports_unbox and not target_type.supports_unbox:
+            return self.box(src, src_type)
+        return src

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -510,3 +510,88 @@ L0:
     r2 = unbox(int, r1)
     return r2
 
+[case testObjectType]
+def g(y: object) -> None:
+    g(y)
+    g([1])
+    g(None)
+[out]
+def g(y):
+    y :: object
+    r0, r1 :: None
+    r2 :: list
+    r3 :: int
+    r4 :: object
+    r5, r6, r7 :: None
+L0:
+    r0 = g(y)
+    r3 = 1
+    r4 = box(int, r3)
+    r2 = [r4]
+    r1 = g(r2)
+    r6 = None
+    r5 = g(r6)
+    r7 = None
+    return r7
+
+[case testCoerceToObject1]
+def g(y: object) -> object:
+    g(1)
+    a = [y]
+    a[0] = (1, 2)
+    y = True
+    return 3
+[out]
+def g(y):
+    y, r0 :: object
+    r1 :: int
+    r2 :: object
+    a :: list
+    r3 :: int
+    r4 :: tuple[int, int]
+    r5, r6 :: int
+    r7 :: object
+    r8, r9 :: bool
+    r10 :: int
+    r11 :: object
+L0:
+    r1 = 1
+    r2 = box(int, r1)
+    r0 = g(r2)
+    a = [y]
+    r3 = 0
+    r5 = 1
+    r6 = 2
+    r4 = (r5, r6)
+    r7 = box(tuple[int, int], r4)
+    a[r3] = r7 :: list; r8 = is_error
+    r9 = True
+    y = box(bool, r9)
+    r10 = 3
+    r11 = box(int, r10)
+    return r11
+
+[case testCoerceToObject2]
+class A:
+    x: object
+    n: int
+def f(a: A, o: object) -> None:
+    a.x = 1
+    o = a.n
+[out]
+def f(a, o):
+    a :: A
+    o :: object
+    r0 :: int
+    r1 :: object
+    r2 :: bool
+    r3 :: int
+    r4 :: None
+L0:
+    r0 = 1
+    r1 = box(int, r0)
+    a.x = r1; r2 = is_error
+    r3 = a.n
+    o = box(int, r3)
+    r4 = None
+    return r4

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -154,7 +154,6 @@ def f(x: bool) -> bool:
         return False
     else:
         return True
-    return False
 [file driver.py]
 from native import f
 print(f(True))


### PR DESCRIPTION
Implicitly box (coerce) unboxed values when they are used as "object" values.
There are likely a bunch of places where we don't correctly box stuff yet. I'll
fix those in separate PRs.
