### PR TITLE
Refactor rtypes

### DIFF
--- a/doc/dev-intro.md
+++ b/doc/dev-intro.md
@@ -176,9 +176,9 @@ Here are some hints about how to add support for a new primitive type
 * Decide whether the primitive type has an "unboxed" representation
   (a representation that is not just `PyObject *`).
 
-* Create a subclass of `RType` to support the primitive type. Make sure
-  `supports_unbox`, `ctype` and various other properties work
-  correctly for the new type.
+* Create a new instance of `RPrimitive` to support the primitive type.
+  Make sure all the attributes are set correctly and also define
+  `<foo>_rprimitive` and `is_<foo>_rprimitive`.
 
 * Update `mypyc.genops.Mapper.type_to_rtype()`.
 

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -5,7 +5,7 @@ from typing import List, Set, Dict, Optional
 
 from mypyc.common import REG_PREFIX
 from mypyc.ops import (
-    Environment, Label, Register, RType, RTuple, UserRType, ROptional,
+    Environment, Label, Register, RType, RTuple, RInstance, ROptional,
     RPrimitive, type_struct_name, is_int_rprimitive, is_bool_rprimitive, short_name,
     is_list_rprimitive, is_dict_rprimitive, is_tuple_rprimitive, is_none_rprimitive,
     object_rprimitive
@@ -179,7 +179,7 @@ class Emitter:
                 err,
                 '{} = NULL;'.format(dest),
                 '}')
-        elif isinstance(typ, UserRType):
+        elif isinstance(typ, RInstance):
             if declare_dest:
                 self.emit_line('PyObject *{};'.format(dest))
             self.emit_lines(

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -6,7 +6,7 @@ from typing import List, Set, Dict, Optional
 from mypyc.common import REG_PREFIX
 from mypyc.ops import (
     Environment, Label, Register, RType, ObjectRType, TupleRType, UserRType, OptionalRType,
-    RInstance, type_struct_name, is_int_rinstance, is_bool_rinstance, short_name
+    RInstance, type_struct_name, is_int_rinstance, is_bool_rinstance, short_name, is_list_rinstance
 )
 
 
@@ -153,10 +153,10 @@ class Emitter:
             err = 'PyErr_SetString(PyExc_TypeError, "{} object expected");'.format(
                 self.pretty_name(typ))
         # TODO: Verify refcount handling.
-        if typ.name in ('list', 'dict'):
+        if is_list_rinstance(typ) or typ.name == 'dict':
             if declare_dest:
                 self.emit_line('PyObject *{};'.format(dest))
-            if typ.name == 'list':
+            if is_list_rinstance(typ):
                 prefix = 'PyList'
             elif typ.name == 'dict':
                 prefix = 'PyDict'

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -108,7 +108,7 @@ class Emitter:
         elif isinstance(rtype, RTuple):
             for i, item_type in enumerate(rtype.types):
                 self.emit_inc_ref('{}.f{}'.format(dest, i), item_type)
-        elif not rtype.supports_unbox:
+        elif not rtype.is_unboxed:
             self.emit_line('Py_INCREF(%s);' % dest)
         # Otherwise assume it's an unboxed, pointerless value and do nothing.
 
@@ -123,7 +123,7 @@ class Emitter:
         elif isinstance(rtype, RTuple):
             for i, item_type in enumerate(rtype.types):
                 self.emit_dec_ref('{}.f{}'.format(dest, i), item_type)
-        elif not rtype.supports_unbox:
+        elif not rtype.is_unboxed:
             self.emit_line('Py_DECREF(%s);' % dest)
         # Otherwise assume it's an unboxed, pointerless value and do nothing.
 
@@ -271,7 +271,7 @@ class Emitter:
                 self.emit_line('PyObject *{} = PyTuple_GetItem({}, {});'.format(temp, src, i))
                 temp2 = self.temp_name()
                 # Unbox or check the item.
-                if item_type.supports_unbox:
+                if item_type.is_unboxed:
                     self.emit_unbox(temp, temp2, item_type, custom_failure, declare_dest=True,
                                     borrow=borrow)
                 else:
@@ -309,7 +309,7 @@ class Emitter:
             self.emit_line('    CPyError_OutOfMemory();')
             # TODO: Fail if dest is None
             for i in range(0, len(typ.types)):
-                if not typ.supports_unbox:
+                if not typ.is_unboxed:
                     self.emit_line('PyTuple_SetItem({}, {}, {}.f{}'.format(dest, i, src, i))
                 else:
                     inner_name = self.temp_name()
@@ -317,7 +317,7 @@ class Emitter:
                                   declare_dest=True)
                     self.emit_line('PyTuple_SetItem({}, {}, {});'.format(dest, i, inner_name, i))
         else:
-            assert not typ.supports_unbox
+            assert not typ.is_unboxed
             # Type is boxed -- trivially just assign.
             self.emit_line('{}{} = {};'.format(declaration, dest, src))
 

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -5,9 +5,9 @@ from typing import List, Set, Dict, Optional
 
 from mypyc.common import REG_PREFIX
 from mypyc.ops import (
-    Environment, Label, Register, RType, ObjectRType, TupleRType, UserRType, OptionalRType,
+    Environment, Label, Register, RType, TupleRType, UserRType, OptionalRType,
     RInstance, type_struct_name, is_int_rinstance, is_bool_rinstance, short_name, is_list_rinstance,
-    is_dict_rinstance, is_tuple_rinstance, is_none_rinstance
+    is_dict_rinstance, is_tuple_rinstance, is_none_rinstance, object_rinstance
 )
 
 
@@ -275,7 +275,7 @@ class Emitter:
                                     borrow=borrow)
                 else:
                     if not borrow:
-                        self.emit_inc_ref(temp, ObjectRType())
+                        self.emit_inc_ref(temp, object_rinstance)
                     self.emit_cast(temp, temp2, item_type, declare_dest=True)
                 self.emit_line('{}.f{} = {};'.format(dest, i, temp2))
             self.emit_line('}')

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -7,7 +7,7 @@ from mypyc.common import REG_PREFIX
 from mypyc.ops import (
     Environment, Label, Register, RType, ObjectRType, TupleRType, UserRType, OptionalRType,
     RInstance, type_struct_name, is_int_rinstance, is_bool_rinstance, short_name, is_list_rinstance,
-    is_dict_rinstance, is_tuple_rinstance
+    is_dict_rinstance, is_tuple_rinstance, is_none_rinstance
 )
 
 
@@ -188,7 +188,7 @@ class Emitter:
                 err,
                 '{} = NULL;'.format(dest),
                 '}')
-        elif typ.name == 'None':
+        elif is_none_rinstance(typ):
             if declare_dest:
                 self.emit_line('PyObject *{};'.format(dest))
             self.emit_lines(

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -6,7 +6,8 @@ from typing import List, Set, Dict, Optional
 from mypyc.common import REG_PREFIX
 from mypyc.ops import (
     Environment, Label, Register, RType, ObjectRType, TupleRType, UserRType, OptionalRType,
-    RInstance, type_struct_name, is_int_rinstance, is_bool_rinstance, short_name, is_list_rinstance
+    RInstance, type_struct_name, is_int_rinstance, is_bool_rinstance, short_name, is_list_rinstance,
+    is_dict_rinstance
 )
 
 
@@ -153,12 +154,12 @@ class Emitter:
             err = 'PyErr_SetString(PyExc_TypeError, "{} object expected");'.format(
                 self.pretty_name(typ))
         # TODO: Verify refcount handling.
-        if is_list_rinstance(typ) or typ.name == 'dict':
+        if is_list_rinstance(typ) or is_dict_rinstance(typ):
             if declare_dest:
                 self.emit_line('PyObject *{};'.format(dest))
             if is_list_rinstance(typ):
                 prefix = 'PyList'
-            elif typ.name == 'dict':
+            elif is_dict_rinstance(typ):
                 prefix = 'PyDict'
             else:
                 assert False, prefix

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -85,14 +85,14 @@ class Emitter:
     # Higher-level operations
 
     def declare_tuple_struct(self, tuple_type: RTuple) -> None:
-        if tuple_type.struct_name not in self.context.declarations:
+        if tuple_type.struct_name() not in self.context.declarations:
             dependencies = set()
             for typ in tuple_type.types:
                 # XXX other types might eventually need similar behavior
                 if isinstance(typ, RTuple):
-                    dependencies.add(typ.struct_name)
+                    dependencies.add(typ.struct_name())
 
-            self.context.declarations[tuple_type.struct_name] = HeaderDeclaration(
+            self.context.declarations[tuple_type.struct_name()] = HeaderDeclaration(
                 dependencies,
                 tuple_type.get_c_declaration(),
             )

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -5,7 +5,7 @@ from typing import List, Set, Dict, Optional
 
 from mypyc.common import REG_PREFIX
 from mypyc.ops import (
-    Environment, Label, Register, RType, RTuple, UserRType, OptionalRType,
+    Environment, Label, Register, RType, RTuple, UserRType, ROptional,
     RInstance, type_struct_name, is_int_rinstance, is_bool_rinstance, short_name, is_list_rinstance,
     is_dict_rinstance, is_tuple_rinstance, is_none_rinstance, object_rinstance
 )
@@ -128,7 +128,7 @@ class Emitter:
 
     def pretty_name(self, typ: RType) -> str:
         pretty_name = typ.name
-        if isinstance(typ, OptionalRType):
+        if isinstance(typ, ROptional):
             pretty_name = '%s or None' % self.pretty_name(typ.value_type)
         return short_name(pretty_name)
 
@@ -198,7 +198,7 @@ class Emitter:
                 err,
                 '{} = NULL;'.format(dest),
                 '}')
-        elif isinstance(typ, OptionalRType):
+        elif isinstance(typ, ROptional):
             if declare_dest:
                 self.emit_line('PyObject *{};'.format(dest))
             self.emit_lines(

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -7,7 +7,7 @@ from mypyc.common import REG_PREFIX
 from mypyc.ops import (
     Environment, Label, Register, RType, ObjectRType, TupleRType, UserRType, OptionalRType,
     RInstance, type_struct_name, is_int_rinstance, is_bool_rinstance, short_name, is_list_rinstance,
-    is_dict_rinstance
+    is_dict_rinstance, is_tuple_rinstance
 )
 
 
@@ -128,9 +128,7 @@ class Emitter:
 
     def pretty_name(self, typ: RType) -> str:
         pretty_name = typ.name
-        if pretty_name == 'sequence_tuple':
-            pretty_name = 'tuple'
-        elif isinstance(typ, OptionalRType):
+        if isinstance(typ, OptionalRType):
             pretty_name = '%s or None' % self.pretty_name(typ.value_type)
         return short_name(pretty_name)
 
@@ -170,7 +168,7 @@ class Emitter:
                 err,
                 '{} = NULL;'.format(dest),
                 '}')
-        elif typ.name == 'sequence_tuple':
+        elif is_tuple_rinstance(typ):
             if declare_dest:
                 self.emit_line('{} {};'.format(typ.ctype, dest))
             self.emit_lines(

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -6,7 +6,7 @@ from typing import List, Set, Dict, Optional
 from mypyc.common import REG_PREFIX
 from mypyc.ops import (
     Environment, Label, Register, RType, ObjectRType, TupleRType, UserRType, OptionalRType,
-    RInstance, type_struct_name, is_int_rinstance, short_name
+    RInstance, type_struct_name, is_int_rinstance, is_bool_rinstance, short_name
 )
 
 
@@ -248,7 +248,7 @@ class Emitter:
             self.emit_line('else {')
             self.emit_lines(*failure)
             self.emit_line('}')
-        elif typ.name == 'bool':
+        elif is_bool_rinstance(typ):
             # Whether we are borrowing or not makes no difference.
             if declare_dest:
                 self.emit_line('char {};'.format(dest))
@@ -298,7 +298,7 @@ class Emitter:
         if is_int_rinstance(typ):
             # Steal the existing reference if it exists.
             self.emit_line('{}{} = CPyTagged_StealAsObject({});'.format(declaration, dest, src))
-        elif typ.name == 'bool':
+        elif is_bool_rinstance(typ):
             # TODO: The Py_RETURN macros return the correct PyObject * with reference count
             #       handling. Relevant here?
             self.emit_lines('{}{} = PyBool_FromLong({});'.format(declaration, dest, src))

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -236,7 +236,7 @@ class Emitter:
                        custom_failure]
         else:
             failure = [raise_exc,
-                       '%s = %s;' % (dest, typ.c_error_value)]
+                       '%s = %s;' % (dest, typ.c_error_value())]
         if is_int_rprimitive(typ):
             if declare_dest:
                 self.emit_line('CPyTagged {};'.format(dest))
@@ -324,9 +324,9 @@ class Emitter:
     def emit_error_check(self, value: str, rtype: RType, failure: str) -> None:
         """Emit code for checking a native function return value for uncaught exception."""
         if not isinstance(rtype, RTuple):
-            self.emit_line('if ({} == {}) {{'.format(value, rtype.c_error_value))
+            self.emit_line('if ({} == {}) {{'.format(value, rtype.c_error_value()))
         else:
-            self.emit_line('if ({}.f0 == {}) {{'.format(value, rtype.types[0].c_error_value))
+            self.emit_line('if ({}.f0 == {}) {{'.format(value, rtype.types[0].c_error_value()))
         self.emit_lines(failure, '}')
 
     def emit_gc_visit(self, target: str, rtype: RType) -> None:
@@ -363,13 +363,13 @@ class Emitter:
         elif isinstance(rtype, RPrimitive) and rtype.name == 'builtins.int':
             self.emit_line('if (CPyTagged_CheckLong({})) {{'.format(target))
             self.emit_line('CPyTagged __tmp = {};'.format(target))
-            self.emit_line('{} = {};'.format(target, rtype.c_undefined_value))
+            self.emit_line('{} = {};'.format(target, rtype.c_undefined_value()))
             self.emit_line('Py_XDECREF(CPyTagged_LongAsObject(__tmp));')
             self.emit_line('}')
         elif isinstance(rtype, RTuple):
             for i, item_type in enumerate(rtype.types):
                 self.emit_gc_clear('{}.f{}'.format(target, i), item_type)
-        elif rtype.ctype == 'PyObject *' and rtype.c_undefined_value == 'NULL':
+        elif rtype.ctype == 'PyObject *' and rtype.c_undefined_value() == 'NULL':
             # The simplest case.
             self.emit_line('Py_CLEAR({});'.format(target))
         else:

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -142,7 +142,7 @@ def generate_native_getters_and_setters(cl: ClassIR,
         emitter.emit_line('{')
         if rtype.is_refcounted:
             emitter.emit_lines(
-                'if (self->{} == {}) {{'.format(attr, rtype.c_undefined_value),
+                'if (self->{} == {}) {{'.format(attr, rtype.c_undefined_value()),
                 'PyErr_SetString(PyExc_AttributeError, "attribute {} of {} undefined");'.format(
                     repr(attr), repr(cl.name)),
                 '} else {')
@@ -158,7 +158,7 @@ def generate_native_getters_and_setters(cl: ClassIR,
                                                           rtype.ctype_spaced))
         emitter.emit_line('{')
         if rtype.is_refcounted:
-            emitter.emit_line('if (self->{} != {}) {{'.format(attr, rtype.c_undefined_value))
+            emitter.emit_line('if (self->{} != {}) {{'.format(attr, rtype.c_undefined_value()))
             emitter.emit_dec_ref('self->{}'.format(attr), rtype)
             emitter.emit_line('}')
         emitter.emit_inc_ref('value'.format(attr), rtype)
@@ -194,7 +194,7 @@ def generate_constructor_for_class(cl: ClassIR,
     emitter.emit_line('    return NULL;')
     emitter.emit_line('self->vtable = {};'.format(vtable_name))
     for attr, rtype in cl.attributes:
-        emitter.emit_line('self->{} = {};'.format(attr, rtype.c_undefined_value))
+        emitter.emit_line('self->{} = {};'.format(attr, rtype.c_undefined_value()))
     emitter.emit_line('return (PyObject *)self;')
     emitter.emit_line('}')
 
@@ -305,7 +305,7 @@ def generate_getter(cl: ClassIR,
     emitter.emit_line('{}({} *self, void *closure)'.format(getter_name(cl.name, attr),
                                                                         cl.struct_name))
     emitter.emit_line('{')
-    emitter.emit_line('if (self->{} == {}) {{'.format(attr, rtype.c_undefined_value))
+    emitter.emit_line('if (self->{} == {}) {{'.format(attr, rtype.c_undefined_value()))
     emitter.emit_line('PyErr_SetString(PyExc_AttributeError,')
     emitter.emit_line('    "attribute {} of {} undefined");'.format(repr(attr),
                                                                         repr(cl.name)))
@@ -327,7 +327,7 @@ def generate_setter(cl: ClassIR,
         cl.struct_name))
     emitter.emit_line('{')
     if rtype.is_refcounted:
-        emitter.emit_line('if (self->{} != {}) {{'.format(attr, rtype.c_undefined_value))
+        emitter.emit_line('if (self->{} != {}) {{'.format(attr, rtype.c_undefined_value()))
         emitter.emit_dec_ref('self->{}'.format(attr), rtype)
         emitter.emit_line('}')
     emitter.emit_line('if (value != NULL) {')
@@ -340,6 +340,6 @@ def generate_setter(cl: ClassIR,
         emitter.emit_inc_ref('tmp', rtype)
     emitter.emit_line('self->{} = tmp;'.format(attr))
     emitter.emit_line('} else')
-    emitter.emit_line('    self->{} = {};'.format(attr, rtype.c_undefined_value))
+    emitter.emit_line('    self->{} = {};'.format(attr, rtype.c_undefined_value()))
     emitter.emit_line('return 0;')
     emitter.emit_line('}')

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -5,7 +5,7 @@ import textwrap
 from mypyc.common import PREFIX, NATIVE_PREFIX
 from mypyc.emit import Emitter
 from mypyc.emitfunc import native_function_header
-from mypyc.ops import ClassIR, FuncIR, RType, Environment, type_struct_name, object_rinstance
+from mypyc.ops import ClassIR, FuncIR, RType, Environment, type_struct_name, object_rprimitive
 
 
 def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
@@ -28,7 +28,7 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
 
     # Use dummy empty __init__ for now.
     # TODO: Use UserRType
-    init = FuncIR(cl.name, None, [], object_rinstance, [], Environment())
+    init = FuncIR(cl.name, None, [], object_rprimitive, [], Environment())
     emitter.emit_line(native_function_header(init) + ';')
     emit_line()
     generate_object_struct(cl, emitter)

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -331,7 +331,7 @@ def generate_setter(cl: ClassIR,
         emitter.emit_dec_ref('self->{}'.format(attr), rtype)
         emitter.emit_line('}')
     emitter.emit_line('if (value != NULL) {')
-    if rtype.supports_unbox:
+    if rtype.is_unboxed:
         emitter.emit_unbox('value', 'tmp', rtype, custom_failure='return -1;', declare_dest=True)
     else:
         emitter.emit_cast('value', 'tmp', rtype, declare_dest=True)

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -5,7 +5,7 @@ import textwrap
 from mypyc.common import PREFIX, NATIVE_PREFIX
 from mypyc.emit import Emitter
 from mypyc.emitfunc import native_function_header
-from mypyc.ops import ClassIR, FuncIR, RType, ObjectRType, Environment, type_struct_name
+from mypyc.ops import ClassIR, FuncIR, RType, Environment, type_struct_name, object_rinstance
 
 
 def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
@@ -28,7 +28,7 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
 
     # Use dummy empty __init__ for now.
     # TODO: Use UserRType
-    init = FuncIR(cl.name, None, [], ObjectRType(), [], Environment())
+    init = FuncIR(cl.name, None, [], object_rinstance, [], Environment())
     emitter.emit_line(native_function_header(init) + ';')
     emit_line()
     generate_object_struct(cl, emitter)

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -128,7 +128,7 @@ def generate_object_struct(cl: ClassIR, emitter: Emitter) -> None:
                        'PyObject_HEAD',
                        'CPyVTableItem *vtable;')
     for attr, rtype in cl.attributes:
-        emitter.emit_line('{}{};'.format(rtype.ctype_spaced, attr))
+        emitter.emit_line('{}{};'.format(rtype.ctype_spaced(), attr))
     emitter.emit_line('}} {};'.format(cl.struct_name))
 
 
@@ -136,7 +136,7 @@ def generate_native_getters_and_setters(cl: ClassIR,
                                         emitter: Emitter) -> None:
     for attr, rtype in cl.attributes:
         # Native getter
-        emitter.emit_line('{}{}({} *self)'.format(rtype.ctype_spaced,
+        emitter.emit_line('{}{}({} *self)'.format(rtype.ctype_spaced(),
                                                native_getter_name(cl.name, attr),
                                                cl.struct_name))
         emitter.emit_line('{')
@@ -155,7 +155,7 @@ def generate_native_getters_and_setters(cl: ClassIR,
         # Native setter
         emitter.emit_line('bool {}({} *self, {}value)'.format(native_setter_name(cl.name, attr),
                                                           cl.struct_name,
-                                                          rtype.ctype_spaced))
+                                                          rtype.ctype_spaced()))
         emitter.emit_line('{')
         if rtype.is_refcounted:
             emitter.emit_line('if (self->{} != {}) {{'.format(attr, rtype.c_undefined_value()))

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -27,7 +27,7 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
         emitter.emit_line()
 
     # Use dummy empty __init__ for now.
-    # TODO: Use UserRType
+    # TODO: Use RInstance
     init = FuncIR(cl.name, None, [], object_rprimitive, [], Environment())
     emitter.emit_line(native_function_header(init) + ';')
     emit_line()

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -113,7 +113,6 @@ class FunctionEmitterVisitor(OpVisitor[None]):
 
     def visit_return(self, op: Return) -> None:
         typ = self.type(op.reg)
-        assert typ.name != 'object'
         regstr = self.reg(op.reg)
         self.emit_line('return %s;' % regstr)
 

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -90,11 +90,11 @@ class FunctionEmitterVisitor(OpVisitor[None]):
                 item_type = typ.types[0]
                 self.emit_line('if ({}.f0 {} {}) {{'.format(self.reg(op.left),
                                                          compare,
-                                                         item_type.c_error_value))
+                                                         item_type.c_error_value()))
             else:
                 self.emit_line('if ({} {} {}) {{'.format(self.reg(op.left),
                                                       compare,
-                                                      typ.c_error_value))
+                                                      typ.c_error_value()))
         else:
             left = self.reg(op.left)
             right = self.reg(op.right)
@@ -264,13 +264,13 @@ class FunctionEmitterVisitor(OpVisitor[None]):
 
     def visit_load_error_value(self, op: LoadErrorValue) -> None:
         if isinstance(op.rtype, RTuple):
-            values = [item.c_undefined_value for item in op.rtype.types]
+            values = [item.c_undefined_value() for item in op.rtype.types]
             tmp = self.temp_name()
             self.emit_line('%s %s = { %s };' % (op.rtype.ctype, tmp, ', '.join(values)))
             self.emit_line('%s = %s;' % (self.reg(op.dest), tmp))
         else:
             self.emit_line('%s = %s;' % (self.reg(op.dest),
-                                         op.rtype.c_error_value))
+                                         op.rtype.c_error_value()))
 
     def visit_get_attr(self, op: GetAttr) -> None:
         dest = self.reg(op.dest)

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -12,10 +12,10 @@ from mypyc.ops import (
 def native_function_header(fn: FuncIR) -> str:
     args = []
     for arg in fn.args:
-        args.append('{}{}{}'.format(arg.type.ctype_spaced, REG_PREFIX, arg.name))
+        args.append('{}{}{}'.format(arg.type.ctype_spaced(), REG_PREFIX, arg.name))
 
     return 'static {ret_type}{prefix}{name}({args})'.format(
-        ret_type=fn.ret_type.ctype_spaced,
+        ret_type=fn.ret_type.ctype_spaced(),
         prefix=NATIVE_PREFIX,
         name=fn.cname,
         args=', '.join(args) or 'void')

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -279,7 +279,7 @@ class FunctionEmitterVisitor(OpVisitor[None]):
         self.emit_line('%s = CPY_GET_ATTR(%s, %d, %s, %s);' % (
             dest, obj,
             rtype.getter_index(op.attr),
-            rtype.struct_name,
+            rtype.struct_name(),
             rtype.attr_type(op.attr).ctype))
 
     def visit_set_attr(self, op: SetAttr) -> None:
@@ -293,7 +293,7 @@ class FunctionEmitterVisitor(OpVisitor[None]):
             obj,
             rtype.setter_index(op.attr),
             src,
-            rtype.struct_name,
+            rtype.struct_name(),
             rtype.attr_type(op.attr).ctype))
 
     def visit_load_static(self, op: LoadStatic) -> None:

--- a/mypyc/emitwrapper.py
+++ b/mypyc/emitwrapper.py
@@ -44,7 +44,7 @@ def generate_wrapper_function(fn: FuncIR, emitter: Emitter) -> None:
         # TODO: The Py_RETURN macros return the correct PyObject * with reference count handling.
         #       Are they relevant?
         ret_type = fn.ret_type
-        emitter.emit_line('{}retval = {}{}({});'.format(ret_type.ctype_spaced,
+        emitter.emit_line('{}retval = {}{}({});'.format(ret_type.ctype_spaced(),
                                                         NATIVE_PREFIX, fn.cname,
                                                         native_args))
         emitter.emit_error_check('retval', ret_type, 'return NULL;')

--- a/mypyc/emitwrapper.py
+++ b/mypyc/emitwrapper.py
@@ -40,7 +40,7 @@ def generate_wrapper_function(fn: FuncIR, emitter: Emitter) -> None:
         generate_arg_check(arg.name, arg.type, emitter)
     native_args = ', '.join('arg_{}'.format(arg.name) for arg in fn.args)
 
-    if fn.ret_type.supports_unbox:
+    if fn.ret_type.is_unboxed:
         # TODO: The Py_RETURN macros return the correct PyObject * with reference count handling.
         #       Are they relevant?
         ret_type = fn.ret_type
@@ -63,7 +63,7 @@ def generate_arg_check(name: str, typ: RType, emitter: Emitter) -> None:
     a value of name arg_{} (unboxed if necessary). For each primitive a runtime
     check ensures the correct type.
     """
-    if typ.supports_unbox:
+    if typ.is_unboxed:
         # Borrow when unboxing to avoid reference count manipulation.
         emitter.emit_unbox('obj_{}'.format(name), 'arg_{}'.format(name), typ,
                            'return NULL;', declare_dest=True, borrow=True)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -29,7 +29,7 @@ from mypy.subtypes import is_named_instance
 
 from mypyc.ops import (
     BasicBlock, Environment, Op, LoadInt, RType, Register, Label, Return, FuncIR, Assign,
-    PrimitiveOp, Branch, Goto, RuntimeArg, Call, Box, Unbox, Cast, TupleRType,
+    PrimitiveOp, Branch, Goto, RuntimeArg, Call, Box, Unbox, Cast, RTuple,
     Unreachable, TupleGet, ClassIR, UserRType, ModuleIR, GetAttr, SetAttr, LoadStatic,
     PyGetAttr, PyCall, RInstance, OptionalRType, c_module_name, PyMethodCall, INVALID_REGISTER,
     INVALID_LABEL, int_rinstance, is_int_rinstance, bool_rinstance, list_rinstance,
@@ -74,7 +74,7 @@ class Mapper:
             elif typ.type in self.type_to_ir:
                 return UserRType(self.type_to_ir[typ.type])
         elif isinstance(typ, TupleType):
-            return TupleRType([self.type_to_rtype(t) for t in typ.items])
+            return RTuple([self.type_to_rtype(t) for t in typ.items])
         elif isinstance(typ, CallableType):
             return object_rinstance
         elif isinstance(typ, NoneTyp):
@@ -653,7 +653,7 @@ class IRBuilder(NodeVisitor[Register]):
             self.add(PrimitiveOp(tmp, op, [base_reg, index_reg], expr.line))
             target = self.alloc_target(target_type)
             return self.unbox_or_cast(tmp, target_type, expr.line, target)
-        elif isinstance(base_rtype, TupleRType):
+        elif isinstance(base_rtype, RTuple):
             assert isinstance(expr.index, IntExpr)  # TODO
             target = self.alloc_target(target_type)
             self.add(TupleGet(target, base_reg, expr.index.value,
@@ -808,7 +808,7 @@ class IRBuilder(NodeVisitor[Register]):
                 self.add(PrimitiveOp(target, PrimitiveOp.LIST_LEN, [arg], expr.line))
             elif is_tuple_rinstance(expr_rtype):
                 self.add(PrimitiveOp(target, PrimitiveOp.HOMOGENOUS_TUPLE_LEN, [arg], expr.line))
-            elif isinstance(expr_rtype, TupleRType):
+            elif isinstance(expr_rtype, RTuple):
                 self.add(LoadInt(target, len(expr_rtype.types)))
             else:
                 assert False, "unsupported use of len"

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -32,9 +32,9 @@ from mypyc.ops import (
     PrimitiveOp, Branch, Goto, RuntimeArg, Call, Box, Unbox, Cast, TupleRType,
     Unreachable, TupleGet, ClassIR, UserRType, ModuleIR, GetAttr, SetAttr, LoadStatic,
     PyGetAttr, PyCall, RInstance, SequenceTupleRType, ObjectRType, NoneRType,
-    OptionalRType, UnicodeRType, c_module_name, PyMethodCall,
+    OptionalRType, c_module_name, PyMethodCall,
     INVALID_REGISTER, INVALID_LABEL, int_rinstance, is_int_rinstance, bool_rinstance,
-    list_rinstance, is_list_rinstance, dict_rinstance, is_dict_rinstance
+    list_rinstance, is_list_rinstance, dict_rinstance, is_dict_rinstance, str_rinstance
 )
 from mypyc.subtype import is_subtype
 from mypyc.sametype import is_same_type
@@ -60,7 +60,7 @@ class Mapper:
             if typ.type.fullname() == 'builtins.int':
                 return int_rinstance
             elif typ.type.fullname() == 'builtins.str':
-                return UnicodeRType()
+                return str_rinstance
             elif typ.type.fullname() == 'builtins.bool':
                 return bool_rinstance
             elif typ.type.fullname() == 'builtins.list':
@@ -1100,7 +1100,7 @@ class IRBuilder(NodeVisitor[Register]):
         if value not in self.unicode_literals:
             self.unicode_literals[value] = '__unicode_' + str(len(self.unicode_literals))
         static_symbol = self.unicode_literals[value]
-        target = self.alloc_target(UnicodeRType())
+        target = self.alloc_target(str_rinstance)
         self.add(LoadStatic(target, static_symbol))
         return target
 

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -31,7 +31,7 @@ from mypyc.ops import (
     BasicBlock, Environment, Op, LoadInt, RType, Register, Label, Return, FuncIR, Assign,
     PrimitiveOp, Branch, Goto, RuntimeArg, Call, Box, Unbox, Cast, RTuple,
     Unreachable, TupleGet, ClassIR, UserRType, ModuleIR, GetAttr, SetAttr, LoadStatic,
-    PyGetAttr, PyCall, RInstance, OptionalRType, c_module_name, PyMethodCall, INVALID_REGISTER,
+    PyGetAttr, PyCall, RInstance, ROptional, c_module_name, PyMethodCall, INVALID_REGISTER,
     INVALID_LABEL, int_rinstance, is_int_rinstance, bool_rinstance, list_rinstance,
     is_list_rinstance, dict_rinstance, is_dict_rinstance, str_rinstance, is_tuple_rinstance,
     tuple_rinstance, none_rinstance, is_none_rinstance, object_rinstance
@@ -85,7 +85,7 @@ class Mapper:
                 value_type = typ.items[1]
             else:
                 value_type = typ.items[0]
-            return OptionalRType(self.type_to_rtype(value_type))
+            return ROptional(self.type_to_rtype(value_type))
         assert False, '%s unsupported' % type(typ)
 
 

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -255,8 +255,8 @@ class RTuple(RType):
         return result
 
 
-class UserRType(RType):
-    """Instance of user-defined class."""
+class RInstance(RType):
+    """Instance of user-defined class (compiled to C extension class)."""
 
     def __init__(self, class_ir: 'ClassIR') -> None:
         self.name = class_ir.name
@@ -264,7 +264,7 @@ class UserRType(RType):
         self.ctype = 'PyObject *'
 
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
-        return visitor.visit_user_rtype(self)
+        return visitor.visit_rinstance(self)
 
     @property
     def supports_unbox(self) -> bool:
@@ -294,7 +294,7 @@ class UserRType(RType):
         assert False, '%r has no attribute %r' % (self.name, name)
 
     def __repr__(self) -> str:
-        return '<UserRType %s>' % self.name
+        return '<RInstance %s>' % self.name
 
 
 class ROptional(RType):
@@ -981,7 +981,7 @@ class GetAttr(StrictRegisterOp):
 
     error_kind = ERR_MAGIC
 
-    def __init__(self, dest: Register, obj: Register, attr: str, rtype: UserRType,
+    def __init__(self, dest: Register, obj: Register, attr: str, rtype: RInstance,
                  line: int) -> None:
         super().__init__(dest, line)
         self.obj = obj
@@ -1003,7 +1003,7 @@ class SetAttr(StrictRegisterOp):
 
     error_kind = ERR_FALSE
 
-    def __init__(self, dest: Register, obj: Register, attr: str, src: Register, rtype: UserRType,
+    def __init__(self, dest: Register, obj: Register, attr: str, src: Register, rtype: RInstance,
                  line: int) -> None:
         super().__init__(dest, line)
         self.obj = obj
@@ -1336,7 +1336,7 @@ class RTypeVisitor(Generic[T]):
         raise NotImplementedError
 
     @abstractmethod
-    def visit_user_rtype(self, typ: UserRType) -> T:
+    def visit_rinstance(self, typ: RInstance) -> T:
         raise NotImplementedError
 
     @abstractmethod

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -138,33 +138,15 @@ class RInstance(RType):
 
 
 int_rinstance = RInstance('builtins.int', is_unboxed=True, is_refcounted=True, ctype='CPyTagged')
+bool_rinstance = RInstance('builtins.bool', is_unboxed=True, is_refcounted=False, ctype='char')
 
 
-def is_int_rinstance(t: RType) -> bool:
-    return isinstance(t, RInstance) and t.name == 'builtins.int'
+def is_int_rinstance(rtype: RType) -> bool:
+    return isinstance(rtype, RInstance) and rtype.name == 'builtins.int'
 
 
-class BoolRType(RType):
-    """bool"""
-
-    def __init__(self) -> None:
-        self.name = 'bool'
-        self.ctype = 'char'
-
-    def accept(self, visitor: 'RTypeVisitor[T]') -> T:
-        return visitor.visit_bool_rtype(self)
-
-    @property
-    def supports_unbox(self) -> bool:
-        return True
-
-    @property
-    def c_undefined_value(self) -> str:
-        return '2'
-
-    @property
-    def is_refcounted(self) -> bool:
-        return False
+def is_bool_rinstance(rtype: RType) -> bool:
+    return isinstance(rtype, RInstance) and rtype.name == 'builtins.bool'
 
 
 class TupleRType(RType):
@@ -663,7 +645,7 @@ class IncRef(StrictRegisterOp):
 
     def to_str(self, env: Environment) -> str:
         s = env.format('inc_ref %r', self.dest)
-        if self.target_type.name == 'bool' or is_int_rinstance(self.target_type):
+        if is_bool_rinstance(self.target_type) or is_int_rinstance(self.target_type):
             s += ' :: {}'.format(short_name(self.target_type.name))
         return s
 
@@ -689,7 +671,7 @@ class DecRef(StrictRegisterOp):
 
     def to_str(self, env: Environment) -> str:
         s = env.format('dec_ref %r', self.dest)
-        if self.target_type.name == 'bool' or is_int_rinstance(self.target_type):
+        if is_bool_rinstance(self.target_type) or is_int_rinstance(self.target_type):
             s += ' :: {}'.format(short_name(self.target_type.name))
         return s
 
@@ -1372,9 +1354,6 @@ class RTypeVisitor(Generic[T]):
         pass
 
     def visit_optional_rtype(self, typ: OptionalRType) -> T:
-        pass
-
-    def visit_bool_rtype(self, typ: BoolRType) -> T:
         pass
 
     def visit_tuple_rtype(self, typ: TupleRType) -> T:

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -64,7 +64,6 @@ class RType:
     def c_undefined_value(self) -> str:
         raise NotImplementedError
 
-    @property
     def ctype_spaced(self) -> str:
         """Adds a space after ctype for non-pointers."""
         if self.ctype[-1] == '*':
@@ -242,7 +241,7 @@ class RTuple(RType):
         result = ['struct {} {{'.format(self.struct_name)]
         i = 0
         for typ in self.types:
-            result.append('    {}f{};'.format(typ.ctype_spaced, i))
+            result.append('    {}f{};'.format(typ.ctype_spaced(), i))
             i += 1
         result.append('};')
         result.append('')

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -138,9 +138,15 @@ class RInstance(RType):
 
 
 int_rinstance = RInstance('builtins.int', is_unboxed=True, is_refcounted=True, ctype='CPyTagged')
+
 bool_rinstance = RInstance('builtins.bool', is_unboxed=True, is_refcounted=False, ctype='char')
+
 list_rinstance = RInstance('builtins.list', is_unboxed=False, is_refcounted=True)
+
 dict_rinstance = RInstance('builtins.dict', is_unboxed=False, is_refcounted=True)
+
+# At the C layer, str is refered to as unicode (PyUnicode)
+str_rinstance = RInstance('builtins.str', is_unboxed=False, is_refcounted=True)
 
 
 def is_int_rinstance(rtype: RType) -> bool:
@@ -157,6 +163,10 @@ def is_list_rinstance(rtype: RType) -> bool:
 
 def is_dict_rinstance(rtype: RType) -> bool:
     return isinstance(rtype, RInstance) and rtype.name == 'builtins.dict'
+
+
+def is_str_rinstance(rtype: RType) -> bool:
+    return isinstance(rtype, RInstance) and rtype.name == 'builtins.str'
 
 
 class TupleRType(RType):
@@ -266,18 +276,6 @@ class NoneRType(PyObjectRType):
 
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
         return visitor.visit_none_rtype(self)
-
-
-class UnicodeRType(PyObjectRType):
-    """str in python 3; but at the c layer, its refered to as unicode (PyUnicode)
-
-    Referring to these as Unicode and as Bytes leaves zero room for confusion.
-    """
-    def __init__(self) -> None:
-        self.name = 'unicode'
-
-    def accept(self, visitor: 'RTypeVisitor[T]') -> T:
-        return visitor.visit_unicode_rtype(self)
 
 
 class UserRType(PyObjectRType):
@@ -1357,7 +1355,4 @@ class RTypeVisitor(Generic[T]):
         pass
 
     def visit_none_rtype(self, typ: NoneRType) -> T:
-        pass
-
-    def visit_unicode_rtype(self, typ: UnicodeRType) -> T:
         pass

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -100,6 +100,11 @@ class RType:
 
 
 class RPrimitive(RType):
+    """Primitive type such as 'object' or 'int'.
+
+    These often have custom ops associated with them.
+    """
+
     def __init__(self,
                  name: str,
                  is_unboxed: bool,
@@ -137,11 +142,12 @@ class RPrimitive(RType):
         return '<RPrimitive %s>'% self.name
 
 
+# Used to represent arbitrary objects and dynamically typed values
+object_rprimitive = RPrimitive('builtins.object', is_unboxed=False, is_refcounted=True)
+
 int_rprimitive = RPrimitive('builtins.int', is_unboxed=True, is_refcounted=True, ctype='CPyTagged')
 
 bool_rprimitive = RPrimitive('builtins.bool', is_unboxed=True, is_refcounted=False, ctype='char')
-
-object_rprimitive = RPrimitive('builtins.object', is_unboxed=False, is_refcounted=True)
 
 none_rprimitive = RPrimitive('builtins.None', is_unboxed=False, is_refcounted=True)
 

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -148,6 +148,9 @@ dict_rinstance = RInstance('builtins.dict', is_unboxed=False, is_refcounted=True
 # At the C layer, str is refered to as unicode (PyUnicode)
 str_rinstance = RInstance('builtins.str', is_unboxed=False, is_refcounted=True)
 
+# Tuple of an arbitrary length (corresponds to Tuple[t, ...], with explicit '...')
+tuple_rinstance = RInstance('builtins.tuple', is_unboxed=False, is_refcounted=True)
+
 
 def is_int_rinstance(rtype: RType) -> bool:
     return isinstance(rtype, RInstance) and rtype.name == 'builtins.int'
@@ -167,6 +170,10 @@ def is_dict_rinstance(rtype: RType) -> bool:
 
 def is_str_rinstance(rtype: RType) -> bool:
     return isinstance(rtype, RInstance) and rtype.name == 'builtins.str'
+
+
+def is_tuple_rinstance(rtype: RType) -> bool:
+    return isinstance(rtype, RInstance) and rtype.name == 'builtins.tuple'
 
 
 class TupleRType(RType):
@@ -258,16 +265,6 @@ class ObjectRType(PyObjectRType):
 
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
         return visitor.visit_object_rtype(self)
-
-
-class SequenceTupleRType(PyObjectRType):
-    """Uniform tuple"""
-
-    def __init__(self) -> None:
-        self.name = 'sequence_tuple'
-
-    def accept(self, visitor: 'RTypeVisitor[T]') -> T:
-        return visitor.visit_sequence_tuple_rtype(self)
 
 
 class NoneRType(PyObjectRType):
@@ -1349,9 +1346,6 @@ class RTypeVisitor(Generic[T]):
         pass
 
     def visit_tuple_rtype(self, typ: TupleRType) -> T:
-        pass
-
-    def visit_sequence_tuple_rtype(self, typ: SequenceTupleRType) -> T:
         pass
 
     def visit_none_rtype(self, typ: NoneRType) -> T:

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -141,6 +141,8 @@ int_rinstance = RInstance('builtins.int', is_unboxed=True, is_refcounted=True, c
 
 bool_rinstance = RInstance('builtins.bool', is_unboxed=True, is_refcounted=False, ctype='char')
 
+none_rinstance = RInstance('builtins.None', is_unboxed=False, is_refcounted=True)
+
 list_rinstance = RInstance('builtins.list', is_unboxed=False, is_refcounted=True)
 
 dict_rinstance = RInstance('builtins.dict', is_unboxed=False, is_refcounted=True)
@@ -158,6 +160,10 @@ def is_int_rinstance(rtype: RType) -> bool:
 
 def is_bool_rinstance(rtype: RType) -> bool:
     return isinstance(rtype, RInstance) and rtype.name == 'builtins.bool'
+
+
+def is_none_rinstance(rtype: RType) -> bool:
+    return isinstance(rtype, RInstance) and rtype.name == 'builtins.None'
 
 
 def is_list_rinstance(rtype: RType) -> bool:
@@ -265,14 +271,6 @@ class ObjectRType(PyObjectRType):
 
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
         return visitor.visit_object_rtype(self)
-
-
-class NoneRType(PyObjectRType):
-    def __init__(self) -> None:
-        self.name = 'None'
-
-    def accept(self, visitor: 'RTypeVisitor[T]') -> T:
-        return visitor.visit_none_rtype(self)
 
 
 class UserRType(PyObjectRType):
@@ -1346,7 +1344,4 @@ class RTypeVisitor(Generic[T]):
         pass
 
     def visit_tuple_rtype(self, typ: TupleRType) -> T:
-        pass
-
-    def visit_none_rtype(self, typ: NoneRType) -> T:
         pass

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -99,7 +99,7 @@ class RType:
         return hash(self.name)
 
 
-class RInstance(RType):
+class RPrimitive(RType):
     def __init__(self,
                  name: str,
                  is_unboxed: bool,
@@ -131,61 +131,61 @@ class RInstance(RType):
         return self._is_refcounted
 
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
-        return visitor.visit_rinstance(self)
+        return visitor.visit_rprimitive(self)
 
     def __repr__(self) -> str:
-        return '<RInstance %s>'% self.name
+        return '<RPrimitive %s>'% self.name
 
 
-int_rinstance = RInstance('builtins.int', is_unboxed=True, is_refcounted=True, ctype='CPyTagged')
+int_rprimitive = RPrimitive('builtins.int', is_unboxed=True, is_refcounted=True, ctype='CPyTagged')
 
-bool_rinstance = RInstance('builtins.bool', is_unboxed=True, is_refcounted=False, ctype='char')
+bool_rprimitive = RPrimitive('builtins.bool', is_unboxed=True, is_refcounted=False, ctype='char')
 
-object_rinstance = RInstance('builtins.object', is_unboxed=False, is_refcounted=True)
+object_rprimitive = RPrimitive('builtins.object', is_unboxed=False, is_refcounted=True)
 
-none_rinstance = RInstance('builtins.None', is_unboxed=False, is_refcounted=True)
+none_rprimitive = RPrimitive('builtins.None', is_unboxed=False, is_refcounted=True)
 
-list_rinstance = RInstance('builtins.list', is_unboxed=False, is_refcounted=True)
+list_rprimitive = RPrimitive('builtins.list', is_unboxed=False, is_refcounted=True)
 
-dict_rinstance = RInstance('builtins.dict', is_unboxed=False, is_refcounted=True)
+dict_rprimitive = RPrimitive('builtins.dict', is_unboxed=False, is_refcounted=True)
 
 # At the C layer, str is refered to as unicode (PyUnicode)
-str_rinstance = RInstance('builtins.str', is_unboxed=False, is_refcounted=True)
+str_rprimitive = RPrimitive('builtins.str', is_unboxed=False, is_refcounted=True)
 
 # Tuple of an arbitrary length (corresponds to Tuple[t, ...], with explicit '...')
-tuple_rinstance = RInstance('builtins.tuple', is_unboxed=False, is_refcounted=True)
+tuple_rprimitive = RPrimitive('builtins.tuple', is_unboxed=False, is_refcounted=True)
 
 
-def is_int_rinstance(rtype: RType) -> bool:
-    return isinstance(rtype, RInstance) and rtype.name == 'builtins.int'
+def is_int_rprimitive(rtype: RType) -> bool:
+    return isinstance(rtype, RPrimitive) and rtype.name == 'builtins.int'
 
 
-def is_bool_rinstance(rtype: RType) -> bool:
-    return isinstance(rtype, RInstance) and rtype.name == 'builtins.bool'
+def is_bool_rprimitive(rtype: RType) -> bool:
+    return isinstance(rtype, RPrimitive) and rtype.name == 'builtins.bool'
 
 
-def is_object_rinstance(rtype: RType) -> bool:
-    return isinstance(rtype, RInstance) and rtype.name == 'builtins.object'
+def is_object_rprimitive(rtype: RType) -> bool:
+    return isinstance(rtype, RPrimitive) and rtype.name == 'builtins.object'
 
 
-def is_none_rinstance(rtype: RType) -> bool:
-    return isinstance(rtype, RInstance) and rtype.name == 'builtins.None'
+def is_none_rprimitive(rtype: RType) -> bool:
+    return isinstance(rtype, RPrimitive) and rtype.name == 'builtins.None'
 
 
-def is_list_rinstance(rtype: RType) -> bool:
-    return isinstance(rtype, RInstance) and rtype.name == 'builtins.list'
+def is_list_rprimitive(rtype: RType) -> bool:
+    return isinstance(rtype, RPrimitive) and rtype.name == 'builtins.list'
 
 
-def is_dict_rinstance(rtype: RType) -> bool:
-    return isinstance(rtype, RInstance) and rtype.name == 'builtins.dict'
+def is_dict_rprimitive(rtype: RType) -> bool:
+    return isinstance(rtype, RPrimitive) and rtype.name == 'builtins.dict'
 
 
-def is_str_rinstance(rtype: RType) -> bool:
-    return isinstance(rtype, RInstance) and rtype.name == 'builtins.str'
+def is_str_rprimitive(rtype: RType) -> bool:
+    return isinstance(rtype, RPrimitive) and rtype.name == 'builtins.str'
 
 
-def is_tuple_rinstance(rtype: RType) -> bool:
-    return isinstance(rtype, RInstance) and rtype.name == 'builtins.tuple'
+def is_tuple_rprimitive(rtype: RType) -> bool:
+    return isinstance(rtype, RPrimitive) and rtype.name == 'builtins.tuple'
 
 
 class RTuple(RType):
@@ -632,7 +632,7 @@ class IncRef(StrictRegisterOp):
 
     def to_str(self, env: Environment) -> str:
         s = env.format('inc_ref %r', self.dest)
-        if is_bool_rinstance(self.target_type) or is_int_rinstance(self.target_type):
+        if is_bool_rprimitive(self.target_type) or is_int_rprimitive(self.target_type):
             s += ' :: {}'.format(short_name(self.target_type.name))
         return s
 
@@ -658,7 +658,7 @@ class DecRef(StrictRegisterOp):
 
     def to_str(self, env: Environment) -> str:
         s = env.format('dec_ref %r', self.dest)
-        if is_bool_rinstance(self.target_type) or is_int_rinstance(self.target_type):
+        if is_bool_rprimitive(self.target_type) or is_int_rprimitive(self.target_type):
             s += ' :: {}'.format(short_name(self.target_type.name))
         return s
 
@@ -1332,7 +1332,7 @@ def format_func(fn: FuncIR) -> List[str]:
 
 class RTypeVisitor(Generic[T]):
     @abstractmethod
-    def visit_rinstance(self, typ: RInstance) -> T:
+    def visit_rprimitive(self, typ: RPrimitive) -> T:
         raise NotImplementedError
 
     @abstractmethod

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -54,9 +54,14 @@ class RType:
     name = None  # type: str
     ctype = None  # type: str
     is_unboxed = False
+    c_undefined = None  # type: str
 
     @abstractmethod
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
+        raise NotImplementedError
+
+    @abstractmethod
+    def c_undefined_value(self) -> str:
         raise NotImplementedError
 
     @property
@@ -67,13 +72,8 @@ class RType:
         else:
             return self.ctype + ' '
 
-    @property
-    def c_undefined_value(self) -> str:
-        raise NotImplementedError
-
-    @property
     def c_error_value(self) -> str:
-        return self.c_undefined_value
+        return self.c_undefined_value()
 
     @property
     def is_refcounted(self) -> bool:
@@ -120,7 +120,6 @@ class RPrimitive(RType):
         else:
             assert False, 'Uncognized ctype: %r' % ctype
 
-    @property
     def c_undefined_value(self) -> str:
         return self.c_undefined
 
@@ -200,7 +199,6 @@ class RTuple(RType):
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
         return visitor.visit_rtuple(self)
 
-    @property
     def c_undefined_value(self) -> str:
         # This doesn't work since this is expected to return a C expression, but
         # defining an undefined tuple requires declaring a temp variable, such as:
@@ -265,7 +263,6 @@ class RInstance(RType):
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
         return visitor.visit_rinstance(self)
 
-    @property
     def c_undefined_value(self) -> str:
         return 'NULL'
 
@@ -305,7 +302,6 @@ class ROptional(RType):
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
         return visitor.visit_roptional(self)
 
-    @property
     def c_undefined_value(self) -> str:
         return 'NULL'
 

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -297,7 +297,7 @@ class UserRType(RType):
         return '<UserRType %s>' % self.name
 
 
-class OptionalRType(RType):
+class ROptional(RType):
     """Optional[x]"""
 
     def __init__(self, value_type: RType) -> None:
@@ -306,7 +306,7 @@ class OptionalRType(RType):
         self.ctype = 'PyObject *'
 
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
-        return visitor.visit_optional_rtype(self)
+        return visitor.visit_roptional(self)
 
     @property
     def supports_unbox(self) -> bool:
@@ -317,13 +317,13 @@ class OptionalRType(RType):
         return 'NULL'
 
     def __repr__(self) -> str:
-        return '<OptionalRType %s>' % self.value_type
+        return '<ROptional %s>' % self.value_type
 
     def __str__(self) -> str:
         return 'optional[%s]' % self.value_type
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, OptionalRType) and other.value_type == self.value_type
+        return isinstance(other, ROptional) and other.value_type == self.value_type
 
     def __hash__(self) -> int:
         return hash(('optional', self.value_type))
@@ -1340,7 +1340,7 @@ class RTypeVisitor(Generic[T]):
         raise NotImplementedError
 
     @abstractmethod
-    def visit_optional_rtype(self, typ: OptionalRType) -> T:
+    def visit_roptional(self, typ: ROptional) -> T:
         raise NotImplementedError
 
     @abstractmethod

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -185,7 +185,7 @@ class RTuple(RType):
     def __init__(self, types: List[RType]) -> None:
         self.name = 'tuple'
         self.types = tuple(types)
-        self.ctype = 'struct {}'.format(self.struct_name)
+        self.ctype = 'struct {}'.format(self.struct_name())
         self.is_refcounted = any(t.is_refcounted for t in self.types)
 
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
@@ -209,7 +209,6 @@ class RTuple(RType):
         """
         return str(abs(hash(self)))[0:15]
 
-    @property
     def struct_name(self) -> str:
         # max c length is 31 charas, this should be enough entropy to be unique.
         return 'tuple_def_' + self.unique_id
@@ -227,7 +226,7 @@ class RTuple(RType):
         return hash((self.name, self.types))
 
     def get_c_declaration(self) -> List[str]:
-        result = ['struct {} {{'.format(self.struct_name)]
+        result = ['struct {} {{'.format(self.struct_name())]
         i = 0
         for typ in self.types:
             result.append('    {}f{};'.format(typ.ctype_spaced(), i))
@@ -254,9 +253,8 @@ class RInstance(RType):
     def c_undefined_value(self) -> str:
         return 'NULL'
 
-    @property
     def struct_name(self) -> str:
-        return self.class_ir.struct_name
+        return self.class_ir.struct_name()
 
     def getter_index(self, name: str) -> int:
         for i, (attr, _) in enumerate(self.class_ir.attributes):
@@ -1180,7 +1178,6 @@ class ClassIR:
         self.attributes = attributes
         self.methods = []  # type: List[FuncIR]
 
-    @property
     def struct_name(self) -> str:
         return '{}Object'.format(self.name)
 

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -140,6 +140,7 @@ class RInstance(RType):
 int_rinstance = RInstance('builtins.int', is_unboxed=True, is_refcounted=True, ctype='CPyTagged')
 bool_rinstance = RInstance('builtins.bool', is_unboxed=True, is_refcounted=False, ctype='char')
 list_rinstance = RInstance('builtins.list', is_unboxed=False, is_refcounted=True)
+dict_rinstance = RInstance('builtins.dict', is_unboxed=False, is_refcounted=True)
 
 
 def is_int_rinstance(rtype: RType) -> bool:
@@ -152,6 +153,10 @@ def is_bool_rinstance(rtype: RType) -> bool:
 
 def is_list_rinstance(rtype: RType) -> bool:
     return isinstance(rtype, RInstance) and rtype.name == 'builtins.list'
+
+
+def is_dict_rinstance(rtype: RType) -> bool:
+    return isinstance(rtype, RInstance) and rtype.name == 'builtins.dict'
 
 
 class TupleRType(RType):
@@ -261,14 +266,6 @@ class NoneRType(PyObjectRType):
 
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
         return visitor.visit_none_rtype(self)
-
-
-class DictRType(PyObjectRType):
-    def __init__(self) -> None:
-        self.name = 'dict'
-
-    def accept(self, visitor: 'RTypeVisitor[T]') -> T:
-        return visitor.visit_dict_rtype(self)
 
 
 class UnicodeRType(PyObjectRType):
@@ -1360,9 +1357,6 @@ class RTypeVisitor(Generic[T]):
         pass
 
     def visit_none_rtype(self, typ: NoneRType) -> T:
-        pass
-
-    def visit_dict_rtype(self, typ: DictRType) -> T:
         pass
 
     def visit_unicode_rtype(self, typ: UnicodeRType) -> T:

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -53,13 +53,10 @@ class RType:
 
     name = None  # type: str
     ctype = None  # type: str
+    is_unboxed = False
 
     @abstractmethod
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
-        raise NotImplementedError
-
-    @property
-    def supports_unbox(self) -> bool:
         raise NotImplementedError
 
     @property
@@ -122,10 +119,6 @@ class RPrimitive(RType):
             self.c_undefined = '2'
         else:
             assert False, 'Uncognized ctype: %r' % ctype
-
-    @property
-    def supports_unbox(self) -> bool:
-        return self.is_unboxed
 
     @property
     def c_undefined_value(self) -> str:
@@ -197,6 +190,8 @@ def is_tuple_rprimitive(rtype: RType) -> bool:
 class RTuple(RType):
     """Fixed-length tuple."""
 
+    is_unboxed = True
+
     def __init__(self, types: List[RType]) -> None:
         self.name = 'tuple'
         self.types = tuple(types)
@@ -204,10 +199,6 @@ class RTuple(RType):
 
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
         return visitor.visit_rtuple(self)
-
-    @property
-    def supports_unbox(self) -> bool:
-        return True
 
     @property
     def c_undefined_value(self) -> str:
@@ -264,6 +255,8 @@ class RTuple(RType):
 class RInstance(RType):
     """Instance of user-defined class (compiled to C extension class)."""
 
+    is_unboxed = False
+
     def __init__(self, class_ir: 'ClassIR') -> None:
         self.name = class_ir.name
         self.class_ir = class_ir
@@ -271,10 +264,6 @@ class RInstance(RType):
 
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
         return visitor.visit_rinstance(self)
-
-    @property
-    def supports_unbox(self) -> bool:
-        return False
 
     @property
     def c_undefined_value(self) -> str:
@@ -306,6 +295,8 @@ class RInstance(RType):
 class ROptional(RType):
     """Optional[x]"""
 
+    is_unboxed = False
+
     def __init__(self, value_type: RType) -> None:
         self.name = 'optional'
         self.value_type = value_type
@@ -313,10 +304,6 @@ class ROptional(RType):
 
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
         return visitor.visit_roptional(self)
-
-    @property
-    def supports_unbox(self) -> bool:
-        return False
 
     @property
     def c_undefined_value(self) -> str:

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -141,6 +141,8 @@ int_rinstance = RInstance('builtins.int', is_unboxed=True, is_refcounted=True, c
 
 bool_rinstance = RInstance('builtins.bool', is_unboxed=True, is_refcounted=False, ctype='char')
 
+object_rinstance = RInstance('builtins.object', is_unboxed=False, is_refcounted=True)
+
 none_rinstance = RInstance('builtins.None', is_unboxed=False, is_refcounted=True)
 
 list_rinstance = RInstance('builtins.list', is_unboxed=False, is_refcounted=True)
@@ -160,6 +162,10 @@ def is_int_rinstance(rtype: RType) -> bool:
 
 def is_bool_rinstance(rtype: RType) -> bool:
     return isinstance(rtype, RInstance) and rtype.name == 'builtins.bool'
+
+
+def is_object_rinstance(rtype: RType) -> bool:
+    return isinstance(rtype, RInstance) and rtype.name == 'builtins.object'
 
 
 def is_none_rinstance(rtype: RType) -> bool:
@@ -261,16 +267,6 @@ class PyObjectRType(RType):
     @property
     def c_undefined_value(self) -> str:
         return 'NULL'
-
-
-class ObjectRType(PyObjectRType):
-    """Arbitrary object (PyObject *)"""
-
-    def __init__(self) -> None:
-        self.name = 'object'
-
-    def accept(self, visitor: 'RTypeVisitor[T]') -> T:
-        return visitor.visit_object_rtype(self)
 
 
 class UserRType(PyObjectRType):
@@ -1331,9 +1327,6 @@ def format_func(fn: FuncIR) -> List[str]:
 
 
 class RTypeVisitor(Generic[T]):
-    def visit_object_rtype(self, typ: ObjectRType) -> T:
-        pass
-
     def visit_rinstance(self, typ: RInstance) -> T:
         pass
 

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -139,6 +139,7 @@ class RInstance(RType):
 
 int_rinstance = RInstance('builtins.int', is_unboxed=True, is_refcounted=True, ctype='CPyTagged')
 bool_rinstance = RInstance('builtins.bool', is_unboxed=True, is_refcounted=False, ctype='char')
+list_rinstance = RInstance('builtins.list', is_unboxed=False, is_refcounted=True)
 
 
 def is_int_rinstance(rtype: RType) -> bool:
@@ -147,6 +148,10 @@ def is_int_rinstance(rtype: RType) -> bool:
 
 def is_bool_rinstance(rtype: RType) -> bool:
     return isinstance(rtype, RInstance) and rtype.name == 'builtins.bool'
+
+
+def is_list_rinstance(rtype: RType) -> bool:
+    return isinstance(rtype, RInstance) and rtype.name == 'builtins.list'
 
 
 class TupleRType(RType):
@@ -256,14 +261,6 @@ class NoneRType(PyObjectRType):
 
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
         return visitor.visit_none_rtype(self)
-
-
-class ListRType(PyObjectRType):
-    def __init__(self) -> None:
-        self.name = 'list'
-
-    def accept(self, visitor: 'RTypeVisitor[T]') -> T:
-        return visitor.visit_list_rtype(self)
 
 
 class DictRType(PyObjectRType):
@@ -1094,7 +1091,7 @@ class Cast(StrictRegisterOp):
         return [self.src]
 
     def to_str(self, env: Environment) -> str:
-        return env.format('%r = cast(%s, %r)', self.dest, self.typ.name, self.src)
+        return env.format('%r = cast(%s, %r)', self.dest, self.typ, self.src)
 
     def accept(self, visitor: 'OpVisitor[T]') -> T:
         return visitor.visit_cast(self)
@@ -1363,9 +1360,6 @@ class RTypeVisitor(Generic[T]):
         pass
 
     def visit_none_rtype(self, typ: NoneRType) -> T:
-        pass
-
-    def visit_list_rtype(self, typ: ListRType) -> T:
         pass
 
     def visit_dict_rtype(self, typ: DictRType) -> T:

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -188,7 +188,7 @@ def is_tuple_rinstance(rtype: RType) -> bool:
     return isinstance(rtype, RInstance) and rtype.name == 'builtins.tuple'
 
 
-class TupleRType(RType):
+class RTuple(RType):
     """Fixed-length tuple."""
 
     def __init__(self, types: List[RType]) -> None:
@@ -197,7 +197,7 @@ class TupleRType(RType):
         self.ctype = 'struct {}'.format(self.struct_name)
 
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
-        return visitor.visit_tuple_rtype(self)
+        return visitor.visit_rtuple(self)
 
     @property
     def supports_unbox(self) -> bool:
@@ -235,10 +235,10 @@ class TupleRType(RType):
         return 'tuple[%s]' % ', '.join(str(typ) for typ in self.types)
 
     def __repr__(self) -> str:
-        return '<TupleRType %s>' % ', '.join(repr(typ) for typ in self.types)
+        return '<RTuple %s>' % ', '.join(repr(typ) for typ in self.types)
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, TupleRType) and self.types == other.types
+        return isinstance(other, RTuple) and self.types == other.types
 
     def __hash__(self) -> int:
         return hash((self.name, self.types))
@@ -1331,14 +1331,18 @@ def format_func(fn: FuncIR) -> List[str]:
 
 
 class RTypeVisitor(Generic[T]):
+    @abstractmethod
     def visit_rinstance(self, typ: RInstance) -> T:
-        pass
+        raise NotImplementedError
 
+    @abstractmethod
     def visit_user_rtype(self, typ: UserRType) -> T:
-        pass
+        raise NotImplementedError
 
+    @abstractmethod
     def visit_optional_rtype(self, typ: OptionalRType) -> T:
-        pass
+        raise NotImplementedError
 
-    def visit_tuple_rtype(self, typ: TupleRType) -> T:
-        pass
+    @abstractmethod
+    def visit_rtuple(self, typ: RTuple) -> T:
+        raise NotImplementedError

--- a/mypyc/sametype.py
+++ b/mypyc/sametype.py
@@ -1,7 +1,7 @@
 """Same type check for RTypes."""
 
 from mypyc.ops import (
-    RType, RTypeVisitor, UserRType, OptionalRType, RInstance, RTuple
+    RType, RTypeVisitor, UserRType, ROptional, RInstance, RTuple
 )
 
 
@@ -16,9 +16,9 @@ class SameTypeVisitor(RTypeVisitor[bool]):
     def visit_user_rtype(self, left: UserRType) -> bool:
         return isinstance(self.right, UserRType) and left.name == self.right.name
 
-    def visit_optional_rtype(self, left: OptionalRType) -> bool:
-        return isinstance(self.right, OptionalRType) and is_same_type(left.value_type,
-                                                                      self.right.value_type)
+    def visit_roptional(self, left: ROptional) -> bool:
+        return isinstance(self.right, ROptional) and is_same_type(left.value_type,
+                                                                  self.right.value_type)
 
     def visit_rinstance(self, left: RInstance) -> bool:
         return isinstance(self.right, RInstance) and left.name == self.right.name

--- a/mypyc/sametype.py
+++ b/mypyc/sametype.py
@@ -1,7 +1,7 @@
 """Same type check for RTypes."""
 
 from mypyc.ops import (
-    RType, RTypeVisitor, ObjectRType, UserRType, OptionalRType, IntRType, BoolRType, TupleRType,
+    RType, RTypeVisitor, ObjectRType, UserRType, OptionalRType, RInstance, BoolRType, TupleRType,
     SequenceTupleRType, NoneRType, ListRType, DictRType, UnicodeRType
 )
 
@@ -24,8 +24,8 @@ class SameTypeVisitor(RTypeVisitor[bool]):
         return isinstance(self.right, OptionalRType) and is_same_type(left.value_type,
                                                                       self.right.value_type)
 
-    def visit_int_rtype(self, left: IntRType) -> bool:
-        return isinstance(self.right, IntRType)
+    def visit_rinstance(self, left: RInstance) -> bool:
+        return isinstance(self.right, RInstance) and left.name == self.right.name
 
     def visit_bool_rtype(self, left: BoolRType) -> bool:
         return isinstance(self.right, BoolRType)

--- a/mypyc/sametype.py
+++ b/mypyc/sametype.py
@@ -1,7 +1,7 @@
 """Same type check for RTypes."""
 
 from mypyc.ops import (
-    RType, RTypeVisitor, UserRType, ROptional, RInstance, RTuple
+    RType, RTypeVisitor, UserRType, ROptional, RPrimitive, RTuple
 )
 
 
@@ -20,8 +20,8 @@ class SameTypeVisitor(RTypeVisitor[bool]):
         return isinstance(self.right, ROptional) and is_same_type(left.value_type,
                                                                   self.right.value_type)
 
-    def visit_rinstance(self, left: RInstance) -> bool:
-        return isinstance(self.right, RInstance) and left.name == self.right.name
+    def visit_rprimitive(self, left: RPrimitive) -> bool:
+        return isinstance(self.right, RPrimitive) and left.name == self.right.name
 
     def visit_rtuple(self, left: RTuple) -> bool:
         return (isinstance(self.right, RTuple)

--- a/mypyc/sametype.py
+++ b/mypyc/sametype.py
@@ -2,7 +2,7 @@
 
 from mypyc.ops import (
     RType, RTypeVisitor, ObjectRType, UserRType, OptionalRType, RInstance, TupleRType,
-    SequenceTupleRType, NoneRType, UnicodeRType
+    SequenceTupleRType, NoneRType
 )
 
 
@@ -37,6 +37,3 @@ class SameTypeVisitor(RTypeVisitor[bool]):
 
     def visit_none_rtype(self, left: NoneRType) -> bool:
         return isinstance(self.right, NoneRType)
-
-    def visit_unicode_rtype(self, left: UnicodeRType) -> bool:
-        return isinstance(self.right, UnicodeRType)

--- a/mypyc/sametype.py
+++ b/mypyc/sametype.py
@@ -1,7 +1,7 @@
 """Same type check for RTypes."""
 
 from mypyc.ops import (
-    RType, RTypeVisitor, UserRType, ROptional, RPrimitive, RTuple
+    RType, RTypeVisitor, RInstance, ROptional, RPrimitive, RTuple
 )
 
 
@@ -13,8 +13,8 @@ class SameTypeVisitor(RTypeVisitor[bool]):
     def __init__(self, right: RType) -> None:
         self.right = right
 
-    def visit_user_rtype(self, left: UserRType) -> bool:
-        return isinstance(self.right, UserRType) and left.name == self.right.name
+    def visit_rinstance(self, left: RInstance) -> bool:
+        return isinstance(self.right, RInstance) and left.name == self.right.name
 
     def visit_roptional(self, left: ROptional) -> bool:
         return isinstance(self.right, ROptional) and is_same_type(left.value_type,

--- a/mypyc/sametype.py
+++ b/mypyc/sametype.py
@@ -1,7 +1,7 @@
 """Same type check for RTypes."""
 
 from mypyc.ops import (
-    RType, RTypeVisitor, UserRType, OptionalRType, RInstance, TupleRType
+    RType, RTypeVisitor, UserRType, OptionalRType, RInstance, RTuple
 )
 
 
@@ -23,7 +23,7 @@ class SameTypeVisitor(RTypeVisitor[bool]):
     def visit_rinstance(self, left: RInstance) -> bool:
         return isinstance(self.right, RInstance) and left.name == self.right.name
 
-    def visit_tuple_rtype(self, left: TupleRType) -> bool:
-        return (isinstance(self.right, TupleRType)
+    def visit_rtuple(self, left: RTuple) -> bool:
+        return (isinstance(self.right, RTuple)
             and len(self.right.types) == len(left.types)
             and all(is_same_type(t1, t2) for t1, t2 in zip(left.types, self.right.types)))

--- a/mypyc/sametype.py
+++ b/mypyc/sametype.py
@@ -1,7 +1,7 @@
 """Same type check for RTypes."""
 
 from mypyc.ops import (
-    RType, RTypeVisitor, ObjectRType, UserRType, OptionalRType, RInstance, TupleRType
+    RType, RTypeVisitor, UserRType, OptionalRType, RInstance, TupleRType
 )
 
 
@@ -12,9 +12,6 @@ def is_same_type(a: RType, b: RType) -> bool:
 class SameTypeVisitor(RTypeVisitor[bool]):
     def __init__(self, right: RType) -> None:
         self.right = right
-
-    def visit_object_rtype(self, left: ObjectRType) -> bool:
-        return isinstance(self.right, ObjectRType)
 
     def visit_user_rtype(self, left: UserRType) -> bool:
         return isinstance(self.right, UserRType) and left.name == self.right.name

--- a/mypyc/sametype.py
+++ b/mypyc/sametype.py
@@ -1,7 +1,7 @@
 """Same type check for RTypes."""
 
 from mypyc.ops import (
-    RType, RTypeVisitor, ObjectRType, UserRType, OptionalRType, RInstance, BoolRType, TupleRType,
+    RType, RTypeVisitor, ObjectRType, UserRType, OptionalRType, RInstance, TupleRType,
     SequenceTupleRType, NoneRType, ListRType, DictRType, UnicodeRType
 )
 
@@ -26,9 +26,6 @@ class SameTypeVisitor(RTypeVisitor[bool]):
 
     def visit_rinstance(self, left: RInstance) -> bool:
         return isinstance(self.right, RInstance) and left.name == self.right.name
-
-    def visit_bool_rtype(self, left: BoolRType) -> bool:
-        return isinstance(self.right, BoolRType)
 
     def visit_tuple_rtype(self, left: TupleRType) -> bool:
         return (isinstance(self.right, TupleRType)

--- a/mypyc/sametype.py
+++ b/mypyc/sametype.py
@@ -1,8 +1,7 @@
 """Same type check for RTypes."""
 
 from mypyc.ops import (
-    RType, RTypeVisitor, ObjectRType, UserRType, OptionalRType, RInstance, TupleRType,
-    NoneRType
+    RType, RTypeVisitor, ObjectRType, UserRType, OptionalRType, RInstance, TupleRType
 )
 
 
@@ -31,6 +30,3 @@ class SameTypeVisitor(RTypeVisitor[bool]):
         return (isinstance(self.right, TupleRType)
             and len(self.right.types) == len(left.types)
             and all(is_same_type(t1, t2) for t1, t2 in zip(left.types, self.right.types)))
-
-    def visit_none_rtype(self, left: NoneRType) -> bool:
-        return isinstance(self.right, NoneRType)

--- a/mypyc/sametype.py
+++ b/mypyc/sametype.py
@@ -2,7 +2,7 @@
 
 from mypyc.ops import (
     RType, RTypeVisitor, ObjectRType, UserRType, OptionalRType, RInstance, TupleRType,
-    SequenceTupleRType, NoneRType, DictRType, UnicodeRType
+    SequenceTupleRType, NoneRType, UnicodeRType
 )
 
 
@@ -37,9 +37,6 @@ class SameTypeVisitor(RTypeVisitor[bool]):
 
     def visit_none_rtype(self, left: NoneRType) -> bool:
         return isinstance(self.right, NoneRType)
-
-    def visit_dict_rtype(self, left: DictRType) -> bool:
-        return isinstance(self.right, DictRType)
 
     def visit_unicode_rtype(self, left: UnicodeRType) -> bool:
         return isinstance(self.right, UnicodeRType)

--- a/mypyc/sametype.py
+++ b/mypyc/sametype.py
@@ -2,7 +2,7 @@
 
 from mypyc.ops import (
     RType, RTypeVisitor, ObjectRType, UserRType, OptionalRType, RInstance, TupleRType,
-    SequenceTupleRType, NoneRType
+    NoneRType
 )
 
 
@@ -31,9 +31,6 @@ class SameTypeVisitor(RTypeVisitor[bool]):
         return (isinstance(self.right, TupleRType)
             and len(self.right.types) == len(left.types)
             and all(is_same_type(t1, t2) for t1, t2 in zip(left.types, self.right.types)))
-
-    def visit_sequence_tuple_rtype(self, left: SequenceTupleRType) -> bool:
-        return isinstance(self.right, SequenceTupleRType)
 
     def visit_none_rtype(self, left: NoneRType) -> bool:
         return isinstance(self.right, NoneRType)

--- a/mypyc/sametype.py
+++ b/mypyc/sametype.py
@@ -2,7 +2,7 @@
 
 from mypyc.ops import (
     RType, RTypeVisitor, ObjectRType, UserRType, OptionalRType, RInstance, TupleRType,
-    SequenceTupleRType, NoneRType, ListRType, DictRType, UnicodeRType
+    SequenceTupleRType, NoneRType, DictRType, UnicodeRType
 )
 
 
@@ -37,9 +37,6 @@ class SameTypeVisitor(RTypeVisitor[bool]):
 
     def visit_none_rtype(self, left: NoneRType) -> bool:
         return isinstance(self.right, NoneRType)
-
-    def visit_list_rtype(self, left: ListRType) -> bool:
-        return isinstance(self.right, ListRType)
 
     def visit_dict_rtype(self, left: DictRType) -> bool:
         return isinstance(self.right, DictRType)

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -1,13 +1,13 @@
 """Subtype check for RTypes."""
 
 from mypyc.ops import (
-    RType, ObjectRType, OptionalRType, UserRType, RInstance, TupleRType, RTypeVisitor,
-    is_bool_rinstance, is_int_rinstance, is_tuple_rinstance, none_rinstance
+    RType, OptionalRType, UserRType, RInstance, TupleRType, RTypeVisitor,
+    is_bool_rinstance, is_int_rinstance, is_tuple_rinstance, none_rinstance, is_object_rinstance
 )
 
 
 def is_subtype(left: RType, right: RType) -> bool:
-    if isinstance(right, ObjectRType):
+    if is_object_rinstance(right):
         return True
     elif isinstance(right, OptionalRType):
         if is_subtype(left, none_rinstance) or is_subtype(left, right.value_type):
@@ -24,9 +24,6 @@ class SubtypeVisitor(RTypeVisitor[bool]):
 
     def __init__(self, right: RType) -> None:
         self.right = right
-
-    def visit_object_rtype(self, left: ObjectRType) -> bool:
-        return False  # 'object' as right handled elsewhere
 
     def visit_user_rtype(self, left: UserRType) -> bool:
         # TODO: Inheritance

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -1,7 +1,7 @@
 """Subtype check for RTypes."""
 
 from mypyc.ops import (
-    RType, ROptional, UserRType, RPrimitive, RTuple, RTypeVisitor,
+    RType, ROptional, RInstance, RPrimitive, RTuple, RTypeVisitor,
     is_bool_rprimitive, is_int_rprimitive, is_tuple_rprimitive, none_rprimitive, is_object_rprimitive
 )
 
@@ -25,9 +25,9 @@ class SubtypeVisitor(RTypeVisitor[bool]):
     def __init__(self, right: RType) -> None:
         self.right = right
 
-    def visit_user_rtype(self, left: UserRType) -> bool:
+    def visit_rinstance(self, left: RInstance) -> bool:
         # TODO: Inheritance
-        return isinstance(self.right, UserRType) and self.right.name == left.name
+        return isinstance(self.right, RInstance) and self.right.name == left.name
 
     def visit_roptional(self, left: ROptional) -> bool:
         return isinstance(self.right, ROptional) and is_subtype(left.value_type,

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -2,8 +2,7 @@
 
 from mypyc.ops import (
     RType, ObjectRType, OptionalRType, NoneRType, UserRType, RInstance, TupleRType,
-    SequenceTupleRType, UnicodeRType, RTypeVisitor, is_bool_rinstance,
-    is_int_rinstance
+    SequenceTupleRType, RTypeVisitor, is_bool_rinstance, is_int_rinstance
 )
 
 
@@ -55,6 +54,3 @@ class SubtypeVisitor(RTypeVisitor[bool]):
 
     def visit_none_rtype(self, left: NoneRType) -> bool:
         return isinstance(self.right, NoneRType)
-
-    def visit_unicode_rtype(self, left: UnicodeRType) -> bool:
-        return isinstance(self.right, UnicodeRType)

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -1,16 +1,16 @@
 """Subtype check for RTypes."""
 
 from mypyc.ops import (
-    RType, ROptional, UserRType, RInstance, RTuple, RTypeVisitor,
-    is_bool_rinstance, is_int_rinstance, is_tuple_rinstance, none_rinstance, is_object_rinstance
+    RType, ROptional, UserRType, RPrimitive, RTuple, RTypeVisitor,
+    is_bool_rprimitive, is_int_rprimitive, is_tuple_rprimitive, none_rprimitive, is_object_rprimitive
 )
 
 
 def is_subtype(left: RType, right: RType) -> bool:
-    if is_object_rinstance(right):
+    if is_object_rprimitive(right):
         return True
     elif isinstance(right, ROptional):
-        if is_subtype(left, none_rinstance) or is_subtype(left, right.value_type):
+        if is_subtype(left, none_rprimitive) or is_subtype(left, right.value_type):
             return True
     return left.accept(SubtypeVisitor(right))
 
@@ -33,13 +33,13 @@ class SubtypeVisitor(RTypeVisitor[bool]):
         return isinstance(self.right, ROptional) and is_subtype(left.value_type,
                                                                 self.right.value_type)
 
-    def visit_rinstance(self, left: RInstance) -> bool:
-        if is_bool_rinstance(left) and is_int_rinstance(self.right):
+    def visit_rprimitive(self, left: RPrimitive) -> bool:
+        if is_bool_rprimitive(left) and is_int_rprimitive(self.right):
             return True
-        return isinstance(self.right, RInstance) and left.name == self.right.name
+        return isinstance(self.right, RPrimitive) and left.name == self.right.name
 
     def visit_rtuple(self, left: RTuple) -> bool:
-        if is_tuple_rinstance(self.right):
+        if is_tuple_rprimitive(self.right):
             return True
         if isinstance(self.right, RTuple):
             return len(self.right.types) == len(left.types) and all(

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -2,7 +2,7 @@
 
 from mypyc.ops import (
     RType, ObjectRType, OptionalRType, NoneRType, UserRType, RInstance, TupleRType,
-    SequenceTupleRType, RTypeVisitor, is_bool_rinstance, is_int_rinstance
+    RTypeVisitor, is_bool_rinstance, is_int_rinstance, is_tuple_rinstance
 )
 
 
@@ -42,15 +42,12 @@ class SubtypeVisitor(RTypeVisitor[bool]):
         return isinstance(self.right, RInstance) and left.name == self.right.name
 
     def visit_tuple_rtype(self, left: TupleRType) -> bool:
-        if isinstance(self.right, SequenceTupleRType):
+        if is_tuple_rinstance(self.right):
             return True
         if isinstance(self.right, TupleRType):
             return len(self.right.types) == len(left.types) and all(
                 is_subtype(t1, t2) for t1, t2 in zip(left.types, self.right.types))
         return False
-
-    def visit_sequence_tuple_rtype(self, left: SequenceTupleRType) -> bool:
-        return isinstance(self.right, SequenceTupleRType)
 
     def visit_none_rtype(self, left: NoneRType) -> bool:
         return isinstance(self.right, NoneRType)

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -1,7 +1,7 @@
 """Subtype check for RTypes."""
 
 from mypyc.ops import (
-    RType, ObjectRType, OptionalRType, NoneRType, UserRType, IntRType, BoolRType, TupleRType,
+    RType, ObjectRType, OptionalRType, NoneRType, UserRType, RInstance, BoolRType, TupleRType,
     SequenceTupleRType, ListRType, DictRType, UnicodeRType, RTypeVisitor
 )
 
@@ -36,11 +36,13 @@ class SubtypeVisitor(RTypeVisitor[bool]):
         return isinstance(self.right, OptionalRType) and is_subtype(left.value_type,
                                                                     self.right.value_type)
 
-    def visit_int_rtype(self, left: IntRType) -> bool:
-        return isinstance(self.right, IntRType)
+    def visit_rinstance(self, left: RInstance) -> bool:
+        return isinstance(self.right, RInstance) and left.name == self.right.name
 
     def visit_bool_rtype(self, left: BoolRType) -> bool:
-        return isinstance(self.right, (BoolRType, IntRType))
+        right = self.right
+        return isinstance(right, BoolRType) or (isinstance(right, RInstance)
+                                                and right.name == 'builtins.int')
 
     def visit_tuple_rtype(self, left: TupleRType) -> bool:
         if isinstance(self.right, SequenceTupleRType):

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -1,8 +1,9 @@
 """Subtype check for RTypes."""
 
 from mypyc.ops import (
-    RType, ObjectRType, OptionalRType, NoneRType, UserRType, RInstance, BoolRType, TupleRType,
-    SequenceTupleRType, ListRType, DictRType, UnicodeRType, RTypeVisitor
+    RType, ObjectRType, OptionalRType, NoneRType, UserRType, RInstance, TupleRType,
+    SequenceTupleRType, ListRType, DictRType, UnicodeRType, RTypeVisitor, is_bool_rinstance,
+    is_int_rinstance
 )
 
 
@@ -37,12 +38,9 @@ class SubtypeVisitor(RTypeVisitor[bool]):
                                                                     self.right.value_type)
 
     def visit_rinstance(self, left: RInstance) -> bool:
+        if is_bool_rinstance(left) and is_int_rinstance(self.right):
+            return True
         return isinstance(self.right, RInstance) and left.name == self.right.name
-
-    def visit_bool_rtype(self, left: BoolRType) -> bool:
-        right = self.right
-        return isinstance(right, BoolRType) or (isinstance(right, RInstance)
-                                                and right.name == 'builtins.int')
 
     def visit_tuple_rtype(self, left: TupleRType) -> bool:
         if isinstance(self.right, SequenceTupleRType):

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -2,7 +2,7 @@
 
 from mypyc.ops import (
     RType, ObjectRType, OptionalRType, NoneRType, UserRType, RInstance, TupleRType,
-    SequenceTupleRType, ListRType, DictRType, UnicodeRType, RTypeVisitor, is_bool_rinstance,
+    SequenceTupleRType, DictRType, UnicodeRType, RTypeVisitor, is_bool_rinstance,
     is_int_rinstance
 )
 
@@ -55,9 +55,6 @@ class SubtypeVisitor(RTypeVisitor[bool]):
 
     def visit_none_rtype(self, left: NoneRType) -> bool:
         return isinstance(self.right, NoneRType)
-
-    def visit_list_rtype(self, left: ListRType) -> bool:
-        return isinstance(self.right, ListRType)
 
     def visit_dict_rtype(self, left: DictRType) -> bool:
         return isinstance(self.right, DictRType)

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -1,7 +1,7 @@
 """Subtype check for RTypes."""
 
 from mypyc.ops import (
-    RType, OptionalRType, UserRType, RInstance, TupleRType, RTypeVisitor,
+    RType, OptionalRType, UserRType, RInstance, RTuple, RTypeVisitor,
     is_bool_rinstance, is_int_rinstance, is_tuple_rinstance, none_rinstance, is_object_rinstance
 )
 
@@ -38,10 +38,10 @@ class SubtypeVisitor(RTypeVisitor[bool]):
             return True
         return isinstance(self.right, RInstance) and left.name == self.right.name
 
-    def visit_tuple_rtype(self, left: TupleRType) -> bool:
+    def visit_rtuple(self, left: RTuple) -> bool:
         if is_tuple_rinstance(self.right):
             return True
-        if isinstance(self.right, TupleRType):
+        if isinstance(self.right, RTuple):
             return len(self.right.types) == len(left.types) and all(
                 is_subtype(t1, t2) for t1, t2 in zip(left.types, self.right.types))
         return False

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -1,8 +1,8 @@
 """Subtype check for RTypes."""
 
 from mypyc.ops import (
-    RType, ObjectRType, OptionalRType, NoneRType, UserRType, RInstance, TupleRType,
-    RTypeVisitor, is_bool_rinstance, is_int_rinstance, is_tuple_rinstance
+    RType, ObjectRType, OptionalRType, UserRType, RInstance, TupleRType, RTypeVisitor,
+    is_bool_rinstance, is_int_rinstance, is_tuple_rinstance, none_rinstance
 )
 
 
@@ -10,7 +10,7 @@ def is_subtype(left: RType, right: RType) -> bool:
     if isinstance(right, ObjectRType):
         return True
     elif isinstance(right, OptionalRType):
-        if is_subtype(left, NoneRType()) or is_subtype(left, right.value_type):
+        if is_subtype(left, none_rinstance) or is_subtype(left, right.value_type):
             return True
     return left.accept(SubtypeVisitor(right))
 
@@ -48,6 +48,3 @@ class SubtypeVisitor(RTypeVisitor[bool]):
             return len(self.right.types) == len(left.types) and all(
                 is_subtype(t1, t2) for t1, t2 in zip(left.types, self.right.types))
         return False
-
-    def visit_none_rtype(self, left: NoneRType) -> bool:
-        return isinstance(self.right, NoneRType)

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -2,7 +2,7 @@
 
 from mypyc.ops import (
     RType, ObjectRType, OptionalRType, NoneRType, UserRType, RInstance, TupleRType,
-    SequenceTupleRType, DictRType, UnicodeRType, RTypeVisitor, is_bool_rinstance,
+    SequenceTupleRType, UnicodeRType, RTypeVisitor, is_bool_rinstance,
     is_int_rinstance
 )
 
@@ -55,9 +55,6 @@ class SubtypeVisitor(RTypeVisitor[bool]):
 
     def visit_none_rtype(self, left: NoneRType) -> bool:
         return isinstance(self.right, NoneRType)
-
-    def visit_dict_rtype(self, left: DictRType) -> bool:
-        return isinstance(self.right, DictRType)
 
     def visit_unicode_rtype(self, left: UnicodeRType) -> bool:
         return isinstance(self.right, UnicodeRType)

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -1,7 +1,7 @@
 """Subtype check for RTypes."""
 
 from mypyc.ops import (
-    RType, OptionalRType, UserRType, RInstance, RTuple, RTypeVisitor,
+    RType, ROptional, UserRType, RInstance, RTuple, RTypeVisitor,
     is_bool_rinstance, is_int_rinstance, is_tuple_rinstance, none_rinstance, is_object_rinstance
 )
 
@@ -9,7 +9,7 @@ from mypyc.ops import (
 def is_subtype(left: RType, right: RType) -> bool:
     if is_object_rinstance(right):
         return True
-    elif isinstance(right, OptionalRType):
+    elif isinstance(right, ROptional):
         if is_subtype(left, none_rinstance) or is_subtype(left, right.value_type):
             return True
     return left.accept(SubtypeVisitor(right))
@@ -29,9 +29,9 @@ class SubtypeVisitor(RTypeVisitor[bool]):
         # TODO: Inheritance
         return isinstance(self.right, UserRType) and self.right.name == left.name
 
-    def visit_optional_rtype(self, left: OptionalRType) -> bool:
-        return isinstance(self.right, OptionalRType) and is_subtype(left.value_type,
-                                                                    self.right.value_type)
+    def visit_roptional(self, left: ROptional) -> bool:
+        return isinstance(self.right, ROptional) and is_subtype(left.value_type,
+                                                                self.right.value_type)
 
     def visit_rinstance(self, left: RInstance) -> bool:
         if is_bool_rinstance(left) and is_int_rinstance(self.right):

--- a/mypyc/test/test_emit.py
+++ b/mypyc/test/test_emit.py
@@ -3,13 +3,13 @@ import unittest
 from mypy.nodes import Var
 
 from mypyc.emit import Emitter, EmitterContext
-from mypyc.ops import Environment, RType, IntRType, Label
+from mypyc.ops import Environment, RType, int_rinstance, Label
 
 
 class TestEmitter(unittest.TestCase):
     def setUp(self) -> None:
         self.env = Environment()
-        self.n = self.env.add_local(Var('n'), IntRType())
+        self.n = self.env.add_local(Var('n'), int_rinstance)
         self.context = EmitterContext()
         self.emitter = Emitter(self.context, self.env)
 

--- a/mypyc/test/test_emit.py
+++ b/mypyc/test/test_emit.py
@@ -3,13 +3,13 @@ import unittest
 from mypy.nodes import Var
 
 from mypyc.emit import Emitter, EmitterContext
-from mypyc.ops import Environment, RType, int_rinstance, Label
+from mypyc.ops import Environment, RType, int_rprimitive, Label
 
 
 class TestEmitter(unittest.TestCase):
     def setUp(self) -> None:
         self.env = Environment()
-        self.n = self.env.add_local(Var('n'), int_rinstance)
+        self.n = self.env.add_local(Var('n'), int_rprimitive)
         self.context = EmitterContext()
         self.emitter = Emitter(self.context, self.env)
 

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -6,8 +6,8 @@ from mypy.test.helpers import assert_string_arrays_equal
 from mypyc.ops import (
     Environment, BasicBlock, FuncIR, RuntimeArg, RType, Goto, Return, LoadInt, Assign,
     PrimitiveOp, IncRef, DecRef, Branch, Call, Unbox, Box, TupleRType, TupleGet, GetAttr,
-    ClassIR, UserRType, SetAttr, Op, Label, IntRType, ListRType, ObjectRType, BoolRType,
-    DictRType
+    ClassIR, UserRType, SetAttr, Op, Label, ListRType, ObjectRType, BoolRType,
+    DictRType, int_rinstance
 )
 from mypyc.emit import Emitter, EmitterContext
 from mypyc.emitfunc import generate_native_function, FunctionEmitterVisitor
@@ -16,9 +16,9 @@ from mypyc.emitfunc import generate_native_function, FunctionEmitterVisitor
 class TestFunctionEmitterVisitor(unittest.TestCase):
     def setUp(self) -> None:
         self.env = Environment()
-        self.n = self.env.add_local(Var('n'), IntRType())
-        self.m = self.env.add_local(Var('m'), IntRType())
-        self.k = self.env.add_local(Var('k'), IntRType())
+        self.n = self.env.add_local(Var('n'), int_rinstance)
+        self.m = self.env.add_local(Var('m'), int_rinstance)
+        self.k = self.env.add_local(Var('k'), int_rinstance)
         self.l = self.env.add_local(Var('l'), ListRType())
         self.ll = self.env.add_local(Var('ll'), ListRType())
         self.o = self.env.add_local(Var('o'), ObjectRType())
@@ -118,19 +118,19 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          "CPyDef_myfn(cpy_r_m, cpy_r_k);")
 
     def test_inc_ref(self) -> None:
-        self.assert_emit(IncRef(self.m, IntRType()),
+        self.assert_emit(IncRef(self.m, int_rinstance),
                          "CPyTagged_IncRef(cpy_r_m);")
 
     def test_dec_ref(self) -> None:
-        self.assert_emit(DecRef(self.m, IntRType()),
+        self.assert_emit(DecRef(self.m, int_rinstance),
                          "CPyTagged_DecRef(cpy_r_m);")
 
     def test_dec_ref_tuple(self) -> None:
-        tuple_type = TupleRType([IntRType(), BoolRType()])
+        tuple_type = TupleRType([int_rinstance, BoolRType()])
         self.assert_emit(DecRef(self.m, tuple_type), 'CPyTagged_DecRef(cpy_r_m.f0);')
 
     def test_dec_ref_tuple_nested(self) -> None:
-        tuple_type = TupleRType([TupleRType([IntRType(), BoolRType()]), BoolRType()])
+        tuple_type = TupleRType([TupleRType([int_rinstance, BoolRType()]), BoolRType()])
         self.assert_emit(DecRef(self.m, tuple_type), 'CPyTagged_DecRef(cpy_r_m.f0.f0);')
 
     def test_list_get_item(self) -> None:
@@ -142,11 +142,11 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """cpy_r_b = CPyList_SetItem(cpy_r_l, cpy_r_n, cpy_r_o) != 0;""")
 
     def test_box(self) -> None:
-        self.assert_emit(Box(self.o, self.n, IntRType()),
+        self.assert_emit(Box(self.o, self.n, int_rinstance),
                          """cpy_r_o = CPyTagged_StealAsObject(cpy_r_n);""")
 
     def test_unbox(self) -> None:
-        self.assert_emit(Unbox(self.n, self.m, IntRType(), 55),
+        self.assert_emit(Unbox(self.n, self.m, int_rinstance, 55),
                          """if (PyLong_Check(cpy_r_m))
                                 cpy_r_n = CPyTagged_FromObject(cpy_r_m);
                             else {
@@ -172,14 +172,14 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
 
     def test_get_attr(self) -> None:
         ir = ClassIR('A', [('x', BoolRType()),
-                           ('y', IntRType())])
+                           ('y', int_rinstance)])
         rtype = UserRType(ir)
         self.assert_emit(GetAttr(self.n, self.m, 'y', rtype, 1),
                          """cpy_r_n = CPY_GET_ATTR(cpy_r_m, 2, AObject, CPyTagged);""")
 
     def test_set_attr(self) -> None:
         ir = ClassIR('A', [('x', BoolRType()),
-                           ('y', IntRType())])
+                           ('y', int_rinstance)])
         rtype = UserRType(ir)
         self.assert_emit(SetAttr(self.b, self.n, 'y', self.m, rtype, 1),
                          """cpy_r_b = CPY_SET_ATTR(cpy_r_n, 3, cpy_r_m, AObject, CPyTagged);""")
@@ -230,14 +230,14 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
 class TestGenerateFunction(unittest.TestCase):
     def setUp(self) -> None:
         self.var = Var('arg')
-        self.arg = RuntimeArg('arg', IntRType())
+        self.arg = RuntimeArg('arg', int_rinstance)
         self.env = Environment()
-        self.reg = self.env.add_local(self.var, IntRType())
+        self.reg = self.env.add_local(self.var, int_rinstance)
         self.block = BasicBlock(Label(0))
 
     def test_simple(self) -> None:
         self.block.ops.append(Return(self.reg))
-        fn = FuncIR('myfunc', None, [self.arg], IntRType(), [self.block], self.env)
+        fn = FuncIR('myfunc', None, [self.arg], int_rinstance, [self.block], self.env)
         emitter = Emitter(EmitterContext())
         generate_native_function(fn, emitter, 'prog.py')
         result = emitter.fragments
@@ -251,7 +251,7 @@ class TestGenerateFunction(unittest.TestCase):
             result, msg='Generated code invalid')
 
     def test_register(self) -> None:
-        self.temp = self.env.add_temp(IntRType())
+        self.temp = self.env.add_temp(int_rinstance)
         self.block.ops.append(LoadInt(self.temp, 5))
         fn = FuncIR('myfunc', None, [self.arg], ListRType(), [self.block], self.env)
         emitter = Emitter(EmitterContext())

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -6,8 +6,8 @@ from mypy.test.helpers import assert_string_arrays_equal
 from mypyc.ops import (
     Environment, BasicBlock, FuncIR, RuntimeArg, RType, Goto, Return, LoadInt, Assign,
     PrimitiveOp, IncRef, DecRef, Branch, Call, Unbox, Box, RTuple, TupleGet, GetAttr,
-    ClassIR, UserRType, SetAttr, Op, Label, int_rinstance, bool_rinstance, list_rinstance,
-    dict_rinstance, object_rinstance
+    ClassIR, UserRType, SetAttr, Op, Label, int_rprimitive, bool_rprimitive, list_rprimitive,
+    dict_rprimitive, object_rprimitive
 )
 from mypyc.emit import Emitter, EmitterContext
 from mypyc.emitfunc import generate_native_function, FunctionEmitterVisitor
@@ -16,15 +16,15 @@ from mypyc.emitfunc import generate_native_function, FunctionEmitterVisitor
 class TestFunctionEmitterVisitor(unittest.TestCase):
     def setUp(self) -> None:
         self.env = Environment()
-        self.n = self.env.add_local(Var('n'), int_rinstance)
-        self.m = self.env.add_local(Var('m'), int_rinstance)
-        self.k = self.env.add_local(Var('k'), int_rinstance)
-        self.l = self.env.add_local(Var('l'), list_rinstance)
-        self.ll = self.env.add_local(Var('ll'), list_rinstance)
-        self.o = self.env.add_local(Var('o'), object_rinstance)
-        self.o2 = self.env.add_local(Var('o2'), object_rinstance)
-        self.d = self.env.add_local(Var('d'), dict_rinstance)
-        self.b = self.env.add_local(Var('b'), bool_rinstance)
+        self.n = self.env.add_local(Var('n'), int_rprimitive)
+        self.m = self.env.add_local(Var('m'), int_rprimitive)
+        self.k = self.env.add_local(Var('k'), int_rprimitive)
+        self.l = self.env.add_local(Var('l'), list_rprimitive)
+        self.ll = self.env.add_local(Var('ll'), list_rprimitive)
+        self.o = self.env.add_local(Var('o'), object_rprimitive)
+        self.o2 = self.env.add_local(Var('o2'), object_rprimitive)
+        self.d = self.env.add_local(Var('d'), dict_rprimitive)
+        self.b = self.env.add_local(Var('b'), bool_rprimitive)
         self.context = EmitterContext()
         self.emitter = Emitter(self.context, self.env)
         self.declarations = Emitter(self.context, self.env)
@@ -43,7 +43,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          "cpy_r_m = 10;")
 
     def test_tuple_get(self) -> None:
-        self.assert_emit(TupleGet(self.m, self.n, 1, bool_rinstance, 0), 'cpy_r_m = cpy_r_n.f1;')
+        self.assert_emit(TupleGet(self.m, self.n, 1, bool_rprimitive, 0), 'cpy_r_m = cpy_r_n.f1;')
 
     def test_load_None(self) -> None:
         self.assert_emit(PrimitiveOp(self.m, PrimitiveOp.NONE, [], 0),
@@ -118,19 +118,19 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          "CPyDef_myfn(cpy_r_m, cpy_r_k);")
 
     def test_inc_ref(self) -> None:
-        self.assert_emit(IncRef(self.m, int_rinstance),
+        self.assert_emit(IncRef(self.m, int_rprimitive),
                          "CPyTagged_IncRef(cpy_r_m);")
 
     def test_dec_ref(self) -> None:
-        self.assert_emit(DecRef(self.m, int_rinstance),
+        self.assert_emit(DecRef(self.m, int_rprimitive),
                          "CPyTagged_DecRef(cpy_r_m);")
 
     def test_dec_ref_tuple(self) -> None:
-        tuple_type = RTuple([int_rinstance, bool_rinstance])
+        tuple_type = RTuple([int_rprimitive, bool_rprimitive])
         self.assert_emit(DecRef(self.m, tuple_type), 'CPyTagged_DecRef(cpy_r_m.f0);')
 
     def test_dec_ref_tuple_nested(self) -> None:
-        tuple_type = RTuple([RTuple([int_rinstance, bool_rinstance]), bool_rinstance])
+        tuple_type = RTuple([RTuple([int_rprimitive, bool_rprimitive]), bool_rprimitive])
         self.assert_emit(DecRef(self.m, tuple_type), 'CPyTagged_DecRef(cpy_r_m.f0.f0);')
 
     def test_list_get_item(self) -> None:
@@ -142,11 +142,11 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """cpy_r_b = CPyList_SetItem(cpy_r_l, cpy_r_n, cpy_r_o) != 0;""")
 
     def test_box(self) -> None:
-        self.assert_emit(Box(self.o, self.n, int_rinstance),
+        self.assert_emit(Box(self.o, self.n, int_rprimitive),
                          """cpy_r_o = CPyTagged_StealAsObject(cpy_r_n);""")
 
     def test_unbox(self) -> None:
-        self.assert_emit(Unbox(self.n, self.m, int_rinstance, 55),
+        self.assert_emit(Unbox(self.n, self.m, int_rprimitive, 55),
                          """if (PyLong_Check(cpy_r_m))
                                 cpy_r_n = CPyTagged_FromObject(cpy_r_m);
                             else {
@@ -171,15 +171,15 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """cpy_r_b = PyList_Append(cpy_r_l, cpy_r_o) != -1;""")
 
     def test_get_attr(self) -> None:
-        ir = ClassIR('A', [('x', bool_rinstance),
-                           ('y', int_rinstance)])
+        ir = ClassIR('A', [('x', bool_rprimitive),
+                           ('y', int_rprimitive)])
         rtype = UserRType(ir)
         self.assert_emit(GetAttr(self.n, self.m, 'y', rtype, 1),
                          """cpy_r_n = CPY_GET_ATTR(cpy_r_m, 2, AObject, CPyTagged);""")
 
     def test_set_attr(self) -> None:
-        ir = ClassIR('A', [('x', bool_rinstance),
-                           ('y', int_rinstance)])
+        ir = ClassIR('A', [('x', bool_rprimitive),
+                           ('y', int_rprimitive)])
         rtype = UserRType(ir)
         self.assert_emit(SetAttr(self.b, self.n, 'y', self.m, rtype, 1),
                          """cpy_r_b = CPY_SET_ATTR(cpy_r_n, 3, cpy_r_m, AObject, CPyTagged);""")
@@ -230,14 +230,14 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
 class TestGenerateFunction(unittest.TestCase):
     def setUp(self) -> None:
         self.var = Var('arg')
-        self.arg = RuntimeArg('arg', int_rinstance)
+        self.arg = RuntimeArg('arg', int_rprimitive)
         self.env = Environment()
-        self.reg = self.env.add_local(self.var, int_rinstance)
+        self.reg = self.env.add_local(self.var, int_rprimitive)
         self.block = BasicBlock(Label(0))
 
     def test_simple(self) -> None:
         self.block.ops.append(Return(self.reg))
-        fn = FuncIR('myfunc', None, [self.arg], int_rinstance, [self.block], self.env)
+        fn = FuncIR('myfunc', None, [self.arg], int_rprimitive, [self.block], self.env)
         emitter = Emitter(EmitterContext())
         generate_native_function(fn, emitter, 'prog.py')
         result = emitter.fragments
@@ -251,9 +251,9 @@ class TestGenerateFunction(unittest.TestCase):
             result, msg='Generated code invalid')
 
     def test_register(self) -> None:
-        self.temp = self.env.add_temp(int_rinstance)
+        self.temp = self.env.add_temp(int_rprimitive)
         self.block.ops.append(LoadInt(self.temp, 5))
-        fn = FuncIR('myfunc', None, [self.arg], list_rinstance, [self.block], self.env)
+        fn = FuncIR('myfunc', None, [self.arg], list_rprimitive, [self.block], self.env)
         emitter = Emitter(EmitterContext())
         generate_native_function(fn, emitter, 'prog.py')
         result = emitter.fragments

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -6,8 +6,8 @@ from mypy.test.helpers import assert_string_arrays_equal
 from mypyc.ops import (
     Environment, BasicBlock, FuncIR, RuntimeArg, RType, Goto, Return, LoadInt, Assign,
     PrimitiveOp, IncRef, DecRef, Branch, Call, Unbox, Box, TupleRType, TupleGet, GetAttr,
-    ClassIR, UserRType, SetAttr, Op, Label, ObjectRType, DictRType,
-    int_rinstance, bool_rinstance, list_rinstance
+    ClassIR, UserRType, SetAttr, Op, Label, ObjectRType, int_rinstance, bool_rinstance,
+    list_rinstance, dict_rinstance
 )
 from mypyc.emit import Emitter, EmitterContext
 from mypyc.emitfunc import generate_native_function, FunctionEmitterVisitor
@@ -23,7 +23,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.ll = self.env.add_local(Var('ll'), list_rinstance)
         self.o = self.env.add_local(Var('o'), ObjectRType())
         self.o2 = self.env.add_local(Var('o2'), ObjectRType())
-        self.d = self.env.add_local(Var('d'), DictRType())
+        self.d = self.env.add_local(Var('d'), dict_rinstance)
         self.b = self.env.add_local(Var('b'), bool_rinstance)
         self.context = EmitterContext()
         self.emitter = Emitter(self.context, self.env)

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -6,8 +6,8 @@ from mypy.test.helpers import assert_string_arrays_equal
 from mypyc.ops import (
     Environment, BasicBlock, FuncIR, RuntimeArg, RType, Goto, Return, LoadInt, Assign,
     PrimitiveOp, IncRef, DecRef, Branch, Call, Unbox, Box, TupleRType, TupleGet, GetAttr,
-    ClassIR, UserRType, SetAttr, Op, Label, ObjectRType, int_rinstance, bool_rinstance,
-    list_rinstance, dict_rinstance
+    ClassIR, UserRType, SetAttr, Op, Label, int_rinstance, bool_rinstance, list_rinstance,
+    dict_rinstance, object_rinstance
 )
 from mypyc.emit import Emitter, EmitterContext
 from mypyc.emitfunc import generate_native_function, FunctionEmitterVisitor
@@ -21,8 +21,8 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.k = self.env.add_local(Var('k'), int_rinstance)
         self.l = self.env.add_local(Var('l'), list_rinstance)
         self.ll = self.env.add_local(Var('ll'), list_rinstance)
-        self.o = self.env.add_local(Var('o'), ObjectRType())
-        self.o2 = self.env.add_local(Var('o2'), ObjectRType())
+        self.o = self.env.add_local(Var('o'), object_rinstance)
+        self.o2 = self.env.add_local(Var('o2'), object_rinstance)
         self.d = self.env.add_local(Var('d'), dict_rinstance)
         self.b = self.env.add_local(Var('b'), bool_rinstance)
         self.context = EmitterContext()

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -5,7 +5,7 @@ from mypy.test.helpers import assert_string_arrays_equal
 
 from mypyc.ops import (
     Environment, BasicBlock, FuncIR, RuntimeArg, RType, Goto, Return, LoadInt, Assign,
-    PrimitiveOp, IncRef, DecRef, Branch, Call, Unbox, Box, TupleRType, TupleGet, GetAttr,
+    PrimitiveOp, IncRef, DecRef, Branch, Call, Unbox, Box, RTuple, TupleGet, GetAttr,
     ClassIR, UserRType, SetAttr, Op, Label, int_rinstance, bool_rinstance, list_rinstance,
     dict_rinstance, object_rinstance
 )
@@ -126,11 +126,11 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          "CPyTagged_DecRef(cpy_r_m);")
 
     def test_dec_ref_tuple(self) -> None:
-        tuple_type = TupleRType([int_rinstance, bool_rinstance])
+        tuple_type = RTuple([int_rinstance, bool_rinstance])
         self.assert_emit(DecRef(self.m, tuple_type), 'CPyTagged_DecRef(cpy_r_m.f0);')
 
     def test_dec_ref_tuple_nested(self) -> None:
-        tuple_type = TupleRType([TupleRType([int_rinstance, bool_rinstance]), bool_rinstance])
+        tuple_type = RTuple([RTuple([int_rinstance, bool_rinstance]), bool_rinstance])
         self.assert_emit(DecRef(self.m, tuple_type), 'CPyTagged_DecRef(cpy_r_m.f0.f0);')
 
     def test_list_get_item(self) -> None:

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -6,8 +6,8 @@ from mypy.test.helpers import assert_string_arrays_equal
 from mypyc.ops import (
     Environment, BasicBlock, FuncIR, RuntimeArg, RType, Goto, Return, LoadInt, Assign,
     PrimitiveOp, IncRef, DecRef, Branch, Call, Unbox, Box, TupleRType, TupleGet, GetAttr,
-    ClassIR, UserRType, SetAttr, Op, Label, ListRType, ObjectRType, BoolRType,
-    DictRType, int_rinstance
+    ClassIR, UserRType, SetAttr, Op, Label, ListRType, ObjectRType, DictRType,
+    int_rinstance, bool_rinstance
 )
 from mypyc.emit import Emitter, EmitterContext
 from mypyc.emitfunc import generate_native_function, FunctionEmitterVisitor
@@ -24,7 +24,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.o = self.env.add_local(Var('o'), ObjectRType())
         self.o2 = self.env.add_local(Var('o2'), ObjectRType())
         self.d = self.env.add_local(Var('d'), DictRType())
-        self.b = self.env.add_local(Var('b'), BoolRType())
+        self.b = self.env.add_local(Var('b'), bool_rinstance)
         self.context = EmitterContext()
         self.emitter = Emitter(self.context, self.env)
         self.declarations = Emitter(self.context, self.env)
@@ -43,7 +43,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          "cpy_r_m = 10;")
 
     def test_tuple_get(self) -> None:
-        self.assert_emit(TupleGet(self.m, self.n, 1, BoolRType(), 0), 'cpy_r_m = cpy_r_n.f1;')
+        self.assert_emit(TupleGet(self.m, self.n, 1, bool_rinstance, 0), 'cpy_r_m = cpy_r_n.f1;')
 
     def test_load_None(self) -> None:
         self.assert_emit(PrimitiveOp(self.m, PrimitiveOp.NONE, [], 0),
@@ -126,11 +126,11 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          "CPyTagged_DecRef(cpy_r_m);")
 
     def test_dec_ref_tuple(self) -> None:
-        tuple_type = TupleRType([int_rinstance, BoolRType()])
+        tuple_type = TupleRType([int_rinstance, bool_rinstance])
         self.assert_emit(DecRef(self.m, tuple_type), 'CPyTagged_DecRef(cpy_r_m.f0);')
 
     def test_dec_ref_tuple_nested(self) -> None:
-        tuple_type = TupleRType([TupleRType([int_rinstance, BoolRType()]), BoolRType()])
+        tuple_type = TupleRType([TupleRType([int_rinstance, bool_rinstance]), bool_rinstance])
         self.assert_emit(DecRef(self.m, tuple_type), 'CPyTagged_DecRef(cpy_r_m.f0.f0);')
 
     def test_list_get_item(self) -> None:
@@ -171,14 +171,14 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """cpy_r_b = PyList_Append(cpy_r_l, cpy_r_o) != -1;""")
 
     def test_get_attr(self) -> None:
-        ir = ClassIR('A', [('x', BoolRType()),
+        ir = ClassIR('A', [('x', bool_rinstance),
                            ('y', int_rinstance)])
         rtype = UserRType(ir)
         self.assert_emit(GetAttr(self.n, self.m, 'y', rtype, 1),
                          """cpy_r_n = CPY_GET_ATTR(cpy_r_m, 2, AObject, CPyTagged);""")
 
     def test_set_attr(self) -> None:
-        ir = ClassIR('A', [('x', BoolRType()),
+        ir = ClassIR('A', [('x', bool_rinstance),
                            ('y', int_rinstance)])
         rtype = UserRType(ir)
         self.assert_emit(SetAttr(self.b, self.n, 'y', self.m, rtype, 1),

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -6,7 +6,7 @@ from mypy.test.helpers import assert_string_arrays_equal
 from mypyc.ops import (
     Environment, BasicBlock, FuncIR, RuntimeArg, RType, Goto, Return, LoadInt, Assign,
     PrimitiveOp, IncRef, DecRef, Branch, Call, Unbox, Box, RTuple, TupleGet, GetAttr,
-    ClassIR, UserRType, SetAttr, Op, Label, int_rprimitive, bool_rprimitive, list_rprimitive,
+    ClassIR, RInstance, SetAttr, Op, Label, int_rprimitive, bool_rprimitive, list_rprimitive,
     dict_rprimitive, object_rprimitive
 )
 from mypyc.emit import Emitter, EmitterContext
@@ -173,14 +173,14 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
     def test_get_attr(self) -> None:
         ir = ClassIR('A', [('x', bool_rprimitive),
                            ('y', int_rprimitive)])
-        rtype = UserRType(ir)
+        rtype = RInstance(ir)
         self.assert_emit(GetAttr(self.n, self.m, 'y', rtype, 1),
                          """cpy_r_n = CPY_GET_ATTR(cpy_r_m, 2, AObject, CPyTagged);""")
 
     def test_set_attr(self) -> None:
         ir = ClassIR('A', [('x', bool_rprimitive),
                            ('y', int_rprimitive)])
-        rtype = UserRType(ir)
+        rtype = RInstance(ir)
         self.assert_emit(SetAttr(self.b, self.n, 'y', self.m, rtype, 1),
                          """cpy_r_b = CPY_SET_ATTR(cpy_r_n, 3, cpy_r_m, AObject, CPyTagged);""")
 

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -6,8 +6,8 @@ from mypy.test.helpers import assert_string_arrays_equal
 from mypyc.ops import (
     Environment, BasicBlock, FuncIR, RuntimeArg, RType, Goto, Return, LoadInt, Assign,
     PrimitiveOp, IncRef, DecRef, Branch, Call, Unbox, Box, TupleRType, TupleGet, GetAttr,
-    ClassIR, UserRType, SetAttr, Op, Label, ListRType, ObjectRType, DictRType,
-    int_rinstance, bool_rinstance
+    ClassIR, UserRType, SetAttr, Op, Label, ObjectRType, DictRType,
+    int_rinstance, bool_rinstance, list_rinstance
 )
 from mypyc.emit import Emitter, EmitterContext
 from mypyc.emitfunc import generate_native_function, FunctionEmitterVisitor
@@ -19,8 +19,8 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.n = self.env.add_local(Var('n'), int_rinstance)
         self.m = self.env.add_local(Var('m'), int_rinstance)
         self.k = self.env.add_local(Var('k'), int_rinstance)
-        self.l = self.env.add_local(Var('l'), ListRType())
-        self.ll = self.env.add_local(Var('ll'), ListRType())
+        self.l = self.env.add_local(Var('l'), list_rinstance)
+        self.ll = self.env.add_local(Var('ll'), list_rinstance)
         self.o = self.env.add_local(Var('o'), ObjectRType())
         self.o2 = self.env.add_local(Var('o2'), ObjectRType())
         self.d = self.env.add_local(Var('d'), DictRType())
@@ -253,7 +253,7 @@ class TestGenerateFunction(unittest.TestCase):
     def test_register(self) -> None:
         self.temp = self.env.add_temp(int_rinstance)
         self.block.ops.append(LoadInt(self.temp, 5))
-        fn = FuncIR('myfunc', None, [self.arg], ListRType(), [self.block], self.env)
+        fn = FuncIR('myfunc', None, [self.arg], list_rinstance, [self.block], self.env)
         emitter = Emitter(EmitterContext())
         generate_native_function(fn, emitter, 'prog.py')
         result = emitter.fragments

--- a/mypyc/test/test_emitwrapper.py
+++ b/mypyc/test/test_emitwrapper.py
@@ -5,7 +5,7 @@ from mypy.test.helpers import assert_string_arrays_equal
 
 from mypyc.emit import Emitter, EmitterContext
 from mypyc.emitwrapper import generate_arg_check
-from mypyc.ops import ListRType, IntRType
+from mypyc.ops import ListRType, int_rinstance
 
 
 class TestArgCheck(unittest.TestCase):
@@ -29,7 +29,7 @@ class TestArgCheck(unittest.TestCase):
 
     def test_check_int(self) -> None:
         emitter = Emitter(self.context)
-        generate_arg_check('x', IntRType(), emitter)
+        generate_arg_check('x', int_rinstance, emitter)
         lines = emitter.fragments
         self.assert_lines([
             'CPyTagged arg_x;',

--- a/mypyc/test/test_emitwrapper.py
+++ b/mypyc/test/test_emitwrapper.py
@@ -5,7 +5,7 @@ from mypy.test.helpers import assert_string_arrays_equal
 
 from mypyc.emit import Emitter, EmitterContext
 from mypyc.emitwrapper import generate_arg_check
-from mypyc.ops import ListRType, int_rinstance
+from mypyc.ops import list_rinstance, int_rinstance
 
 
 class TestArgCheck(unittest.TestCase):
@@ -14,7 +14,7 @@ class TestArgCheck(unittest.TestCase):
 
     def test_check_list(self) -> None:
         emitter = Emitter(self.context)
-        generate_arg_check('x', ListRType(), emitter)
+        generate_arg_check('x', list_rinstance, emitter)
         lines = emitter.fragments
         self.assert_lines([
             'PyObject *arg_x;',

--- a/mypyc/test/test_emitwrapper.py
+++ b/mypyc/test/test_emitwrapper.py
@@ -5,7 +5,7 @@ from mypy.test.helpers import assert_string_arrays_equal
 
 from mypyc.emit import Emitter, EmitterContext
 from mypyc.emitwrapper import generate_arg_check
-from mypyc.ops import list_rinstance, int_rinstance
+from mypyc.ops import list_rprimitive, int_rprimitive
 
 
 class TestArgCheck(unittest.TestCase):
@@ -14,7 +14,7 @@ class TestArgCheck(unittest.TestCase):
 
     def test_check_list(self) -> None:
         emitter = Emitter(self.context)
-        generate_arg_check('x', list_rinstance, emitter)
+        generate_arg_check('x', list_rprimitive, emitter)
         lines = emitter.fragments
         self.assert_lines([
             'PyObject *arg_x;',
@@ -29,7 +29,7 @@ class TestArgCheck(unittest.TestCase):
 
     def test_check_int(self) -> None:
         emitter = Emitter(self.context)
-        generate_arg_check('x', int_rinstance, emitter)
+        generate_arg_check('x', int_rprimitive, emitter)
         lines = emitter.fragments
         self.assert_lines([
             'CPyTagged arg_x;',

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -635,7 +635,7 @@ def f(o: Optional[A], n: int, t: Tuple[int, ...]) -> None:
 def f(o, n, t):
     o :: optional[A]
     n :: int
-    t :: sequence_tuple
+    t :: tuple
     a :: A
     m :: bool
     r0 :: object
@@ -677,7 +677,7 @@ def f(o, p, n, b, t, s, a, l, d):
     p :: optional[A]
     n :: int
     b :: bool
-    t :: sequence_tuple
+    t :: tuple
     s :: tuple[int, int]
     a :: A
     l :: list

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -489,7 +489,7 @@ def f() -> str:
     return "some string"
 [out]
 def f():
-    r0 :: unicode
+    r0 :: str
 L0:
     r0 = __unicode_0 :: static
     return r0
@@ -501,7 +501,7 @@ def f(x: List[int]) -> int:
 [out]
 def f(x):
     x :: list
-    r0 :: unicode
+    r0 :: str
     r1 :: object
     r2 :: int
 L0:

--- a/test-data/genops-tuple.test
+++ b/test-data/genops-tuple.test
@@ -50,7 +50,7 @@ def f(x: List[bool]) -> bool:
 [out]
 def f(x):
     x :: list
-    r0 :: sequence_tuple
+    r0 :: tuple
     r1 :: int
     r2 :: object
     r3 :: bool
@@ -67,7 +67,7 @@ def f(x: Tuple[int, ...]) -> int:
   return len(x)
 [out]
 def f(x):
-    x :: sequence_tuple
+    x :: tuple
     r0 :: int
 L0:
     r0 = len x :: sequence_tuple
@@ -80,7 +80,7 @@ def f() -> int:
     return t[1]
 [out]
 def f():
-    t :: sequence_tuple
+    t :: tuple
     r0 :: tuple[int, int]
     r1, r2, r3 :: int
     r4 :: object


### PR DESCRIPTION
Refactor various aspects of rtypes, including these:

* Create `RPrimitive` for primitive types and use it instead of separate
  classes for individual primitive types. Create predefined type objects
  such as `int_rinstance` which can be shared.
* Rename other rtypes: `UserRType` -> `RInstance`, `TupleRType` -> 
  `RTuple`, and `OptionalRType` -> `ROptional`.
* Turn some `RType` properties into methods so that it's clear that 
  some of them could perform nontrivial computation or fail.
* Turn some `RType` properties into attributes so that it's easier to
  vary them per-instance.
* Remove one level of inheritance.
* Rename `supports_unbox` into `is_unboxed`.
* Refactor various rtype name tests as they were error-prone and
  inconsistent.
* Use fully-qualified names such as `builtins.int`.
* Name of variable-length tuples is `builtins.tuple` instead of 
  `sequence_tuple` (for consistency).

Fixes #79.