### PR TITLE
Use unlikely() for error checks

### DIFF
--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -9,6 +9,9 @@
 extern "C" {
 #endif
 
+#define likely(x)       __builtin_expect((x),1)
+#define unlikely(x)     __builtin_expect((x),0)
+
 // Naming conventions:
 //
 // Tagged: tagged int

--- a/test-data/run-bench.test
+++ b/test-data/run-bench.test
@@ -50,6 +50,7 @@ def test(m):
 
 nsum, nsum2, nbuild = test(native)
 isum, isum2, ibuild = test(interpreted)
+print(nsum, nsum2, nbuild)
 print("Sum speedup:", isum/nsum)
 print("Sum method speedup:", isum2/nsum2)
 print("Build speedup:", ibuild/nbuild)


### PR DESCRIPTION
This gets a very modest speed win (~5%), but doesn't make the code
more complicated and might have bigger impacts for larger programs
where it might help keep the right code in L1 I$.
