### PR TITLE
Implement native method calls

### DIFF
--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -43,6 +43,9 @@ static void CPyDebug_Print(const char *msg) {
     ((bool (*)(object_type *, attr_type))((object_type *)obj)->vtable[vtable_index])( \
         (object_type *)obj, value)
 
+#define CPY_GET_METHOD(obj, vtable_index, object_type, method_type) \
+    ((method_type)(((object_type *)obj)->vtable[vtable_index]))
+
 static void CPyError_OutOfMemory(void) {
     fprintf(stderr, "fatal: out of memory\n");
     fflush(stderr);

--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -8,7 +8,7 @@ from mypyc.ops import (
     BasicBlock, OpVisitor, Assign, LoadInt, LoadErrorValue, RegisterOp, Goto,
     Branch, Return, Call, Environment, Box, Unbox, Cast, Op, Unreachable,
     TupleGet, TupleSet, GetAttr, SetAttr, PyCall, LoadStatic, PyGetAttr, Label, Register,
-    PyMethodCall, PrimitiveOp
+    PyMethodCall, PrimitiveOp, MethodCall,
 )
 
 
@@ -90,6 +90,9 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill]):
         return self.visit_register_op(op)
 
     def visit_py_call(self, op: PyCall) -> GenAndKill:
+        return self.visit_register_op(op)
+
+    def visit_method_call(self, op: MethodCall) -> GenAndKill:
         return self.visit_register_op(op)
 
     def visit_py_method_call(self, op: PyMethodCall) -> GenAndKill:

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -195,6 +195,8 @@ def generate_vtable(cl: ClassIR,
     for attr, rtype in cl.attributes:
         emitter.emit_line('(CPyVTableItem){},'.format(native_getter_name(cl.name, attr)))
         emitter.emit_line('(CPyVTableItem){},'.format(native_setter_name(cl.name, attr)))
+    for fn in cl.methods:
+        emitter.emit_line('(CPyVTableItem){}{},'.format(NATIVE_PREFIX, fn.cname))
     emitter.emit_line('};')
 
 

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -564,8 +564,8 @@ def g(y):
     r11 :: object
 L0:
     r0 = 1
-    r1 = box(int, r0)
-    r2 = g(r1)
+    r2 = box(int, r0)
+    r1 = g(r2)
     a = [y]
     r3 = 0
     r5 = 1

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -62,3 +62,33 @@ L0:
     r5 = 1
     r6 = r4 + r5 :: int
     return r6
+
+[case testMethodCall]
+class A:
+    def f(self, x: int, y: str) -> int:
+        return x + 10
+
+def g(a: A) -> None:
+    a.f(1, 'hi')
+[out]
+def f(self, x, y):
+    self :: A
+    x :: int
+    y :: str
+    r0, r1 :: int
+L0:
+    r0 = 10
+    r1 = x + r0 :: int
+    return r1
+def g(a):
+    a :: A
+    r0 :: int
+    r1 :: str
+    r2 :: int
+    r3 :: None
+L0:
+    r0 = 1
+    r1 = __unicode_0 :: static
+    r2 = a.f(r0, r1)
+    r3 = None
+    return r3


### PR DESCRIPTION
This is pretty straightforward: we just stick function pointers to the
native functions in the same vtable as we stick the accessors.

The tree benchmark now has the method benchmark running at ~14x
cpython.