### PR TITLE
Add support for equality of arbitrary objects

### DIFF
--- a/mypyc/emitwrapper.py
+++ b/mypyc/emitwrapper.py
@@ -2,7 +2,7 @@
 
 from mypyc.common import PREFIX, NATIVE_PREFIX
 from mypyc.emit import Emitter
-from mypyc.ops import FuncIR, RType
+from mypyc.ops import FuncIR, RType, is_object_rprimitive
 
 
 def wrapper_function_header(fn: FuncIR) -> str:
@@ -67,6 +67,9 @@ def generate_arg_check(name: str, typ: RType, emitter: Emitter) -> None:
         # Borrow when unboxing to avoid reference count manipulation.
         emitter.emit_unbox('obj_{}'.format(name), 'arg_{}'.format(name), typ,
                            'return NULL;', declare_dest=True, borrow=True)
+    elif is_object_rprimitive(typ):
+        # Trivial, since any object is valid.
+        emitter.emit_line('PyObject *arg_{} = obj_{};'.format(name, name))
     else:
         emitter.emit_cast('obj_{}'.format(name), 'arg_{}'.format(name), typ,
                           declare_dest=True)

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -832,7 +832,8 @@ OpDescription = NamedTuple(
                       ('is_var_arg', bool),
                       ('error_kind', int),
                       ('format_str', str),
-                      ('emit', EmitCallback)])
+                      ('emit', EmitCallback),
+                      ('priority', int)])  # To resolve ambiguities, highest priority wins
 
 
 class PrimitiveOp(RegisterOp):

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -2,8 +2,11 @@
 
 from typing import List
 
-from mypyc.ops import EmitterInterface, PrimitiveOp, none_rprimitive, bool_rprimitive, ERR_NEVER
-from mypyc.ops_primitive import name_ref_op, simple_emit
+from mypyc.ops import (
+    EmitterInterface, PrimitiveOp, none_rprimitive, bool_rprimitive, object_rprimitive, ERR_NEVER,
+    ERR_MAGIC
+)
+from mypyc.ops_primitive import name_ref_op, simple_emit, binary_op
 
 
 def emit_none(emitter: EmitterInterface, args: List[str], dest: str) -> None:
@@ -27,3 +30,17 @@ false_op = name_ref_op('builtins.False',
                        result_type=bool_rprimitive,
                        error_kind=ERR_NEVER,
                        emit=simple_emit('{dest} = 0;'))
+
+
+for op, opid in [('==', 'Py_EQ'),
+                 ('!=', 'Py_NE'),
+                 ('<', 'Py_LT'),
+                 ('<=', 'Py_LE'),
+                 ('>', 'Py_GT'),
+                 ('>=', 'Py_GE')]:
+    # The result type is 'object' since that's what PyObject_RichCompare returns.
+    binary_op(op=op,
+              arg_types=[object_rprimitive, object_rprimitive],
+              result_type=object_rprimitive,
+              error_kind=ERR_MAGIC,
+              emit=simple_emit('{dest} = PyObject_RichCompare({args[0]}, {args[1]}, %s);' % opid))

--- a/test-data/fixtures/ir.py
+++ b/test-data/fixtures/ir.py
@@ -8,6 +8,8 @@ S = TypeVar('S')
 
 class object:
     def __init__(self) -> None: pass
+    def __eq__(self, x: object) -> bool: pass
+    def __ne__(self, x: object) -> bool: pass
 
 class type: pass
 
@@ -21,8 +23,8 @@ class int:
     def __mod__(self, x: int) -> int: pass
     def __neg__(self) -> int: pass
     def __pos__(self) -> int: pass
-    def __eq__(self, n: int) -> bool: pass
-    def __ne__(self, n: int) -> bool: pass
+    def __eq__(self, n: object) -> bool: pass
+    def __ne__(self, n: object) -> bool: pass
     def __lt__(self, n: int) -> bool: pass
     def __gt__(self, n: int) -> bool: pass
     def __le__(self, n: int) -> bool: pass
@@ -31,6 +33,8 @@ class int:
 class str:
     def __init__(self, x: object) -> None: pass
     def __add__(self, x: str) -> str: pass
+    def __eq__(self, x: object) -> bool: pass
+    def __ne__(self, x: object) -> bool: pass
 
 class float: pass
 class bool: pass

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -302,12 +302,22 @@ def tostr(x: int) -> str:
     return str(x)
 def concat(x: str, y: str) -> str:
     return x + y
+def eq(x: str) -> int:
+    if x == 'foo':
+        return 0
+    elif x != 'bar':
+        return 1
+    return 2
+
 [file driver.py]
-from native import f, g, tostr, concat
+from native import f, g, tostr, concat, eq
 assert f() == 'some string'
 assert g() == 'some\a \v \t \x7f " \n \0string 🐍'
 assert tostr(57) == '57'
 assert concat('foo', 'bar') == 'foobar'
+assert eq('foo') == 0
+assert eq('zar') == 1
+assert eq('bar') == 2
 
 [case testDictUpdate]
 from typing import Dict
@@ -364,3 +374,29 @@ Traceback (most recent call last):
   File "tmp/py/native.py", line 6, in g
     x[5] = 2
 IndexError: list assignment index out of range
+
+[case testGenericEquality]
+def eq(a: object, b: object) -> bool:
+    if a == b:
+        return True
+    else:
+        return False
+def ne(a: object, b: object) -> bool:
+    if a != b:
+        return True
+    else:
+        return False
+def f(o: object) -> bool:
+    if [1, 2] == o:
+        return True
+    else:
+        return False
+[file driver.py]
+from native import eq, ne, f
+assert eq('xz', 'x' + 'z')
+assert not eq('x', 'y')
+assert not ne('xz', 'x' + 'z')
+assert ne('x', 'y')
+assert f([1, 2])
+assert not f([2, 2])
+assert not f(1)


### PR DESCRIPTION
Special case string equality. Add priorities to binary ops to
handle cases where multiple ops are possible.

Also clean up binary operation target handling, as it was inconsistent.

Fixes #9.