### PR TITLE
Overhaul the IR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ test_capi
 
 /env
 /env-debug
+/env-3.5
 /.mypy_cache
 /.cache
 /.pytest_cache

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -43,6 +43,9 @@ static void CPyDebug_Print(const char *msg) {
     ((bool (*)(object_type *, attr_type))((object_type *)obj)->vtable[vtable_index])( \
         (object_type *)obj, value)
 
+#define CPY_GET_METHOD(obj, vtable_index, object_type, method_type) \
+    ((method_type)(((object_type *)obj)->vtable[vtable_index]))
+
 static void CPyError_OutOfMemory(void) {
     fprintf(stderr, "fatal: out of memory\n");
     fflush(stderr);

--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -8,7 +8,7 @@ from mypyc.ops import (
     BasicBlock, OpVisitor, Assign, LoadInt, LoadErrorValue, RegisterOp, Goto,
     Branch, Return, Call, Environment, Box, Unbox, Cast, Op, Unreachable,
     TupleGet, TupleSet, GetAttr, SetAttr, PyCall, LoadStatic, PyGetAttr, Label, Register,
-    PyMethodCall, PrimitiveOp
+    PyMethodCall, PrimitiveOp, MethodCall,
 )
 
 
@@ -90,6 +90,9 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill]):
         return self.visit_register_op(op)
 
     def visit_py_call(self, op: PyCall) -> GenAndKill:
+        return self.visit_register_op(op)
+
+    def visit_method_call(self, op: MethodCall) -> GenAndKill:
         return self.visit_register_op(op)
 
     def visit_py_method_call(self, op: PyMethodCall) -> GenAndKill:

--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -278,9 +278,7 @@ def analyze_undefined_regs(blocks: List[BasicBlock],
     A register is undefined if there is some path from initial block
     where it has an undefined value.
     """
-    initial_undefined = {reg
-                         for reg in env.regs()
-                         if reg not in initial_defined}
+    initial_undefined = set(env.regs()) - initial_defined
     return run_analysis(blocks=blocks,
                         cfg=cfg,
                         gen_and_kill=UndefinedVisitor(),

--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -2,7 +2,7 @@
 
 from abc import abstractmethod
 
-from typing import Dict, Tuple, List, Set, TypeVar, Iterator, Generic, Optional
+from typing import Dict, Tuple, List, Set, TypeVar, Iterator, Generic, Optional, Iterable
 
 from mypyc.ops import (
     Register, CRegister,
@@ -194,7 +194,7 @@ def analyze_must_defined_regs(
         blocks: List[BasicBlock],
         cfg: CFG,
         initial_defined: Set[Register],
-        num_regs: int) -> AnalysisResult[Register]:
+        regs: Iterable[Register]) -> AnalysisResult[Register]:
     """Calculate always defined registers at each CFG location.
 
     A register is defined if it has a value along all paths from the initial location.
@@ -205,7 +205,7 @@ def analyze_must_defined_regs(
                         initial=initial_defined,
                         backward=False,
                         kind=MUST_ANALYSIS,
-                        universe=set([CRegister(r) for r in range(num_regs)]))
+                        universe=set(regs))
 
 
 class BorrowedArgumentsVisitor(BaseAnalysisVisitor):
@@ -267,9 +267,9 @@ def analyze_undefined_regs(blocks: List[BasicBlock],
     A register is undefined if there is some path from initial block
     where it has an undefined value.
     """
-    initial_undefined = {CRegister(reg)
-                         for reg in range(len(env.names))
-                         if CRegister(reg) not in initial_defined}  # type: Set[Register]
+    initial_undefined = {reg
+                         for reg in env.names.keys()
+                         if reg not in initial_defined}
     return run_analysis(blocks=blocks,
                         cfg=cfg,
                         gen_and_kill=UndefinedVisitor(),

--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -279,7 +279,7 @@ def analyze_undefined_regs(blocks: List[BasicBlock],
     where it has an undefined value.
     """
     initial_undefined = {reg
-                         for reg in env.names.keys()
+                         for reg in env.regs()
                          if reg not in initial_defined}
     return run_analysis(blocks=blocks,
                         cfg=cfg,

--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -151,8 +151,8 @@ class MaybeDefinedVisitor(BaseAnalysisVisitor):
         return set(), set()
 
     def visit_register_op(self, op: RegisterOp) -> GenAndKill:
-        if op.dest is not None:
-            return {op.dest}, set()
+        if not op.is_void:
+            return {op}, set()
         else:
             return set(), set()
 
@@ -188,8 +188,8 @@ class MustDefinedVisitor(BaseAnalysisVisitor):
         return set(), set()
 
     def visit_register_op(self, op: RegisterOp) -> GenAndKill:
-        if op.dest is not None:
-            return {op.dest}, set()
+        if not op.is_void:
+            return {op}, set()
         else:
             return set(), set()
 
@@ -264,7 +264,7 @@ class UndefinedVisitor(BaseAnalysisVisitor):
         return set(), set()
 
     def visit_register_op(self, op: RegisterOp) -> GenAndKill:
-        return set(), {op.dest} if op.dest is not None else set()
+        return set(), {op} if not op.is_void else set()
 
     def visit_assign(self, op: Assign) -> GenAndKill:
         return set(), {op.target}
@@ -301,8 +301,8 @@ class LivenessVisitor(BaseAnalysisVisitor):
 
     def visit_register_op(self, op: RegisterOp) -> GenAndKill:
         gen = set(op.sources())
-        if op.dest is not None:
-            return gen, {op.dest}
+        if not op.is_void:
+            return gen, {op}
         else:
             return gen, set()
 

--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -157,7 +157,7 @@ class MaybeDefinedVisitor(BaseAnalysisVisitor):
             return set(), set()
 
     def visit_assign(self, op: Assign) -> GenAndKill:
-        return {op.target}, set()
+        return {op.dest}, set()
 
 
 def analyze_maybe_defined_regs(blocks: List[BasicBlock],
@@ -194,7 +194,7 @@ class MustDefinedVisitor(BaseAnalysisVisitor):
             return set(), set()
 
     def visit_assign(self, op: Assign) -> GenAndKill:
-        return {op.target}, set()
+        return {op.dest}, set()
 
 
 def analyze_must_defined_regs(
@@ -232,8 +232,8 @@ class BorrowedArgumentsVisitor(BaseAnalysisVisitor):
         return set(), set()
 
     def visit_assign(self, op: Assign) -> GenAndKill:
-        if op.target in self.args:
-            return set(), {op.target}
+        if op.dest in self.args:
+            return set(), {op.dest}
         return set(), set()
 
 def analyze_borrowed_arguments(
@@ -267,7 +267,7 @@ class UndefinedVisitor(BaseAnalysisVisitor):
         return set(), {op} if not op.is_void else set()
 
     def visit_assign(self, op: Assign) -> GenAndKill:
-        return set(), {op.target}
+        return set(), {op.dest}
 
 def analyze_undefined_regs(blocks: List[BasicBlock],
                            cfg: CFG,
@@ -307,7 +307,7 @@ class LivenessVisitor(BaseAnalysisVisitor):
             return gen, set()
 
     def visit_assign(self, op: Assign) -> GenAndKill:
-        return set(op.sources()), {op.target}
+        return set(op.sources()), {op.dest}
 
 
 def analyze_live_regs(blocks: List[BasicBlock],

--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -5,9 +5,10 @@ from abc import abstractmethod
 from typing import Dict, Tuple, List, Set, TypeVar, Iterator, Generic, Optional
 
 from mypyc.ops import (
+    Register, CRegister,
     BasicBlock, OpVisitor, Assign, LoadInt, LoadErrorValue, RegisterOp, Goto,
     Branch, Return, Call, Environment, Box, Unbox, Cast, Op, Unreachable,
-    TupleGet, TupleSet, GetAttr, SetAttr, PyCall, LoadStatic, PyGetAttr, Label, Register,
+    TupleGet, TupleSet, GetAttr, SetAttr, PyCall, LoadStatic, PyGetAttr, Label,
     PyMethodCall, PrimitiveOp, MethodCall,
 )
 
@@ -204,7 +205,7 @@ def analyze_must_defined_regs(
                         initial=initial_defined,
                         backward=False,
                         kind=MUST_ANALYSIS,
-                        universe=set([Register(r) for r in range(num_regs)]))
+                        universe=set([CRegister(r) for r in range(num_regs)]))
 
 
 class BorrowedArgumentsVisitor(BaseAnalysisVisitor):
@@ -266,9 +267,9 @@ def analyze_undefined_regs(blocks: List[BasicBlock],
     A register is undefined if there is some path from initial block
     where it has an undefined value.
     """
-    initial_undefined = {Register(reg)
+    initial_undefined = {CRegister(reg)
                          for reg in range(len(env.names))
-                         if Register(reg) not in initial_defined}
+                         if CRegister(reg) not in initial_defined}  # type: Set[Register]
     return run_analysis(blocks=blocks,
                         cfg=cfg,
                         gen_and_kill=UndefinedVisitor(),

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -5,7 +5,7 @@ from typing import List, Set, Dict, Optional
 
 from mypyc.common import REG_PREFIX
 from mypyc.ops import (
-    Environment, Label, Register, RType, RTuple, RInstance, ROptional,
+    Environment, Label, Register, CRegister, RType, RTuple, RInstance, ROptional,
     RPrimitive, type_struct_name, is_int_rprimitive, is_bool_rprimitive, short_name,
     is_list_rprimitive, is_dict_rprimitive, is_tuple_rprimitive, is_none_rprimitive,
     object_rprimitive

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -5,7 +5,7 @@ from typing import List, Set, Dict, Optional
 
 from mypyc.common import REG_PREFIX
 from mypyc.ops import (
-    Environment, Label, Register, CRegister, RType, RTuple, RInstance, ROptional,
+    Environment, Label, Value, Register, RType, RTuple, RInstance, ROptional,
     RPrimitive, type_struct_name, is_int_rprimitive, is_bool_rprimitive, short_name,
     is_list_rprimitive, is_dict_rprimitive, is_tuple_rprimitive, is_none_rprimitive,
     object_rprimitive, is_str_rprimitive
@@ -51,7 +51,7 @@ class Emitter:
     def label(self, label: Label) -> str:
         return 'CPyL%d' % label
 
-    def reg(self, reg: Register) -> str:
+    def reg(self, reg: Value) -> str:
         name = self.env.names[reg]
         return REG_PREFIX + name
 

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -52,8 +52,7 @@ class Emitter:
         return 'CPyL%d' % label
 
     def reg(self, reg: Value) -> str:
-        name = self.env.names[reg]
-        return REG_PREFIX + name
+        return REG_PREFIX + reg.name
 
     def emit_line(self, line: str = '') -> None:
         if line.startswith('}'):

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -195,6 +195,8 @@ def generate_vtable(cl: ClassIR,
     for attr, rtype in cl.attributes:
         emitter.emit_line('(CPyVTableItem){},'.format(native_getter_name(cl.name, attr)))
         emitter.emit_line('(CPyVTableItem){},'.format(native_setter_name(cl.name, attr)))
+    for fn in cl.methods:
+        emitter.emit_line('(CPyVTableItem){}{},'.format(NATIVE_PREFIX, fn.cname))
     emitter.emit_line('};')
 
 

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -210,7 +210,8 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         dest = self.reg(op.dest)
         src = self.reg(op.src)
         self.emit_line('{} = {}.f{};'.format(dest, src, op.index))
-        self.emit_inc_ref(dest, op.target_type)
+        assert op.type is not None
+        self.emit_inc_ref(dest, op.type)
 
     def get_dest_assign(self, dest: Optional[Register]) -> str:
         if dest is not None:
@@ -266,7 +267,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         self.emitter.emit_box(self.reg(op.src), self.reg(op.dest), op.src_type)
 
     def visit_cast(self, op: Cast) -> None:
-        self.emitter.emit_cast(self.reg(op.src), self.reg(op.dest), op.typ)
+        self.emitter.emit_cast(self.reg(op.src), self.reg(op.dest), op.type)
 
     def visit_unbox(self, op: Unbox) -> None:
         assert op.type is not None

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -41,7 +41,7 @@ def generate_native_function(fn: FuncIR, emitter: Emitter, source_path: str) -> 
     for r, i in fn.env.indexes.items():
         if i < len(fn.args):
             continue  # skip the arguments
-        ctype = fn.env.types[r].ctype
+        ctype = r.type.ctype
         declarations.emit_line('{ctype} {prefix}{name};'.format(ctype=ctype,
                                                                 prefix=REG_PREFIX,
                                                                 name=r.name))
@@ -95,7 +95,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
             compare = '!=' if op.negated else '=='
             cond = '{} {} Py_None'.format(self.reg(op.left), compare)
         elif op.op == Branch.IS_ERROR:
-            typ = self.env.types[op.left]
+            typ = op.left.type
             compare = '!=' if op.negated else '=='
             if isinstance(typ, RTuple):
                 # TODO: What about empty tuple?
@@ -130,7 +130,6 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         )
 
     def visit_return(self, op: Return) -> None:
-        typ = self.type(op.reg)
         regstr = self.reg(op.reg)
         self.emit_line('return %s;' % regstr)
 
@@ -280,9 +279,6 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
 
     def reg(self, reg: Value) -> str:
         return self.emitter.reg(reg)
-
-    def type(self, reg: Value) -> RType:
-        return self.env.types[reg]
 
     def emit_line(self, line: str) -> None:
         self.emitter.emit_line(line)

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -7,7 +7,7 @@ from mypyc.emit import Emitter
 from mypyc.ops import (
     FuncIR, OpVisitor, Goto, Branch, Return, Assign, LoadInt, LoadErrorValue, GetAttr,
     SetAttr, LoadStatic, TupleGet, TupleSet, Call, PyCall, PyGetAttr, IncRef, DecRef, Box, Cast,
-    Unbox, Label, Register, RType, RTuple, MethodCall, PyMethodCall,
+    Unbox, Label, Register, CRegister, RType, RTuple, MethodCall, PyMethodCall,
     PrimitiveOp, EmitterInterface,
 )
 
@@ -39,10 +39,11 @@ def generate_native_function(fn: FuncIR, emitter: Emitter, source_path: str) -> 
     body.indent()
 
     for i in range(len(fn.args), fn.env.num_regs()):
-        ctype = fn.env.types[i].ctype
+        r = CRegister(i)
+        ctype = fn.env.types[r].ctype
         declarations.emit_line('{ctype} {prefix}{name};'.format(ctype=ctype,
                                                                 prefix=REG_PREFIX,
-                                                                name=fn.env.names[i]))
+                                                                name=fn.env.names[r]))
 
     for block in fn.blocks:
         body.emit_label(block.label)

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -7,7 +7,7 @@ from mypyc.emit import Emitter
 from mypyc.ops import (
     FuncIR, OpVisitor, Goto, Branch, Return, Assign, LoadInt, LoadErrorValue, GetAttr,
     SetAttr, LoadStatic, TupleGet, TupleSet, Call, PyCall, PyGetAttr, IncRef, DecRef, Box, Cast,
-    Unbox, Label, Register, CRegister, RType, RTuple, MethodCall, PyMethodCall,
+    Unbox, Label, Value, Register, RType, RTuple, MethodCall, PyMethodCall,
     PrimitiveOp, EmitterInterface,
 )
 
@@ -213,7 +213,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         assert op.type is not None
         self.emit_inc_ref(dest, op.type)
 
-    def get_dest_assign(self, dest: Optional[Register]) -> str:
+    def get_dest_assign(self, dest: Optional[Value]) -> str:
         if dest is not None:
             return self.reg(dest) + ' = '
         else:
@@ -278,10 +278,10 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
     def label(self, label: Label) -> str:
         return self.emitter.label(label)
 
-    def reg(self, reg: Register) -> str:
+    def reg(self, reg: Value) -> str:
         return self.emitter.reg(reg)
 
-    def type(self, reg: Register) -> RType:
+    def type(self, reg: Value) -> RType:
         return self.env.types[reg]
 
     def emit_line(self, line: str) -> None:

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -38,13 +38,13 @@ def generate_native_function(fn: FuncIR, emitter: Emitter, source_path: str) -> 
     declarations.emit_line('{} {{'.format(native_function_header(fn)))
     body.indent()
 
-    for r in fn.env.names.keys():
-        if fn.env.indexes[r] < len(fn.args):
+    for r, i in fn.env.indexes.items():
+        if i < len(fn.args):
             continue  # skip the arguments
         ctype = fn.env.types[r].ctype
         declarations.emit_line('{ctype} {prefix}{name};'.format(ctype=ctype,
                                                                 prefix=REG_PREFIX,
-                                                                name=fn.env.names[r]))
+                                                                name=r.name))
 
     for block in fn.blocks:
         body.emit_label(block.label)

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -254,11 +254,11 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
 
     def visit_inc_ref(self, op: IncRef) -> None:
         src = self.reg(op.src)
-        self.emit_inc_ref(src, op.target_type)
+        self.emit_inc_ref(src, op.src.type)
 
     def visit_dec_ref(self, op: DecRef) -> None:
         src = self.reg(op.src)
-        self.emit_dec_ref(src, op.target_type)
+        self.emit_dec_ref(src, op.src.type)
 
     def visit_box(self, op: Box) -> None:
         self.emitter.emit_box(self.reg(op.src), self.reg(op), op.src.type)

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -154,8 +154,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         self.emit_inc_ref(dest, tuple_type)
 
     def visit_assign(self, op: Assign) -> None:
-        assert op.dest is not None
-        dest = self.reg(op.dest)
+        dest = self.reg(op.target)
         src = self.reg(op.src)
         self.emit_line('%s = %s;' % (dest, src))
 

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -154,7 +154,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         self.emit_inc_ref(dest, tuple_type)
 
     def visit_assign(self, op: Assign) -> None:
-        dest = self.reg(op.target)
+        dest = self.reg(op.dest)
         src = self.reg(op.src)
         self.emit_line('%s = %s;' % (dest, src))
 

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -154,6 +154,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         self.emit_inc_ref(dest, tuple_type)
 
     def visit_assign(self, op: Assign) -> None:
+        assert op.dest is not None
         dest = self.reg(op.dest)
         src = self.reg(op.src)
         self.emit_line('%s = %s;' % (dest, src))
@@ -256,12 +257,12 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
             dest, obj, method, args))
 
     def visit_inc_ref(self, op: IncRef) -> None:
-        dest = self.reg(op.dest)
-        self.emit_inc_ref(dest, op.target_type)
+        src = self.reg(op.src)
+        self.emit_inc_ref(src, op.target_type)
 
     def visit_dec_ref(self, op: DecRef) -> None:
-        dest = self.reg(op.dest)
-        self.emit_dec_ref(dest, op.target_type)
+        src = self.reg(op.src)
+        self.emit_dec_ref(src, op.target_type)
 
     def visit_box(self, op: Box) -> None:
         self.emitter.emit_box(self.reg(op.src), self.reg(op.dest), op.src_type)

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -261,7 +261,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         self.emit_dec_ref(src, op.target_type)
 
     def visit_box(self, op: Box) -> None:
-        self.emitter.emit_box(self.reg(op.src), self.reg(op), op.src_type)
+        self.emitter.emit_box(self.reg(op.src), self.reg(op), op.src.type)
 
     def visit_cast(self, op: Cast) -> None:
         self.emitter.emit_cast(self.reg(op.src), self.reg(op), op.type)

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -136,8 +136,8 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
 
     def visit_primitive_op(self, op: PrimitiveOp) -> None:
         args = [self.reg(arg) for arg in op.args]
-        if op.dest is not None:
-            dest = self.reg(op.dest)
+        if not op.is_void:
+            dest = self.reg(op)
         else:
             # This will generate a C compile error if used. The reason for this
             # is that we don't want to insert "assert dest is not None" checks
@@ -146,7 +146,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         op.desc.emit(self, args, dest)
 
     def visit_tuple_set(self, op: TupleSet) -> None:
-        dest = self.reg(op.dest)
+        dest = self.reg(op)
         tuple_type = op.tuple_type
         self.emitter.declare_tuple_struct(tuple_type)
         for i, item in enumerate(op.items):
@@ -159,7 +159,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         self.emit_line('%s = %s;' % (dest, src))
 
     def visit_load_int(self, op: LoadInt) -> None:
-        dest = self.reg(op.dest)
+        dest = self.reg(op)
         self.emit_line('%s = %d;' % (dest, op.value * 2))
 
     def visit_load_error_value(self, op: LoadErrorValue) -> None:
@@ -167,14 +167,14 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
             values = [item.c_undefined_value() for item in op.type.types]
             tmp = self.temp_name()
             self.emit_line('%s %s = { %s };' % (op.type.ctype, tmp, ', '.join(values)))
-            self.emit_line('%s = %s;' % (self.reg(op.dest), tmp))
+            self.emit_line('%s = %s;' % (self.reg(op), tmp))
         else:
             assert op.type is not None
-            self.emit_line('%s = %s;' % (self.reg(op.dest),
+            self.emit_line('%s = %s;' % (self.reg(op),
                                          op.type.c_error_value()))
 
     def visit_get_attr(self, op: GetAttr) -> None:
-        dest = self.reg(op.dest)
+        dest = self.reg(op)
         obj = self.reg(op.obj)
         rtype = op.class_type
         self.emit_line('%s = CPY_GET_ATTR(%s, %d, %s, %s);' % (
@@ -184,7 +184,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
             rtype.attr_type(op.attr).ctype))
 
     def visit_set_attr(self, op: SetAttr) -> None:
-        dest = self.reg(op.dest)
+        dest = self.reg(op)
         obj = self.reg(op.obj)
         src = self.reg(op.src)
         rtype = op.class_type
@@ -198,34 +198,34 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
             rtype.attr_type(op.attr).ctype))
 
     def visit_load_static(self, op: LoadStatic) -> None:
-        dest = self.reg(op.dest)
+        dest = self.reg(op)
         self.emit_line('%s = %s;' % (dest, op.identifier))
 
     def visit_py_get_attr(self, op: PyGetAttr) -> None:
-        dest = self.reg(op.dest)
+        dest = self.reg(op)
         left = self.reg(op.left)
         self.emit_line('{} = CPyObject_GetAttrString({}, "{}");'.format(dest, left, op.right))
 
     def visit_tuple_get(self, op: TupleGet) -> None:
-        dest = self.reg(op.dest)
+        dest = self.reg(op)
         src = self.reg(op.src)
         self.emit_line('{} = {}.f{};'.format(dest, src, op.index))
         assert op.type is not None
         self.emit_inc_ref(dest, op.type)
 
-    def get_dest_assign(self, dest: Optional[Value]) -> str:
-        if dest is not None:
+    def get_dest_assign(self, dest: Value) -> str:
+        if not dest.is_void:
             return self.reg(dest) + ' = '
         else:
             return ''
 
     def visit_call(self, op: Call) -> None:
-        dest = self.get_dest_assign(op.dest)
+        dest = self.get_dest_assign(op)
         args = ', '.join(self.reg(arg) for arg in op.args)
         self.emit_line('%s%s%s(%s);' % (dest, NATIVE_PREFIX, op.fn, args))
 
     def visit_method_call(self, op: MethodCall) -> None:
-        dest = self.get_dest_assign(op.dest)
+        dest = self.get_dest_assign(op)
         obj = self.reg(op.obj)
 
         rtype = op.receiver_type
@@ -238,7 +238,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
             dest, obj, method_idx, rtype.struct_name(), mtype, args))
 
     def visit_py_call(self, op: PyCall) -> None:
-        dest = self.get_dest_assign(op.dest)
+        dest = self.get_dest_assign(op)
         function = self.reg(op.function)
         args = ', '.join(self.reg(arg) for arg in op.args)
         if args:
@@ -246,7 +246,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         self.emit_line('{}PyObject_CallFunctionObjArgs({}, {}NULL);'.format(dest, function, args))
 
     def visit_py_method_call(self, op: PyMethodCall) -> None:
-        dest = self.get_dest_assign(op.dest)
+        dest = self.get_dest_assign(op)
         obj = self.reg(op.obj)
         method = self.reg(op.method)
         args = ', '.join(self.reg(arg) for arg in op.args)
@@ -264,14 +264,14 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         self.emit_dec_ref(src, op.target_type)
 
     def visit_box(self, op: Box) -> None:
-        self.emitter.emit_box(self.reg(op.src), self.reg(op.dest), op.src_type)
+        self.emitter.emit_box(self.reg(op.src), self.reg(op), op.src_type)
 
     def visit_cast(self, op: Cast) -> None:
-        self.emitter.emit_cast(self.reg(op.src), self.reg(op.dest), op.type)
+        self.emitter.emit_cast(self.reg(op.src), self.reg(op), op.type)
 
     def visit_unbox(self, op: Unbox) -> None:
         assert op.type is not None
-        self.emitter.emit_unbox(self.reg(op.src), self.reg(op.dest), op.type)
+        self.emitter.emit_unbox(self.reg(op.src), self.reg(op), op.type)
 
     # Helpers
 

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -168,7 +168,6 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
             self.emit_line('%s %s = { %s };' % (op.type.ctype, tmp, ', '.join(values)))
             self.emit_line('%s = %s;' % (self.reg(op), tmp))
         else:
-            assert op.type is not None
             self.emit_line('%s = %s;' % (self.reg(op),
                                          op.type.c_error_value()))
 
@@ -209,7 +208,6 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         dest = self.reg(op)
         src = self.reg(op.src)
         self.emit_line('{} = {}.f{};'.format(dest, src, op.index))
-        assert op.type is not None
         self.emit_inc_ref(dest, op.type)
 
     def get_dest_assign(self, dest: Value) -> str:
@@ -269,7 +267,6 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         self.emitter.emit_cast(self.reg(op.src), self.reg(op), op.type)
 
     def visit_unbox(self, op: Unbox) -> None:
-        assert op.type is not None
         self.emitter.emit_unbox(self.reg(op.src), self.reg(op), op.type)
 
     # Helpers

--- a/mypyc/exceptions.py
+++ b/mypyc/exceptions.py
@@ -34,10 +34,10 @@ def insert_exception_handling(ir: FuncIR) -> None:
 
 def add_handler_block(ir: FuncIR) -> Label:
     block = BasicBlock(Label(len(ir.blocks)))
-    rtype = ir.ret_type
-    reg = ir.env.add_temp(rtype)
-    block.ops.append(LoadErrorValue(reg, rtype))
-    block.ops.append(Return(reg))
+    op = LoadErrorValue(ir.ret_type)
+    block.ops.append(op)
+    ir.env.add_op(op)
+    block.ops.append(Return(op))
     ir.blocks.append(block)
     return block.label
 

--- a/mypyc/exceptions.py
+++ b/mypyc/exceptions.py
@@ -73,9 +73,9 @@ def split_blocks_at_errors(blocks: List[BasicBlock],
 
                 # Void ops can't generate errors since error is always
                 # indicated by a special value stored in a register.
-                assert op.dest is not None, op
+                assert not op.is_void, "void op generating errors?"
 
-                branch = Branch(op.dest, INVALID_VALUE,
+                branch = Branch(op, INVALID_VALUE,
                                 true_label=error_label,
                                 false_label=Label(new_block.label + 1),
                                 op=variant,

--- a/mypyc/exceptions.py
+++ b/mypyc/exceptions.py
@@ -13,7 +13,7 @@ from typing import Optional, List
 
 from mypyc.ops import (
     FuncIR, BasicBlock, Label, LoadErrorValue, Return, Goto, Branch, ERR_NEVER, ERR_MAGIC,
-    ERR_FALSE, INVALID_REGISTER, RegisterOp
+    ERR_FALSE, INVALID_VALUE, RegisterOp
 )
 
 
@@ -75,7 +75,7 @@ def split_blocks_at_errors(blocks: List[BasicBlock],
                 # indicated by a special value stored in a register.
                 assert op.dest is not None, op
 
-                branch = Branch(op.dest, INVALID_REGISTER,
+                branch = Branch(op.dest, INVALID_VALUE,
                                 true_label=error_label,
                                 false_label=Label(new_block.label + 1),
                                 op=variant,

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -917,14 +917,12 @@ class IRBuilder(NodeVisitor[Register]):
         tuple_type = self.node_type(expr)
         assert isinstance(tuple_type, RTuple)
 
-        target = self.alloc_target(tuple_type)
         items = []
         for item_expr, item_type in zip(expr.items, tuple_type.types):
             reg = self.accept(item_expr)
             reg = self.coerce(reg, self.environment.types[reg], item_type, item_expr.line)
             items.append(reg)
-        self.add(TupleSet(target, items, tuple_type, expr.line))
-        return target
+        return self.add(TupleSet(items, tuple_type, expr.line))
 
     def visit_dict_expr(self, expr: DictExpr) -> Register:
         assert not expr.items  # TODO

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -364,8 +364,7 @@ class IRBuilder(NodeVisitor[Value]):
             rvalue_reg = self.accept(rvalue)
             if needs_box:
                 rvalue_reg = self.box(rvalue_reg)
-            return self.add(SetAttr(target.obj, target.attr, rvalue_reg, target.obj_type,
-                                    rvalue.line))
+            return self.add(SetAttr(target.obj, target.attr, rvalue_reg, rvalue.line))
         elif isinstance(target, AssignmentTargetIndex):
             item = self.accept(rvalue)
 
@@ -673,10 +672,8 @@ class IRBuilder(NodeVisitor[Value]):
             return self.load_static_module_attr(expr)
 
         else:
-            obj_reg = self.accept(expr.expr)
-            obj_type = self.node_type(expr.expr)
-            assert isinstance(obj_type, RInstance), 'Attribute access not supported: %s' % obj_type
-            return self.add(GetAttr(obj_reg, expr.name, obj_type, expr.line))
+            obj = self.accept(expr.expr)
+            return self.add(GetAttr(obj, expr.name, expr.line))
 
     def load_static_module_attr(self, expr: RefExpr) -> Value:
         assert expr.node, "RefExpr not resolved"

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -100,7 +100,7 @@ class AssignmentTarget(object):
 
 
 class AssignmentTargetRegister(AssignmentTarget):
-    """Value as assignment target"""
+    """Register as assignment target"""
 
     def __init__(self, register: Register) -> None:
         self.register = register
@@ -311,7 +311,7 @@ class IRBuilder(NodeVisitor[Value]):
             rreg = self.accept(stmt.rvalue)
             res = self.binary_op(ltype, target.register, rtype, rreg, stmt.op, stmt.line)
             self.add(Assign(target.register, res))
-            return INVALID_VALUE  # XXX: is this right?
+            return INVALID_VALUE
 
         # NOTE: List index not supported yet for compound assignments.
         assert False, 'Unsupported lvalue: %r'

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -497,8 +497,7 @@ class IRBuilder(NodeVisitor[Register]):
             end_goto.label = end_block.label
 
             # Increment index register.
-            one_reg = self.alloc_temp(int_rprimitive)
-            self.add(LoadInt(one_reg, 1))
+            one_reg = self.add(LoadInt(1))
             self.binary_op(int_rprimitive, index_reg, int_rprimitive, one_reg, '+', s.line,
                            target=index_reg)
 
@@ -515,11 +514,9 @@ class IRBuilder(NodeVisitor[Register]):
 
             expr_reg = self.accept(s.expr)
 
-            index_reg = self.alloc_temp(int_rprimitive)
-            self.add(LoadInt(index_reg, 0))
+            index_reg = self.add(LoadInt(0))
 
-            one_reg = self.alloc_temp(int_rprimitive)
-            self.add(LoadInt(one_reg, 1))
+            one_reg = self.add(LoadInt(1))
 
             assert isinstance(s.index, NameExpr)
             assert isinstance(s.index.node, Var)
@@ -641,9 +638,7 @@ class IRBuilder(NodeVisitor[Register]):
         assert False, 'Unsupported indexing operation'
 
     def visit_int_expr(self, expr: IntExpr) -> Register:
-        reg = self.alloc_target(int_rprimitive)
-        self.add(LoadInt(reg, expr.value))
-        return reg
+        return self.add(LoadInt(expr.value))
 
     def is_native_name_expr(self, expr: NameExpr) -> bool:
         # TODO later we want to support cross-module native calls too
@@ -792,9 +787,7 @@ class IRBuilder(NodeVisitor[Register]):
             expr_rtype = arg_types[0]
             if isinstance(expr_rtype, RTuple):
                 # len() of fixed-length tuple can be trivially determined statically.
-                target = self.alloc_target(int_rprimitive)
-                self.add(LoadInt(target, len(expr_rtype.types)))
-                return target
+                return self.add(LoadInt(len(expr_rtype.types)))
 
         # Handle data-driven special-cased primitive call ops.
         if fullname is not None:

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1024,7 +1024,7 @@ class IRBuilder(NodeVisitor[Register]):
 
     def add(self, op: Op) -> Register:
         self.blocks[-1][-1].ops.append(op)
-        if isinstance(op, RegisterOp) and op.no_reg:
+        if isinstance(op, RegisterOp):
             self.environment.add_op(op)
         return op
 

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -922,7 +922,7 @@ class IRBuilder(NodeVisitor[Value]):
                     target = self.binary_op(left, right, 'in', e.line)
                 else:
                     target = self.binary_op(left, right, op, e.line)
-                target = self.coerce(target, target.type, e.line)
+                target = self.coerce(target, bool_rprimitive, e.line)
                 branch = Branch(target, INVALID_VALUE, INVALID_LABEL, INVALID_LABEL,
                                 Branch.BOOL_EXPR)
                 if op == 'not in':

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -706,14 +706,11 @@ class IRBuilder(NodeVisitor[Register]):
 
     def load_static_module_attr(self, expr: RefExpr) -> Register:
         assert expr.node, "RefExpr not resolved"
-        target = self.alloc_target(self.node_type(expr))
         module = '.'.join(expr.node.fullname().split('.')[:-1])
         right = expr.node.fullname().split('.')[-1]
         left = self.alloc_temp(object_rprimitive)
         self.add(LoadStatic(left, c_module_name(module)))
-        self.add(PyGetAttr(target, left, right, expr.line))
-
-        return target
+        return self.add(PyGetAttr(self.node_type(expr), left, right, expr.line))
 
     def py_call(self, function: Register, args: List[Register],
                 target_type: RType, line: int) -> Register:

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -332,15 +332,15 @@ class IRBuilder(NodeVisitor[Value]):
             # Indexed assignment x[y] = e
             base_type = self.node_type(lvalue.base)
             index_type = self.node_type(lvalue.index)
-            base_reg = self.accept(lvalue.base)
-            index_reg = self.accept(lvalue.index)
-            if is_list_rprimitive(base_type) and is_int_rprimitive(index_type):
+            base = self.accept(lvalue.base)
+            index = self.accept(lvalue.index)
+            if is_list_rprimitive(base.type) and is_int_rprimitive(index.type):
                 # Indexed list set
-                return AssignmentTargetIndex(base_reg, index_reg, base_type)
+                return AssignmentTargetIndex(base, index, base.type)
             elif is_dict_rprimitive(base_type):
                 # Indexed dict set
-                boxed_index = self.box(index_reg, index_type)
-                return AssignmentTargetIndex(base_reg, boxed_index, base_type)
+                boxed_index = self.box(index, index.type)
+                return AssignmentTargetIndex(base, boxed_index, base.type)
         elif isinstance(lvalue, MemberExpr):
             # Attribute assignment x.y = e
             obj_type = self.node_type(lvalue.expr)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -606,18 +606,15 @@ class IRBuilder(NodeVisitor[Value]):
         assert False, 'Unsupported binary operation'
 
     def visit_index_expr(self, expr: IndexExpr) -> Value:
-        base_rtype = self.node_type(expr.base)
-        base_reg = self.accept(expr.base)
-        target_type = self.node_type(expr)
+        base = self.accept(expr.base)
 
-        if isinstance(base_rtype, RTuple):
+        if isinstance(base.type, RTuple):
             assert isinstance(expr.index, IntExpr)  # TODO
-            return self.add(TupleGet(base_reg, expr.index.value,
-                                     target_type, expr.line))
+            return self.add(TupleGet(base, expr.index.value, expr.line))
 
         index_reg = self.accept(expr.index)
         target_reg = self.translate_special_method_call(
-            base_reg,
+            base,
             '__getitem__',
             [index_reg],
             self.node_type(expr),
@@ -869,7 +866,7 @@ class IRBuilder(NodeVisitor[Value]):
         for item_expr, item_type in zip(expr.items, tuple_type.types):
             reg = self.accept(item_expr)
             items.append(self.coerce(reg, item_type, item_expr.line))
-        return self.add(TupleSet(items, tuple_type, expr.line))
+        return self.add(TupleSet(items, expr.line))
 
     def visit_dict_expr(self, expr: DictExpr) -> Value:
         assert not expr.items  # TODO

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -28,7 +28,8 @@ from mypy.visitor import NodeVisitor
 from mypy.subtypes import is_named_instance
 
 from mypyc.ops import (
-    BasicBlock, Environment, Op, LoadInt, RType, Register, Label, Return, FuncIR, Assign,
+    BasicBlock, Environment, Op, LoadInt, RType, Register, CRegister, Label, Return, FuncIR,
+    Assign,
     Branch, Goto, RuntimeArg, Call, Box, Unbox, Cast, RTuple,
     Unreachable, TupleGet, TupleSet, ClassIR, RInstance, ModuleIR, GetAttr, SetAttr, LoadStatic,
     PyGetAttr, PyCall, ROptional, c_module_name, PyMethodCall, MethodCall, INVALID_REGISTER,
@@ -101,7 +102,7 @@ class AssignmentTarget(object):
 class AssignmentTargetRegister(AssignmentTarget):
     """Register as assignment target"""
 
-    def __init__(self, register: Register) -> None:
+    def __init__(self, register: CRegister) -> None:
         self.register = register
 
 
@@ -515,7 +516,8 @@ class IRBuilder(NodeVisitor[Register]):
 
             expr_reg = self.accept(s.expr)
 
-            index_reg = self.add(LoadInt(0))
+            index_reg = self.alloc_temp(int_rprimitive)
+            self.add(Assign(index_reg, self.add(LoadInt(0))))
 
             one_reg = self.add(LoadInt(1))
 
@@ -1046,7 +1048,7 @@ class IRBuilder(NodeVisitor[Register]):
     def accept(self, node: Node) -> Register:
         return node.accept(self)
 
-    def alloc_temp(self, type: RType) -> Register:
+    def alloc_temp(self, type: RType) -> CRegister:
         return self.environment.add_temp(type)
 
     def type_to_rtype(self, typ: Type) -> RType:

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -369,10 +369,8 @@ class IRBuilder(NodeVisitor[Register]):
             rvalue_reg = self.accept(rvalue)
             if needs_box:
                 rvalue_reg = self.box(rvalue_reg, rvalue_type)
-            target_reg = self.alloc_temp(bool_rprimitive)
-            self.add(SetAttr(target_reg, target.obj_reg, target.attr, rvalue_reg, target.obj_type,
-                             rvalue.line))
-            return target_reg
+            return self.add(SetAttr(target.obj_reg, target.attr, rvalue_reg, target.obj_type,
+                                    rvalue.line))
         elif isinstance(target, AssignmentTargetIndex):
             item_reg = self.accept(rvalue)
 
@@ -708,8 +706,7 @@ class IRBuilder(NodeVisitor[Register]):
         assert expr.node, "RefExpr not resolved"
         module = '.'.join(expr.node.fullname().split('.')[:-1])
         right = expr.node.fullname().split('.')[-1]
-        left = self.alloc_temp(object_rprimitive)
-        self.add(LoadStatic(left, c_module_name(module)))
+        left = self.add(LoadStatic(object_rprimitive, c_module_name(module)))
         return self.add(PyGetAttr(self.node_type(expr), left, right, expr.line))
 
     def py_call(self, function: Register, args: List[Register],
@@ -1145,8 +1142,7 @@ class IRBuilder(NodeVisitor[Register]):
         if value not in self.unicode_literals:
             self.unicode_literals[value] = '__unicode_' + str(len(self.unicode_literals))
         static_symbol = self.unicode_literals[value]
-        target = self.alloc_temp(str_rprimitive, target)
-        self.add(LoadStatic(target, static_symbol))
+        return self.add(LoadStatic(str_rprimitive, static_symbol))
         return target
 
     def coerce(self, src: Register, src_type: RType, target_type: RType, line: int,

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1096,7 +1096,7 @@ class IRBuilder(NodeVisitor[Register]):
         return self.alloc_temp(type, self.cur_target())
 
     def alloc_temp(self, type: RType, target: Register = INVALID_REGISTER) -> Register:
-        if target < 0:
+        if target == INVALID_REGISTER:
             return self.environment.add_temp(type)
         else:
             return target

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -738,7 +738,7 @@ class IRBuilder(NodeVisitor[Value]):
                 arg_regs = self.coerce_native_call_args(
                     args, self.types[expr.callee], expr.line)
                 return self.add(MethodCall(self.node_type(expr), obj, expr.callee.name,
-                                           arg_regs, receiver_rtype, expr.line))
+                                           arg_regs, expr.line))
             else:
                 method = self.load_static_unicode(expr.callee.name)
                 return self.py_method_call(

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -309,7 +309,7 @@ class Environment:
         self.indexes = {}  # type: Dict[Register, int]
         self.names = {}  # type: Dict[Register, str]
         self.types = {}  # type: Dict[Register, RType]
-        self.symtable = {}  # type: Dict[Var, Register]
+        self.symtable = {}  # type: Dict[Var, CRegister]
         self.temp_index = 0
 
     def regs(self) -> Iterable['Register']:
@@ -320,7 +320,7 @@ class Environment:
         self.names[reg] = name
         self.types[reg] = typ
 
-    def add_local(self, var: Var, typ: RType) -> 'Register':
+    def add_local(self, var: Var, typ: RType) -> 'CRegister':
         assert isinstance(var, Var)
         reg = CRegister(typ, var.line)
 
@@ -328,10 +328,10 @@ class Environment:
         self.add(reg, var.name(), typ)
         return reg
 
-    def lookup(self, var: Var) -> 'Register':
+    def lookup(self, var: Var) -> 'CRegister':
         return self.symtable[var]
 
-    def add_temp(self, typ: RType) -> 'Register':
+    def add_temp(self, typ: RType) -> 'CRegister':
         assert isinstance(typ, RType)
         reg = CRegister(typ)
         self.add(reg, 'r%d' % self.temp_index, typ)
@@ -914,9 +914,8 @@ class PrimitiveOp(RegisterOp):
         return list(self.args)
 
     def __repr__(self) -> str:
-        return '<PrimitiveOp name=%r dest=%s args=%s>' % (self.desc.name,
-                                                          self.dest,
-                                                          self.args)
+        return '<PrimitiveOp name=%r args=%s>' % (self.desc.name,
+                                                  self.args)
 
     def to_str(self, env: Environment) -> str:
         params = {}  # type: Dict[str, Any]
@@ -936,7 +935,7 @@ class Assign(Op):
 
     error_kind = ERR_NEVER
 
-    def __init__(self, dest: Register, src: Register, line: int = -1) -> None:
+    def __init__(self, dest: CRegister, src: Register, line: int = -1) -> None:
         super().__init__(line)
         self.src = src
         self.target = dest

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1118,11 +1118,13 @@ class Box(StrictRegisterOp):
     """
 
     error_kind = ERR_NEVER
+    no_reg = True
 
-    def __init__(self, dest: Register, src: Register, typ: RType, line: int = -1) -> None:
-        super().__init__(dest, line)
+    def __init__(self, src: Register, typ: RType, line: int = -1) -> None:
+        super().__init__(self, line)
         self.src = src
         self.src_type = typ
+        self._type = object_rprimitive
 
     def sources(self) -> List[Register]:
         return [self.src]

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1218,11 +1218,9 @@ class ClassIR:
 
     # TODO: Use dictionary for attributes in addition to (or instead of) list.
 
-    def __init__(self,
-                 name: str,
-                 attributes: List[Tuple[str, RType]]) -> None:
+    def __init__(self, name: str) -> None:
         self.name = name
-        self.attributes = attributes
+        self.attributes = []  # type: List[Tuple[str, RType]]
         self.methods = []  # type: List[FuncIR]
 
     def struct_name(self) -> str:

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -802,11 +802,13 @@ class PyGetAttr(StrictRegisterOp):
     """dest = left.right :: py"""
 
     error_kind = ERR_MAGIC
+    no_reg = True
 
-    def __init__(self, dest: Register, left: Register, right: str, line: int) -> None:
-        super().__init__(dest, line)
+    def __init__(self, type: RType, left: Register, right: str, line: int) -> None:
+        super().__init__(self, line)
         self.left = left
         self.right = right
+        self.type = type
 
     def sources(self) -> List[Register]:
         return [self.left]
@@ -961,7 +963,6 @@ class GetAttr(StrictRegisterOp):
     """dest = obj.attr (for a native object)"""
 
     error_kind = ERR_MAGIC
-
     no_reg = True
 
     def __init__(self, obj: Register, attr: str,

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1036,11 +1036,13 @@ class TupleSet(StrictRegisterOp):
     """dest = (reg, ...) (for fixed-length tuple)"""
 
     error_kind = ERR_NEVER
+    no_reg = True
 
-    def __init__(self, dest: Register, items: List[Register], typ: RTuple, line: int) -> None:
-        super().__init__(dest, line)
+    def __init__(self, items: List[Register], typ: RTuple, line: int) -> None:
+        super().__init__(self, line)
         self.items = items
         self.tuple_type = typ
+        self.type = typ
 
     def sources(self) -> List[Register]:
         return self.items[:]

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -16,6 +16,7 @@ from typing import (
     List, Dict, Generic, TypeVar, Optional, Any, NamedTuple, Tuple, NewType, Callable, Union,
     Iterable,
 )
+from collections import OrderedDict
 
 from mypy.nodes import Var
 
@@ -321,7 +322,7 @@ class Environment:
     """Maintain the register symbol table and manage temp generation"""
 
     def __init__(self) -> None:
-        self.indexes = {}  # type: Dict[Value, int]
+        self.indexes = OrderedDict()  # type: Dict[Value, int]
         self.symtable = {}  # type: Dict[Var, Register]
         self.temp_index = 0
 

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -626,16 +626,6 @@ class RegisterOp(Op):
         return result
 
 
-class StrictRegisterOp(RegisterOp):
-    """An operation that can be written as r1 = f(r2, ..., rn), where r1 must exist.
-
-    Like RegisterOp but without the option of r1 being None.
-    """
-
-    def __init__(self, line: int) -> None:
-        super().__init__(line)
-
-
 class IncRef(RegisterOp):
     """inc_ref r"""
 
@@ -815,7 +805,7 @@ class PyMethodCall(RegisterOp):
         return visitor.visit_py_method_call(self)
 
 
-class PyGetAttr(StrictRegisterOp):
+class PyGetAttr(RegisterOp):
     """dest = left.right :: py"""
 
     error_kind = ERR_MAGIC
@@ -942,7 +932,7 @@ class Assign(Op):
         return visitor.visit_assign(self)
 
 
-class LoadInt(StrictRegisterOp):
+class LoadInt(RegisterOp):
     """dest = int"""
 
     error_kind = ERR_NEVER
@@ -962,7 +952,7 @@ class LoadInt(StrictRegisterOp):
         return visitor.visit_load_int(self)
 
 
-class LoadErrorValue(StrictRegisterOp):
+class LoadErrorValue(RegisterOp):
     """dest = <error value for type>"""
 
     error_kind = ERR_NEVER
@@ -981,7 +971,7 @@ class LoadErrorValue(StrictRegisterOp):
         return visitor.visit_load_error_value(self)
 
 
-class GetAttr(StrictRegisterOp):
+class GetAttr(RegisterOp):
     """dest = obj.attr (for a native object)"""
 
     error_kind = ERR_MAGIC
@@ -1005,7 +995,7 @@ class GetAttr(StrictRegisterOp):
         return visitor.visit_get_attr(self)
 
 
-class SetAttr(StrictRegisterOp):
+class SetAttr(RegisterOp):
     """obj.attr = src (for a native object)"""
 
     error_kind = ERR_FALSE
@@ -1030,7 +1020,7 @@ class SetAttr(StrictRegisterOp):
         return visitor.visit_set_attr(self)
 
 
-class LoadStatic(StrictRegisterOp):
+class LoadStatic(RegisterOp):
     """dest = name :: static"""
 
     error_kind = ERR_NEVER
@@ -1050,7 +1040,7 @@ class LoadStatic(StrictRegisterOp):
         return visitor.visit_load_static(self)
 
 
-class TupleSet(StrictRegisterOp):
+class TupleSet(RegisterOp):
     """dest = (reg, ...) (for fixed-length tuple)"""
 
     error_kind = ERR_NEVER
@@ -1072,7 +1062,7 @@ class TupleSet(StrictRegisterOp):
         return visitor.visit_tuple_set(self)
 
 
-class TupleGet(StrictRegisterOp):
+class TupleGet(RegisterOp):
     """dest = src[n] (for fixed-length tuple)"""
 
     error_kind = ERR_NEVER
@@ -1094,7 +1084,7 @@ class TupleGet(StrictRegisterOp):
         return visitor.visit_tuple_get(self)
 
 
-class Cast(StrictRegisterOp):
+class Cast(RegisterOp):
     """dest = cast(type, src)
 
     Perform a runtime type check (no representation or value conversion).
@@ -1119,7 +1109,7 @@ class Cast(StrictRegisterOp):
         return visitor.visit_cast(self)
 
 
-class Box(StrictRegisterOp):
+class Box(RegisterOp):
     """dest = box(type, src)
 
     This converts from a potentially unboxed representation to a straight Python object.
@@ -1144,7 +1134,7 @@ class Box(StrictRegisterOp):
         return visitor.visit_box(self)
 
 
-class Unbox(StrictRegisterOp):
+class Unbox(RegisterOp):
     """dest = unbox(type, src)
 
     This is similar to a cast, but it also changes to a (potentially) unboxed runtime

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -421,6 +421,7 @@ class Value:
     def to_str(self, env: Environment) -> str:
         raise NotImplementedError
 
+
 class Register(Value):
     def __init__(self, type: RType, line: int = -1) -> None:
         super().__init__(line)
@@ -433,6 +434,7 @@ class Register(Value):
     def is_void(self) -> bool:
         return False
 
+
 # Unfortunately we have visitors which are statement-like rather than expression-like.
 # It doesn't make sense to have the visitor return Optional[Value] because every
 # method either always returns no value or returns a value.
@@ -440,7 +442,7 @@ class Register(Value):
 # Eventually we may want to separate expression visitors and statement-like visitors at
 # the type level but until then returning INVALID_VALUE from a statement-like visitor
 # seems acceptable.
-INVALID_VALUE = Register(None)  # type: ignore
+INVALID_VALUE = Register(void_rtype)
 
 
 class Op(Value):

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -924,20 +924,21 @@ class PrimitiveOp(RegisterOp):
         return visitor.visit_primitive_op(self)
 
 
-class Assign(RegisterOp):
+class Assign(Op):
     """dest = int"""
 
     error_kind = ERR_NEVER
 
     def __init__(self, dest: Register, src: Register, line: int = -1) -> None:
-        super().__init__(dest, line)
+        super().__init__(line)
         self.src = src
+        self.target = dest
 
     def sources(self) -> List[Register]:
         return [self.src]
 
     def to_str(self, env: Environment) -> str:
-        return env.format('%r = %r', self.dest, self.src)
+        return env.format('%r = %r', self.target, self.src)
 
     def accept(self, visitor: 'OpVisitor[T]') -> T:
         return visitor.visit_assign(self)

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -989,15 +989,17 @@ class SetAttr(StrictRegisterOp):
     """obj.attr = src (for a native object)"""
 
     error_kind = ERR_FALSE
+    no_reg = True
 
-    def __init__(self, dest: Register, obj: Register, attr: str, src: Register,
+    def __init__(self, obj: Register, attr: str, src: Register,
                  class_type: RInstance,
                  line: int) -> None:
-        super().__init__(dest, line)
+        super().__init__(self, line)
         self.obj = obj
         self.attr = attr
         self.src = src
         self.class_type = class_type
+        self.type = bool_rprimitive
 
     def sources(self) -> List[Register]:
         return [self.obj, self.src]
@@ -1013,10 +1015,12 @@ class LoadStatic(StrictRegisterOp):
     """dest = name :: static"""
 
     error_kind = ERR_NEVER
+    no_reg = True
 
-    def __init__(self, dest: Register, identifier: str, line: int = -1) -> None:
-        super().__init__(dest, line)
+    def __init__(self, type: RType, identifier: str, line: int = -1) -> None:
+        super().__init__(self, line)
         self.identifier = identifier
+        self.type = type
 
     def sources(self) -> List[Register]:
         return []

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -424,8 +424,9 @@ class Value:
 
 
 class Register(Value):
-    def __init__(self, type: RType, line: int = -1) -> None:
+    def __init__(self, type: RType, line: int = -1, name: str = '') -> None:
         super().__init__(line)
+        self.name = name
         self.type = type
 
     def to_str(self, env: Environment) -> str:
@@ -443,7 +444,7 @@ class Register(Value):
 # Eventually we may want to separate expression visitors and statement-like visitors at
 # the type level but until then returning INVALID_VALUE from a statement-like visitor
 # seems acceptable.
-INVALID_VALUE = Register(void_rtype)
+INVALID_VALUE = Register(void_rtype, name='<INVALID_VALUE>')
 
 
 class Op(Value):

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -307,17 +307,16 @@ class Environment:
 
     def __init__(self) -> None:
         self.indexes = {}  # type: Dict[Value, int]
-        self.names = {}  # type: Dict[Value, str]
         self.types = {}  # type: Dict[Value, RType]
         self.symtable = {}  # type: Dict[Var, Register]
         self.temp_index = 0
 
     def regs(self) -> Iterable['Value']:
-        return self.names.keys()
+        return self.indexes.keys()
 
     def add(self, reg: 'Value', name: str, typ: RType) -> None:
-        self.indexes[reg] = len(self.names)
-        self.names[reg] = name
+        reg.name = name
+        self.indexes[reg] = len(self.indexes)
         self.types[reg] = typ
 
     def add_local(self, var: Var, typ: RType) -> 'Register':
@@ -357,7 +356,7 @@ class Environment:
                 typespec = fmt[n + 1]
                 arg = arglist.pop(0)
                 if typespec == 'r':
-                    result.append(self.names[arg])
+                    result.append(arg.name)
                 elif typespec == 'd':
                     result.append('%d' % arg)
                 elif typespec == 'l':
@@ -374,7 +373,7 @@ class Environment:
     def to_lines(self) -> List[str]:
         result = []
         i = 0
-        names = [self.names[k] for k in self.regs()]
+        names = [k.name for k in self.regs()]
         types = [self.types[k] for k in self.regs()]
 
         n = len(names)
@@ -397,6 +396,7 @@ ERR_FALSE = 2  # Generates false (bool) on exception
 class Value:
     # Source line number
     line = -1
+    name = ''
 
     def __init__(self, line: int) -> None:
         self.line = line
@@ -416,7 +416,7 @@ class Register(Value):
         self.type = type
 
     def to_str(self, env: Environment) -> str:
-        return env.names[self]
+        return self.name
 
     @property
     def is_void(self) -> bool:

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1120,17 +1120,16 @@ class Box(RegisterOp):
 
     error_kind = ERR_NEVER
 
-    def __init__(self, src: Value, typ: RType, line: int = -1) -> None:
+    def __init__(self, src: Value, line: int = -1) -> None:
         super().__init__(line)
         self.src = src
-        self.src_type = typ
         self.type = object_rprimitive
 
     def sources(self) -> List[Value]:
         return [self.src]
 
     def to_str(self, env: Environment) -> str:
-        return env.format('%r = box(%s, %r)', self, self.src_type, self.src)
+        return env.format('%r = box(%s, %r)', self, self.src.type, self.src)
 
     def accept(self, visitor: 'OpVisitor[T]') -> T:
         return visitor.visit_box(self)

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -633,16 +633,15 @@ class IncRef(RegisterOp):
 
     error_kind = ERR_NEVER
 
-    def __init__(self, src: Value, typ: RType, line: int = -1) -> None:
-        assert typ.is_refcounted
+    def __init__(self, src: Value, line: int = -1) -> None:
+        assert src.type.is_refcounted
         super().__init__(line)
         self.src = src
-        self.target_type = typ
 
     def to_str(self, env: Environment) -> str:
         s = env.format('inc_ref %r', self.src)
-        if is_bool_rprimitive(self.target_type) or is_int_rprimitive(self.target_type):
-            s += ' :: {}'.format(short_name(self.target_type.name))
+        if is_bool_rprimitive(self.src.type) or is_int_rprimitive(self.src.type):
+            s += ' :: {}'.format(short_name(self.src.type.name))
         return s
 
     def sources(self) -> List[Value]:
@@ -657,19 +656,18 @@ class DecRef(RegisterOp):
 
     error_kind = ERR_NEVER
 
-    def __init__(self, src: Value, typ: RType, line: int = -1) -> None:
-        assert typ.is_refcounted
+    def __init__(self, src: Value, line: int = -1) -> None:
+        assert src.type.is_refcounted
         super().__init__(line)
         self.src = src
-        self.target_type = typ
 
     def __repr__(self) -> str:
         return '<DecRef %r>' % self.src
 
     def to_str(self, env: Environment) -> str:
         s = env.format('dec_ref %r', self.src)
-        if is_bool_rprimitive(self.target_type) or is_int_rprimitive(self.target_type):
-            s += ' :: {}'.format(short_name(self.target_type.name))
+        if is_bool_rprimitive(self.src.type) or is_int_rprimitive(self.src.type):
+            s += ' :: {}'.format(short_name(self.src.type.name))
         return s
 
     def sources(self) -> List[Value]:
@@ -980,8 +978,7 @@ class GetAttr(RegisterOp):
 
     error_kind = ERR_MAGIC
 
-    def __init__(self, obj: Value, attr: str,
-                 line: int) -> None:
+    def __init__(self, obj: Value, attr: str, line: int) -> None:
         super().__init__(line)
         self.obj = obj
         self.attr = attr
@@ -1004,8 +1001,7 @@ class SetAttr(RegisterOp):
 
     error_kind = ERR_FALSE
 
-    def __init__(self, obj: Value, attr: str, src: Value,
-                 line: int) -> None:
+    def __init__(self, obj: Value, attr: str, src: Value, line: int) -> None:
         super().__init__(line)
         self.obj = obj
         self.attr = attr

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -687,6 +687,7 @@ class Call(RegisterOp):
 
     error_kind = ERR_MAGIC
 
+    # TODO: take a FuncIR and extract the ret type
     def __init__(self, ret_type: RType, fn: str, args: List[Value], line: int) -> None:
         super().__init__(line)
         self.fn = fn
@@ -712,18 +713,19 @@ class MethodCall(RegisterOp):
 
     error_kind = ERR_MAGIC
 
+    # TODO: extract the ret type from the receiver
     def __init__(self,
                  ret_type: RType,
                  obj: Value,
                  method: str,
                  args: List[Value],
-                 receiver_type: RInstance,
                  line: int = -1) -> None:
         super().__init__(line)
         self.obj = obj
         self.method = method
         self.args = args
-        self.receiver_type = receiver_type
+        assert isinstance(obj.type, RInstance), "Methods can only be called on instances"
+        self.receiver_type = obj.type
         self.type = ret_type
 
     def to_str(self, env: Environment) -> str:

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -979,13 +979,13 @@ class GetAttr(RegisterOp):
     error_kind = ERR_MAGIC
 
     def __init__(self, obj: Value, attr: str,
-                 class_type: RInstance,
                  line: int) -> None:
         super().__init__(line)
         self.obj = obj
         self.attr = attr
-        self.class_type = class_type
-        self.type = class_type.attr_type(attr)
+        assert isinstance(obj.type, RInstance), 'Attribute access not supported: %s' % obj.type
+        self.class_type = obj.type
+        self.type = obj.type.attr_type(attr)
 
     def sources(self) -> List[Value]:
         return [self.obj]
@@ -1003,13 +1003,13 @@ class SetAttr(RegisterOp):
     error_kind = ERR_FALSE
 
     def __init__(self, obj: Value, attr: str, src: Value,
-                 class_type: RInstance,
                  line: int) -> None:
         super().__init__(line)
         self.obj = obj
         self.attr = attr
         self.src = src
-        self.class_type = class_type
+        assert isinstance(obj.type, RInstance), 'Attribute access not supported: %s' % obj.type
+        self.class_type = obj.type
         self.type = bool_rprimitive
 
     def sources(self) -> List[Value]:

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -576,7 +576,6 @@ class RegisterOp(Op):
 
     error_kind = -1  # Can this raise exception and how is it signalled; one of ERR_*
 
-    no_reg = False
     _type = None  # type: Optional[RType]
 
     def __init__(self, dest: Optional[Register], line: int) -> None:
@@ -614,8 +613,6 @@ class StrictRegisterOp(RegisterOp):
 
     Like RegisterOp but without the option of r1 being None.
     """
-
-    no_reg = True
 
     def __init__(self, line: int) -> None:
         super().__init__(self, line)
@@ -690,7 +687,6 @@ class Call(RegisterOp):
     """
 
     error_kind = ERR_MAGIC
-    no_reg = True
 
     def __init__(self, ret_type: RType, fn: str, args: List[Register], line: int) -> None:
         super().__init__(self, line)
@@ -716,7 +712,6 @@ class MethodCall(RegisterOp):
     """Native method call obj.m(arg, ...) """
 
     error_kind = ERR_MAGIC
-    no_reg = True
 
     def __init__(self,
                  ret_type: RType,
@@ -758,7 +753,6 @@ class PyCall(RegisterOp):
     """
 
     error_kind = ERR_MAGIC
-    no_reg = True
 
     def __init__(self, function: Register, args: List[Register],
                  line: int) -> None:
@@ -788,7 +782,6 @@ class PyMethodCall(RegisterOp):
     """
 
     error_kind = ERR_MAGIC
-    no_reg = True
 
     def __init__(self,
                  obj: Register,
@@ -885,8 +878,6 @@ class PrimitiveOp(RegisterOp):
     operations. mypyc.genops uses the descriptions to look for suitable
     primitive ops.
     """
-
-    no_reg = True
 
     def __init__(self,
                  args: List[Register],

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -936,13 +936,13 @@ class Assign(Op):
     def __init__(self, dest: Register, src: Value, line: int = -1) -> None:
         super().__init__(line)
         self.src = src
-        self.target = dest
+        self.dest = dest
 
     def sources(self) -> List[Value]:
         return [self.src]
 
     def to_str(self, env: Environment) -> str:
-        return env.format('%r = %r', self.target, self.src)
+        return env.format('%r = %r', self.dest, self.src)
 
     def accept(self, visitor: 'OpVisitor[T]') -> T:
         return visitor.visit_assign(self)

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1047,11 +1047,11 @@ class TupleSet(RegisterOp):
 
     error_kind = ERR_NEVER
 
-    def __init__(self, items: List[Value], typ: RTuple, line: int) -> None:
+    def __init__(self, items: List[Value], line: int) -> None:
         super().__init__(line)
         self.items = items
-        self.tuple_type = typ
-        self.type = typ
+        self.tuple_type = RTuple([arg.type for arg in items])
+        self.type = self.tuple_type
 
     def sources(self) -> List[Value]:
         return self.items[:]
@@ -1069,12 +1069,12 @@ class TupleGet(RegisterOp):
 
     error_kind = ERR_NEVER
 
-    def __init__(self, src: Value, index: int, target_type: RType,
-                 line: int) -> None:
+    def __init__(self, src: Value, index: int, line: int) -> None:
         super().__init__(line)
         self.src = src
         self.index = index
-        self.type = target_type
+        assert isinstance(src.type, RTuple), "TupleGet only operates on tuples"
+        self.type = src.type.types[index]
 
     def sources(self) -> List[Value]:
         return [self.src]

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -944,9 +944,10 @@ class LoadErrorValue(StrictRegisterOp):
     """dest = <error value for type>"""
 
     error_kind = ERR_NEVER
+    no_reg = True
 
-    def __init__(self, dest: Register, rtype: RType, line: int = -1) -> None:
-        super().__init__(dest, line)
+    def __init__(self, rtype: RType, line: int = -1) -> None:
+        super().__init__(self, line)
         self.type = rtype
 
     def sources(self) -> List[Register]:

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -885,25 +885,31 @@ class PrimitiveOp(RegisterOp):
     primitive ops.
     """
 
+    no_reg = True
+
     def __init__(self,
-                  dest: Optional[Register],
-                  args: List[Register],
-                  desc: OpDescription,
-                  line: int) -> None:
+                 args: List[Register],
+                 desc: OpDescription,
+                 line: int) -> None:
         if not desc.is_var_arg:
             assert len(args) == len(desc.arg_types)
         self.error_kind = desc.error_kind
-        super().__init__(dest, line)
+        super().__init__(self, line)
         self.args = args
         self.desc = desc
+        if desc.result_type is None:
+            assert desc.error_kind == ERR_FALSE  # TODO: No-value ops not supported yet
+            self._type = bool_rprimitive
+        else:
+            self._type = desc.result_type
 
     def sources(self) -> List[Register]:
         return list(self.args)
 
     def __repr__(self) -> str:
-        return '<PrimiveOp2 name=%r dest=%s args=%s>' % (self.desc.name,
-                                                         self.dest,
-                                                         self.args)
+        return '<PrimitiveOp name=%r dest=%s args=%s>' % (self.desc.name,
+                                                          self.dest,
+                                                          self.args)
 
     def to_str(self, env: Environment) -> str:
         params = {}  # type: Dict[str, Any]

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -690,11 +690,13 @@ class Call(RegisterOp):
     """
 
     error_kind = ERR_MAGIC
+    no_reg = True
 
-    def __init__(self, dest: Optional[Register], fn: str, args: List[Register], line: int) -> None:
-        super().__init__(dest, line)
+    def __init__(self, ret_type: RType, fn: str, args: List[Register], line: int) -> None:
+        super().__init__(self, line)
         self.fn = fn
         self.args = args
+        self._type = ret_type
 
     def to_str(self, env: Environment) -> str:
         args = ', '.join(env.format('%r', arg) for arg in self.args)
@@ -714,19 +716,21 @@ class MethodCall(RegisterOp):
     """Native method call obj.m(arg, ...) """
 
     error_kind = ERR_MAGIC
+    no_reg = True
 
     def __init__(self,
-                 dest: Optional[Register],
+                 ret_type: RType,
                  obj: Register,
                  method: str,
                  args: List[Register],
                  receiver_type: RInstance,
                  line: int = -1) -> None:
-        super().__init__(dest, line)
+        super().__init__(self, line)
         self.obj = obj
         self.method = method
         self.args = args
         self.receiver_type = receiver_type
+        self._type = ret_type
 
     def to_str(self, env: Environment) -> str:
         args = ', '.join(env.format('%r', arg) for arg in self.args)
@@ -754,12 +758,14 @@ class PyCall(RegisterOp):
     """
 
     error_kind = ERR_MAGIC
+    no_reg = True
 
-    def __init__(self, dest: Optional[Register], function: Register, args: List[Register],
+    def __init__(self, function: Register, args: List[Register],
                  line: int) -> None:
-        super().__init__(dest, line)
+        super().__init__(self, line)
         self.function = function
         self.args = args
+        self._type = object_rprimitive
 
     def to_str(self, env: Environment) -> str:
         args = ', '.join(env.format('%r', arg) for arg in self.args)
@@ -782,17 +788,18 @@ class PyMethodCall(RegisterOp):
     """
 
     error_kind = ERR_MAGIC
+    no_reg = True
 
     def __init__(self,
-            dest: Optional[Register],
-            obj: Register,
-            method: Register,
-            args: List[Register],
-            line: int = -1) -> None:
-        super().__init__(dest, line)
+                 obj: Register,
+                 method: Register,
+                 args: List[Register],
+                 line: int = -1) -> None:
+        super().__init__(self, line)
         self.obj = obj
         self.method = method
         self.args = args
+        self._type = object_rprimitive
 
     def to_str(self, env: Environment) -> str:
         args = ', '.join(env.format('%r', arg) for arg in self.args)

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -23,10 +23,11 @@ from mypy.nodes import Var
 
 T = TypeVar('T')
 
+# TODO: Use pointers to BasicBlocks instead?
 Label = NewType('Label', int)
 
-# Similarly this is used for placeholder labels which aren't assigned yet (but will
-# be eventually. Its kind of a hack.
+# This is used for placeholder labels which aren't assigned yet (but will
+# be eventually. It's kind of a hack.
 INVALID_LABEL = Label(-88888)
 
 

--- a/mypyc/ops_list.py
+++ b/mypyc/ops_list.py
@@ -4,7 +4,7 @@ from typing import List
 
 from mypyc.ops import (
     int_rprimitive, list_rprimitive, object_rprimitive, bool_rprimitive, ERR_MAGIC, ERR_NEVER,
-    ERR_FALSE, EmitterInterface, PrimitiveOp, Register
+    ERR_FALSE, EmitterInterface, PrimitiveOp, Value
 )
 from mypyc.ops_primitive import binary_op, func_op, method_op, custom_op, simple_emit
 

--- a/mypyc/refcount.py
+++ b/mypyc/refcount.py
@@ -74,7 +74,7 @@ def transform_block(block: BasicBlock,
     for i, op in enumerate(old_ops):
         key = (block.label, i)
         if isinstance(op, (Assign, Cast, Box)):
-            dest = op.target if isinstance(op, Assign) else op
+            dest = op.dest if isinstance(op, Assign) else op
             # These operations just copy/steal a reference and don't create new
             # references.
             if op.src in post_live[key] or op.src in pre_borrow[key]:

--- a/mypyc/refcount.py
+++ b/mypyc/refcount.py
@@ -27,7 +27,8 @@ from mypyc.analysis import (
 )
 from mypyc.ops import (
     FuncIR, BasicBlock, Assign, RegisterOp, DecRef, IncRef, Branch, Goto, Environment,
-    Return, Op, Register, Label, Cast, Box, Unbox, LoadStatic, RType,
+    Return, Op, Label, Cast, Box, Unbox, LoadStatic, RType,
+    Register, CRegister,
 )
 
 
@@ -37,7 +38,7 @@ def insert_ref_count_opcodes(ir: FuncIR) -> None:
     This is the entry point to this module.
     """
     cfg = get_cfg(ir.blocks)
-    args = set([Register(i) for i in range(len(ir.args))])
+    args = set([CRegister(i) for i in range(len(ir.args))])  # type: Set[Register]
     live = analyze_live_regs(ir.blocks, cfg)
     borrow = analyze_borrowed_arguments(ir.blocks, cfg, args)
     for block in ir.blocks[:]:

--- a/mypyc/refcount.py
+++ b/mypyc/refcount.py
@@ -83,6 +83,7 @@ def transform_block(block: BasicBlock,
                     maybe_append_dec_ref(ops, op.dest, env)
             ops.append(op)
             if op.dest not in post_live[key]:
+                assert op.dest is not None
                 maybe_append_dec_ref(ops, op.dest, env)
         elif isinstance(op, RegisterOp):
             # These operations construct a new reference.

--- a/mypyc/refcount.py
+++ b/mypyc/refcount.py
@@ -89,24 +89,24 @@ def transform_block(block: BasicBlock,
         elif isinstance(op, RegisterOp):
             # These operations construct a new reference.
             tmp_reg = None  # type: Optional[Value]
-            if (op.dest not in pre_borrow[key] and
-                    op.dest in pre_live[key]):
-                if op.dest not in op.sources():
-                    maybe_append_dec_ref(ops, op.dest, env)
+            if (op not in pre_borrow[key] and
+                    op in pre_live[key]):
+                if op not in op.sources():
+                    maybe_append_dec_ref(ops, op, env)
                 else:
-                    tmp_reg = env.add_temp(env.types[op.dest])
-                    ops.append(Assign(tmp_reg, op.dest))
+                    tmp_reg = env.add_temp(env.types[op])
+                    ops.append(Assign(tmp_reg, op))
             ops.append(op)
             for src in op.unique_sources():
                 # Decrement source that won't be live afterwards.
                 if src not in post_live[key] and src not in pre_borrow[key]:
-                    if src != op.dest:
+                    if src != op:
                         maybe_append_dec_ref(ops, src, env)
             # TODO: Analyze LoadStatics as being borrowed! (#66)
             if isinstance(op, LoadStatic):
-                maybe_append_inc_ref(ops, op.dest, env)
-            if op.dest is not None and op.dest not in post_live[key]:
-                maybe_append_dec_ref(ops, op.dest, env)
+                maybe_append_inc_ref(ops, op, env)
+            if not op.is_void and op not in post_live[key]:
+                maybe_append_dec_ref(ops, op, env)
             if tmp_reg is not None:
                 maybe_append_dec_ref(ops, tmp_reg, env)
         elif isinstance(op, Return) and op.reg in pre_borrow[key]:

--- a/mypyc/refcount.py
+++ b/mypyc/refcount.py
@@ -185,7 +185,7 @@ def after_branch_decrefs(label: Label,
     decref = source_live_regs - target_pre_live - source_borrowed
     if decref:
         return [DecRef(reg, env.types[reg])
-                for reg in sorted(decref)
+                for reg in sorted(decref, key=lambda r: env.indexes[r])
                 if env.types[reg].is_refcounted and reg not in omitted]
     return []
 
@@ -198,7 +198,7 @@ def after_branch_increfs(label: Label,
     incref = source_borrowed - target_borrowed
     if incref:
         return [IncRef(reg, env.types[reg])
-                for reg in sorted(incref)
+                for reg in sorted(incref, key=lambda r: env.indexes[r])
                 if env.types[reg].is_refcounted]
     return []
 

--- a/mypyc/refcount.py
+++ b/mypyc/refcount.py
@@ -53,15 +53,13 @@ def insert_ref_count_opcodes(ir: FuncIR) -> None:
 
 
 def maybe_append_dec_ref(ops: List[Op], dest: Value) -> None:
-    rtype = dest.type
-    if rtype.is_refcounted:
-        ops.append(DecRef(dest, rtype))
+    if dest.type.is_refcounted:
+        ops.append(DecRef(dest))
 
 
 def maybe_append_inc_ref(ops: List[Op], dest: Value) -> None:
-    rtype = dest.type
-    if rtype.is_refcounted:
-        ops.append(IncRef(dest, rtype))
+    if dest.type.is_refcounted:
+        ops.append(IncRef(dest))
 
 
 def transform_block(block: BasicBlock,
@@ -186,7 +184,7 @@ def after_branch_decrefs(label: Label,
     target_pre_live = pre_live[label, 0]
     decref = source_live_regs - target_pre_live - source_borrowed
     if decref:
-        return [DecRef(reg, reg.type)
+        return [DecRef(reg)
                 for reg in sorted(decref, key=lambda r: env.indexes[r])
                 if reg.type.is_refcounted and reg not in omitted]
     return []
@@ -199,7 +197,7 @@ def after_branch_increfs(label: Label,
     target_borrowed = pre_borrow[label, 0]
     incref = source_borrowed - target_borrowed
     if incref:
-        return [IncRef(reg, reg.type)
+        return [IncRef(reg)
                 for reg in sorted(incref, key=lambda r: env.indexes[r])
                 if reg.type.is_refcounted]
     return []

--- a/mypyc/refcount.py
+++ b/mypyc/refcount.py
@@ -74,17 +74,18 @@ def transform_block(block: BasicBlock,
     for i, op in enumerate(old_ops):
         key = (block.label, i)
         if isinstance(op, (Assign, Cast, Box)):
+            dest = op.target if isinstance(op, Assign) else op
             # These operations just copy/steal a reference and don't create new
             # references.
             if op.src in post_live[key] or op.src in pre_borrow[key]:
                 maybe_append_inc_ref(ops, op.src, env)
-                if (op.dest not in pre_borrow[key] and
-                        op.dest in pre_live[key]):
-                    maybe_append_dec_ref(ops, op.dest, env)
+                if (dest not in pre_borrow[key] and
+                        dest in pre_live[key]):
+                    maybe_append_dec_ref(ops, dest, env)
             ops.append(op)
-            if op.dest not in post_live[key]:
-                assert op.dest is not None
-                maybe_append_dec_ref(ops, op.dest, env)
+            if dest not in post_live[key]:
+                assert dest is not None
+                maybe_append_dec_ref(ops, dest, env)
         elif isinstance(op, RegisterOp):
             # These operations construct a new reference.
             tmp_reg = None  # type: Optional[Register]

--- a/mypyc/refcount.py
+++ b/mypyc/refcount.py
@@ -38,7 +38,7 @@ def insert_ref_count_opcodes(ir: FuncIR) -> None:
     This is the entry point to this module.
     """
     cfg = get_cfg(ir.blocks)
-    args = set([CRegister(i) for i in range(len(ir.args))])  # type: Set[Register]
+    args = set(reg for reg, i in ir.env.indexes.items() if i < len(ir.args))
     live = analyze_live_regs(ir.blocks, cfg)
     borrow = analyze_borrowed_arguments(ir.blocks, cfg, args)
     for block in ir.blocks[:]:

--- a/mypyc/sametype.py
+++ b/mypyc/sametype.py
@@ -1,7 +1,7 @@
 """Same type check for RTypes."""
 
 from mypyc.ops import (
-    RType, RTypeVisitor, RInstance, ROptional, RPrimitive, RTuple
+    RType, RTypeVisitor, RInstance, ROptional, RPrimitive, RTuple, RVoid,
 )
 
 
@@ -27,3 +27,6 @@ class SameTypeVisitor(RTypeVisitor[bool]):
         return (isinstance(self.right, RTuple)
             and len(self.right.types) == len(left.types)
             and all(is_same_type(t1, t2) for t1, t2 in zip(left.types, self.right.types)))
+
+    def visit_rvoid(self, left: RVoid) -> bool:
+        return isinstance(self.right, RVoid)

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -1,7 +1,7 @@
 """Subtype check for RTypes."""
 
 from mypyc.ops import (
-    RType, ROptional, RInstance, RPrimitive, RTuple, RTypeVisitor,
+    RType, ROptional, RInstance, RPrimitive, RTuple, RVoid, RTypeVisitor,
     is_bool_rprimitive, is_int_rprimitive, is_tuple_rprimitive, none_rprimitive, is_object_rprimitive
 )
 
@@ -45,3 +45,6 @@ class SubtypeVisitor(RTypeVisitor[bool]):
             return len(self.right.types) == len(left.types) and all(
                 is_subtype(t1, t2) for t1, t2 in zip(left.types, self.right.types))
         return False
+
+    def visit_rvoid(self, left: RVoid) -> bool:
+        return isinstance(self.right, RVoid)

--- a/mypyc/test/test_analysis.py
+++ b/mypyc/test/test_analysis.py
@@ -72,7 +72,7 @@ class TestAnalysis(MypycDataSuite):
                         # Forward, must
                         analysis_result = analysis.analyze_must_defined_regs(
                             fn.blocks, cfg, args,
-                            num_regs=fn.env.num_regs())
+                            regs=fn.env.regs())
                     elif name.endswith('_BorrowedArgument'):
                         # Forward, must
                         analysis_result = analysis.analyze_borrowed_arguments(fn.blocks, cfg, args)

--- a/mypyc/test/test_analysis.py
+++ b/mypyc/test/test_analysis.py
@@ -81,7 +81,9 @@ class TestAnalysis(MypycDataSuite):
 
                     actual.append('')
                     for key in sorted(analysis_result.before.keys()):
-                        pre = ', '.join(fn.env.names[reg] for reg in analysis_result.before[key])
-                        post = ', '.join(fn.env.names[reg] for reg in analysis_result.after[key])
+                        pre = ', '.join(sorted(fn.env.names[reg]
+                                               for reg in analysis_result.before[key]))
+                        post = ', '.join(sorted(fn.env.names[reg]
+                                                for reg in analysis_result.after[key]))
                         actual.append('%-8s %-23s %s' % (key, '{%s}' % pre, '{%s}' % post))
             assert_test_output(testcase, actual, 'Invalid source code output')

--- a/mypyc/test/test_analysis.py
+++ b/mypyc/test/test_analysis.py
@@ -14,7 +14,7 @@ from mypy import experiments
 
 from mypyc import analysis
 from mypyc import genops
-from mypyc.ops import format_func, CRegister, Register
+from mypyc.ops import format_func, Register, Value
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, assert_test_output
 )

--- a/mypyc/test/test_analysis.py
+++ b/mypyc/test/test_analysis.py
@@ -82,9 +82,9 @@ class TestAnalysis(MypycDataSuite):
 
                     actual.append('')
                     for key in sorted(analysis_result.before.keys()):
-                        pre = ', '.join(sorted(fn.env.names[reg]
+                        pre = ', '.join(sorted(reg.name
                                                for reg in analysis_result.before[key]))
-                        post = ', '.join(sorted(fn.env.names[reg]
+                        post = ', '.join(sorted(reg.name
                                                 for reg in analysis_result.after[key]))
                         actual.append('%-8s %-23s %s' % (key, '{%s}' % pre, '{%s}' % post))
             assert_test_output(testcase, actual, 'Invalid source code output')

--- a/mypyc/test/test_analysis.py
+++ b/mypyc/test/test_analysis.py
@@ -3,7 +3,7 @@
 import os.path
 import re
 import shutil
-from typing import List
+from typing import List, Set
 
 from mypy import build
 from mypy.test.data import parse_test_cases, DataDrivenTestCase
@@ -14,7 +14,7 @@ from mypy import experiments
 
 from mypyc import analysis
 from mypyc import genops
-from mypyc.ops import format_func, Register
+from mypyc.ops import format_func, CRegister, Register
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, assert_test_output
 )
@@ -60,7 +60,7 @@ class TestAnalysis(MypycDataSuite):
                     actual = actual[actual.index('L0:'):]
                     cfg = analysis.get_cfg(fn.blocks)
 
-                    args = set([Register(i) for i in range(len(fn.args))])
+                    args = set([CRegister(i) for i in range(len(fn.args))])  # type: Set[Register]
                     name = testcase.name
                     if name.endswith('_MaybeDefined'):
                         # Forward, maybe

--- a/mypyc/test/test_analysis.py
+++ b/mypyc/test/test_analysis.py
@@ -60,7 +60,8 @@ class TestAnalysis(MypycDataSuite):
                     actual = actual[actual.index('L0:'):]
                     cfg = analysis.get_cfg(fn.blocks)
 
-                    args = set([CRegister(i) for i in range(len(fn.args))])  # type: Set[Register]
+                    args = set(reg for reg, i in fn.env.indexes.items() if i < len(fn.args))
+
                     name = testcase.name
                     if name.endswith('_MaybeDefined'):
                         # Forward, maybe

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -7,7 +7,7 @@ from mypyc.ops import (
     Environment, BasicBlock, FuncIR, RuntimeArg, RType, Goto, Return, LoadInt, Assign,
     IncRef, DecRef, Branch, Call, Unbox, Box, RTuple, TupleGet, GetAttr, PrimitiveOp,
     RegisterOp,
-    ClassIR, RInstance, SetAttr, Op, Label, Register, int_rprimitive, bool_rprimitive,
+    ClassIR, RInstance, SetAttr, Op, Label, Value, int_rprimitive, bool_rprimitive,
     list_rprimitive, dict_rprimitive, object_rprimitive,
 )
 from mypyc.emit import Emitter, EmitterContext
@@ -241,9 +241,9 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
 
     def assert_emit_binary_op(self,
                               op: str,
-                              dest: Register,
-                              left: Register,
-                              right: Register,
+                              dest: Value,
+                              left: Value,
+                              right: Value,
                               expected: str) -> None:
         ops = binary_ops[op]
         left_type = self.env.types[left]

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -185,8 +185,8 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         ir = ClassIR('A', [('x', bool_rprimitive),
                            ('y', int_rprimitive)])
         rtype = RInstance(ir)
-        self.assert_emit(GetAttr(self.n, self.m, 'y', rtype, 1),
-                         """cpy_r_n = CPY_GET_ATTR(cpy_r_m, 2, AObject, CPyTagged);""")
+        self.assert_emit(GetAttr(self.m, 'y', rtype, 1),
+                         """cpy_r_r0 = CPY_GET_ATTR(cpy_r_m, 2, AObject, CPyTagged);""")
 
     def test_set_attr(self) -> None:
         ir = ClassIR('A', [('x', bool_rprimitive),
@@ -229,6 +229,9 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
     def assert_emit(self, op: Op, expected: str) -> None:
         self.emitter.fragments = []
         self.declarations.fragments = []
+        self.env.temp_index = 0
+        if op.no_reg:
+            self.env.add_op(op)
         op.accept(self.visitor)
         frags = self.declarations.fragments + self.emitter.fragments
         actual_lines = [line.strip(' ') for line in frags]

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -246,11 +246,9 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                               right: Value,
                               expected: str) -> None:
         ops = binary_ops[op]
-        left_type = self.env.types[left]
-        right_type = self.env.types[right]
         for desc in ops:
-            if (is_subtype(left_type, desc.arg_types[0])
-                    and is_subtype(right_type, desc.arg_types[1])):
+            if (is_subtype(left.type, desc.arg_types[0])
+                    and is_subtype(right.type, desc.arg_types[1])):
                 self.assert_emit(PrimitiveOp([left, right], desc, 55), expected)
                 break
         else:

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -150,7 +150,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """cpy_r_r0 = CPyList_SetItem(cpy_r_l, cpy_r_n, cpy_r_o) != 0;""")
 
     def test_box(self) -> None:
-        self.assert_emit(Box(self.n, int_rprimitive),
+        self.assert_emit(Box(self.n),
                          """cpy_r_r0 = CPyTagged_StealAsObject(cpy_r_n);""")
 
     def test_unbox(self) -> None:

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -154,8 +154,8 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """cpy_r_b = CPyList_SetItem(cpy_r_l, cpy_r_n, cpy_r_o) != 0;""")
 
     def test_box(self) -> None:
-        self.assert_emit(Box(self.o, self.n, int_rprimitive),
-                         """cpy_r_o = CPyTagged_StealAsObject(cpy_r_n);""")
+        self.assert_emit(Box(self.n, int_rprimitive),
+                         """cpy_r_r0 = CPyTagged_StealAsObject(cpy_r_n);""")
 
     def test_unbox(self) -> None:
         self.assert_emit(Unbox(self.m, int_rprimitive, 55),

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -55,16 +55,16 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.assert_emit(TupleGet(self.n, 1, bool_rprimitive, 0), 'cpy_r_r0 = cpy_r_n.f1;')
 
     def test_load_None(self) -> None:
-        self.assert_emit(PrimitiveOp(self.m, [], none_op, 0),
-                         """cpy_r_m = Py_None;
-                            Py_INCREF(cpy_r_m);
+        self.assert_emit(PrimitiveOp([], none_op, 0),
+                         """cpy_r_r0 = Py_None;
+                            Py_INCREF(cpy_r_r0);
                          """)
 
     def test_load_True(self) -> None:
-        self.assert_emit(PrimitiveOp(self.m, [], true_op, 0), "cpy_r_m = 1;")
+        self.assert_emit(PrimitiveOp([], true_op, 0), "cpy_r_r0 = 1;")
 
     def test_load_False(self) -> None:
-        self.assert_emit(PrimitiveOp(self.m, [], false_op, 0), "cpy_r_m = 0;")
+        self.assert_emit(PrimitiveOp([], false_op, 0), "cpy_r_r0 = 0;")
 
     def test_assign_int(self) -> None:
         self.assert_emit(Assign(self.m, self.n),
@@ -73,12 +73,12 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
     def test_int_add(self) -> None:
         self.assert_emit_binary_op(
             '+', self.n, self.m, self.k,
-            "cpy_r_n = CPyTagged_Add(cpy_r_m, cpy_r_k);")
+            "cpy_r_r0 = CPyTagged_Add(cpy_r_m, cpy_r_k);")
 
     def test_int_sub(self) -> None:
         self.assert_emit_binary_op(
             '-', self.n, self.m, self.k,
-            "cpy_r_n = CPyTagged_Subtract(cpy_r_m, cpy_r_k);")
+            "cpy_r_r0 = CPyTagged_Subtract(cpy_r_m, cpy_r_k);")
 
     def test_list_repeat(self) -> None:
         self.assert_emit_binary_op(
@@ -87,18 +87,18 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                 __tmp1 = CPyTagged_AsLongLong(cpy_r_n);
                 if (__tmp1 == -1 && PyErr_Occurred())
                     CPyError_OutOfMemory();
-                cpy_r_ll = PySequence_Repeat(cpy_r_l, __tmp1);
+                cpy_r_r0 = PySequence_Repeat(cpy_r_l, __tmp1);
              """)
 
     def test_int_neg(self) -> None:
-        self.assert_emit(PrimitiveOp(self.n, [self.m], int_neg_op, 55),
-                         "cpy_r_n = CPyTagged_Negate(cpy_r_m);")
+        self.assert_emit(PrimitiveOp([self.m], int_neg_op, 55),
+                         "cpy_r_r0 = CPyTagged_Negate(cpy_r_m);")
 
     def test_list_len(self) -> None:
-        self.assert_emit(PrimitiveOp(self.n, [self.l], list_len_op, 55),
+        self.assert_emit(PrimitiveOp([self.l], list_len_op, 55),
                          """long long __tmp1;
                             __tmp1 = PyList_GET_SIZE(cpy_r_l);
-                            cpy_r_n = CPyTagged_ShortFromLongLong(__tmp1);
+                            cpy_r_r0 = CPyTagged_ShortFromLongLong(__tmp1);
                          """)
 
     def test_branch_eq(self) -> None:
@@ -142,12 +142,12 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.assert_emit(DecRef(self.m, tuple_type), 'CPyTagged_DecRef(cpy_r_m.f0.f0);')
 
     def test_list_get_item(self) -> None:
-        self.assert_emit(PrimitiveOp(self.n, [self.m, self.k], list_get_item_op, 55),
-                         """cpy_r_n = CPyList_GetItem(cpy_r_m, cpy_r_k);""")
+        self.assert_emit(PrimitiveOp([self.m, self.k], list_get_item_op, 55),
+                         """cpy_r_r0 = CPyList_GetItem(cpy_r_m, cpy_r_k);""")
 
     def test_list_set_item(self) -> None:
-        self.assert_emit(PrimitiveOp(self.b, [self.l, self.n, self.o], list_set_item_op, 55),
-                         """cpy_r_b = CPyList_SetItem(cpy_r_l, cpy_r_n, cpy_r_o) != 0;""")
+        self.assert_emit(PrimitiveOp([self.l, self.n, self.o], list_set_item_op, 55),
+                         """cpy_r_r0 = CPyList_SetItem(cpy_r_l, cpy_r_n, cpy_r_o) != 0;""")
 
     def test_box(self) -> None:
         self.assert_emit(Box(self.n, int_rprimitive),
@@ -164,19 +164,19 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """)
 
     def test_new_list(self) -> None:
-        self.assert_emit(PrimitiveOp(self.l, [self.n, self.m], new_list_op, 55),
-                         """cpy_r_l = PyList_New(2);
+        self.assert_emit(PrimitiveOp([self.n, self.m], new_list_op, 55),
+                         """cpy_r_r0 = PyList_New(2);
                             Py_INCREF(cpy_r_n);
                             Py_INCREF(cpy_r_m);
-                            if (cpy_r_l != NULL) {
-                                PyList_SET_ITEM(cpy_r_l, 0, cpy_r_n);
-                                PyList_SET_ITEM(cpy_r_l, 1, cpy_r_m);
+                            if (cpy_r_r0 != NULL) {
+                                PyList_SET_ITEM(cpy_r_r0, 0, cpy_r_n);
+                                PyList_SET_ITEM(cpy_r_r0, 1, cpy_r_m);
                             }
                          """)
 
     def test_list_append(self) -> None:
-        self.assert_emit(PrimitiveOp(self.b, [self.l, self.o], list_append_op, 1),
-                         """cpy_r_b = PyList_Append(cpy_r_l, cpy_r_o) != -1;""")
+        self.assert_emit(PrimitiveOp([self.l, self.o], list_append_op, 1),
+                         """cpy_r_r0 = PyList_Append(cpy_r_l, cpy_r_o) != -1;""")
 
     def test_get_attr(self) -> None:
         ir = ClassIR('A', [('x', bool_rprimitive),
@@ -193,34 +193,34 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """cpy_r_r0 = CPY_SET_ATTR(cpy_r_n, 3, cpy_r_m, AObject, CPyTagged);""")
 
     def test_dict_get_item(self) -> None:
-        self.assert_emit(PrimitiveOp(self.o, [self.d, self.o2], dict_get_item_op, 1),
-                         """cpy_r_o = PyDict_GetItemWithError(cpy_r_d, cpy_r_o2);
-                            if (!cpy_r_o)
+        self.assert_emit(PrimitiveOp([self.d, self.o2], dict_get_item_op, 1),
+                         """cpy_r_r0 = PyDict_GetItemWithError(cpy_r_d, cpy_r_o2);
+                            if (!cpy_r_r0)
                                 PyErr_SetObject(PyExc_KeyError, cpy_r_o2);
                             else
-                                Py_INCREF(cpy_r_o);
+                                Py_INCREF(cpy_r_r0);
                          """)
 
     def test_dict_set_item(self) -> None:
-        self.assert_emit(PrimitiveOp(self.b, [self.d, self.o, self.o2], dict_set_item_op, 1),
-                         """cpy_r_b = PyDict_SetItem(cpy_r_d, cpy_r_o, cpy_r_o2) >= 0;""")
+        self.assert_emit(PrimitiveOp([self.d, self.o, self.o2], dict_set_item_op, 1),
+                         """cpy_r_r0 = PyDict_SetItem(cpy_r_d, cpy_r_o, cpy_r_o2) >= 0;""")
 
     def test_dict_update(self) -> None:
-        self.assert_emit(PrimitiveOp(self.b, [self.d, self.o], dict_update_op, 1),
-                        """cpy_r_b = PyDict_Update(cpy_r_d, cpy_r_o) != -1;""")
+        self.assert_emit(PrimitiveOp([self.d, self.o], dict_update_op, 1),
+                        """cpy_r_r0 = PyDict_Update(cpy_r_d, cpy_r_o) != -1;""")
 
     def test_new_dict(self) -> None:
-        self.assert_emit(PrimitiveOp(self.d, [], new_dict_op, 1),
-                         """cpy_r_d = PyDict_New();""")
+        self.assert_emit(PrimitiveOp([], new_dict_op, 1),
+                         """cpy_r_r0 = PyDict_New();""")
 
     def test_dict_contains(self) -> None:
         self.assert_emit_binary_op(
             'in', self.b, self.o, self.d,
              """int __tmp1 = PyDict_Contains(cpy_r_d, cpy_r_o);
                 if (__tmp1 < 0)
-                    cpy_r_b = 2;
+                    cpy_r_r0 = 2;
                 else
-                    cpy_r_b = __tmp1;
+                    cpy_r_r0 = __tmp1;
              """)
 
     def assert_emit(self, op: Op, expected: str) -> None:
@@ -251,7 +251,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         for desc in ops:
             if (is_subtype(left_type, desc.arg_types[0])
                     and is_subtype(right_type, desc.arg_types[1])):
-                self.assert_emit(PrimitiveOp(dest, [left, right], desc, 55), expected)
+                self.assert_emit(PrimitiveOp([left, right], desc, 55), expected)
                 break
         else:
             assert False, 'Could not find matching op'

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -48,8 +48,8 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          "return cpy_r_m;")
 
     def test_load_int(self) -> None:
-        self.assert_emit(LoadInt(self.m, 5),
-                         "cpy_r_m = 10;")
+        self.assert_emit(LoadInt(5),
+                         "cpy_r_r0 = 10;")
 
     def test_tuple_get(self) -> None:
         self.assert_emit(TupleGet(self.n, 1, bool_rprimitive, 0), 'cpy_r_r0 = cpy_r_n.f1;')
@@ -285,8 +285,10 @@ class TestGenerateFunction(unittest.TestCase):
             result, msg='Generated code invalid')
 
     def test_register(self) -> None:
-        self.temp = self.env.add_temp(int_rprimitive)
-        self.block.ops.append(LoadInt(self.temp, 5))
+        self.env.temp_index = 0
+        op = LoadInt(5)
+        self.block.ops.append(op)
+        self.env.add_op(op)
         fn = FuncIR('myfunc', None, [self.arg], list_rprimitive, [self.block], self.env)
         emitter = Emitter(EmitterContext())
         generate_native_function(fn, emitter, 'prog.py')

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -118,16 +118,12 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """)
 
     def test_call(self) -> None:
-        self.assert_emit(Call(self.n, 'myfn', [self.m], 55),
-                         "cpy_r_n = CPyDef_myfn(cpy_r_m);")
+        self.assert_emit(Call(int_rprimitive, 'myfn', [self.m], 55),
+                         "cpy_r_r0 = CPyDef_myfn(cpy_r_m);")
 
     def test_call_two_args(self) -> None:
-        self.assert_emit(Call(self.n, 'myfn', [self.m, self.k], 55),
-                         "cpy_r_n = CPyDef_myfn(cpy_r_m, cpy_r_k);")
-
-    def test_call_no_return(self) -> None:
-        self.assert_emit(Call(None, 'myfn', [self.m, self.k], 55),
-                         "CPyDef_myfn(cpy_r_m, cpy_r_k);")
+        self.assert_emit(Call(int_rprimitive, 'myfn', [self.m, self.k], 55),
+                         "cpy_r_r0 = CPyDef_myfn(cpy_r_m, cpy_r_k);")
 
     def test_inc_ref(self) -> None:
         self.assert_emit(IncRef(self.m, int_rprimitive),

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -37,8 +37,8 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.t = self.env.add_local(Var('t'), RTuple([int_rprimitive, bool_rprimitive]))
         self.tt = self.env.add_local(
             Var('tt'), RTuple([RTuple([int_rprimitive, bool_rprimitive]), bool_rprimitive]))
-        ir = ClassIR('A', [('x', bool_rprimitive),
-                           ('y', int_rprimitive)])
+        ir = ClassIR('A')
+        ir.attributes = [('x', bool_rprimitive), ('y', int_rprimitive)]
         self.r = self.env.add_local(Var('r'), RInstance(ir))
 
         self.context = EmitterContext()

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -35,7 +35,8 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.d = self.env.add_local(Var('d'), dict_rprimitive)
         self.b = self.env.add_local(Var('b'), bool_rprimitive)
         self.t = self.env.add_local(Var('t'), RTuple([int_rprimitive, bool_rprimitive]))
-
+        self.tt = self.env.add_local(
+            Var('tt'), RTuple([RTuple([int_rprimitive, bool_rprimitive]), bool_rprimitive]))
         ir = ClassIR('A', [('x', bool_rprimitive),
                            ('y', int_rprimitive)])
         self.r = self.env.add_local(Var('r'), RInstance(ir))
@@ -132,20 +133,18 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          "cpy_r_r0 = CPyDef_myfn(cpy_r_m, cpy_r_k);")
 
     def test_inc_ref(self) -> None:
-        self.assert_emit(IncRef(self.m, int_rprimitive),
+        self.assert_emit(IncRef(self.m),
                          "CPyTagged_IncRef(cpy_r_m);")
 
     def test_dec_ref(self) -> None:
-        self.assert_emit(DecRef(self.m, int_rprimitive),
+        self.assert_emit(DecRef(self.m),
                          "CPyTagged_DecRef(cpy_r_m);")
 
     def test_dec_ref_tuple(self) -> None:
-        tuple_type = RTuple([int_rprimitive, bool_rprimitive])
-        self.assert_emit(DecRef(self.m, tuple_type), 'CPyTagged_DecRef(cpy_r_m.f0);')
+        self.assert_emit(DecRef(self.t), 'CPyTagged_DecRef(cpy_r_t.f0);')
 
     def test_dec_ref_tuple_nested(self) -> None:
-        tuple_type = RTuple([RTuple([int_rprimitive, bool_rprimitive]), bool_rprimitive])
-        self.assert_emit(DecRef(self.m, tuple_type), 'CPyTagged_DecRef(cpy_r_m.f0.f0);')
+        self.assert_emit(DecRef(self.tt), 'CPyTagged_DecRef(cpy_r_tt.f0.f0);')
 
     def test_list_get_item(self) -> None:
         self.assert_emit(PrimitiveOp([self.m, self.k], list_get_item_op, 55),

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -192,8 +192,8 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         ir = ClassIR('A', [('x', bool_rprimitive),
                            ('y', int_rprimitive)])
         rtype = RInstance(ir)
-        self.assert_emit(SetAttr(self.b, self.n, 'y', self.m, rtype, 1),
-                         """cpy_r_b = CPY_SET_ATTR(cpy_r_n, 3, cpy_r_m, AObject, CPyTagged);""")
+        self.assert_emit(SetAttr(self.n, 'y', self.m, rtype, 1),
+                         """cpy_r_r0 = CPY_SET_ATTR(cpy_r_n, 3, cpy_r_m, AObject, CPyTagged);""")
 
     def test_dict_get_item(self) -> None:
         self.assert_emit(PrimitiveOp(self.o, [self.d, self.o2], dict_get_item_op, 1),

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -227,7 +227,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.emitter.fragments = []
         self.declarations.fragments = []
         self.env.temp_index = 0
-        if isinstance(op, RegisterOp) and op.no_reg:
+        if isinstance(op, RegisterOp):
             self.env.add_op(op)
         op.accept(self.visitor)
         frags = self.declarations.fragments + self.emitter.fragments

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -34,6 +34,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.o2 = self.env.add_local(Var('o2'), object_rprimitive)
         self.d = self.env.add_local(Var('d'), dict_rprimitive)
         self.b = self.env.add_local(Var('b'), bool_rprimitive)
+        self.t = self.env.add_local(Var('t'), RTuple([int_rprimitive, bool_rprimitive]))
         self.context = EmitterContext()
         self.emitter = Emitter(self.context, self.env)
         self.declarations = Emitter(self.context, self.env)
@@ -52,7 +53,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          "cpy_r_r0 = 10;")
 
     def test_tuple_get(self) -> None:
-        self.assert_emit(TupleGet(self.n, 1, bool_rprimitive, 0), 'cpy_r_r0 = cpy_r_n.f1;')
+        self.assert_emit(TupleGet(self.t, 1, 0), 'cpy_r_r0 = cpy_r_t.f1;')
 
     def test_load_None(self) -> None:
         self.assert_emit(PrimitiveOp([], none_op, 0),

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -35,6 +35,11 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.d = self.env.add_local(Var('d'), dict_rprimitive)
         self.b = self.env.add_local(Var('b'), bool_rprimitive)
         self.t = self.env.add_local(Var('t'), RTuple([int_rprimitive, bool_rprimitive]))
+
+        ir = ClassIR('A', [('x', bool_rprimitive),
+                           ('y', int_rprimitive)])
+        self.r = self.env.add_local(Var('r'), RInstance(ir))
+
         self.context = EmitterContext()
         self.emitter = Emitter(self.context, self.env)
         self.declarations = Emitter(self.context, self.env)
@@ -180,18 +185,12 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """cpy_r_r0 = PyList_Append(cpy_r_l, cpy_r_o) != -1;""")
 
     def test_get_attr(self) -> None:
-        ir = ClassIR('A', [('x', bool_rprimitive),
-                           ('y', int_rprimitive)])
-        rtype = RInstance(ir)
-        self.assert_emit(GetAttr(self.m, 'y', rtype, 1),
-                         """cpy_r_r0 = CPY_GET_ATTR(cpy_r_m, 2, AObject, CPyTagged);""")
+        self.assert_emit(GetAttr(self.r, 'y', 1),
+                         """cpy_r_r0 = CPY_GET_ATTR(cpy_r_r, 2, AObject, CPyTagged);""")
 
     def test_set_attr(self) -> None:
-        ir = ClassIR('A', [('x', bool_rprimitive),
-                           ('y', int_rprimitive)])
-        rtype = RInstance(ir)
-        self.assert_emit(SetAttr(self.n, 'y', self.m, rtype, 1),
-                         """cpy_r_r0 = CPY_SET_ATTR(cpy_r_n, 3, cpy_r_m, AObject, CPyTagged);""")
+        self.assert_emit(SetAttr(self.r, 'y', self.m, 1),
+                         """cpy_r_r0 = CPY_SET_ATTR(cpy_r_r, 3, cpy_r_m, AObject, CPyTagged);""")
 
     def test_dict_get_item(self) -> None:
         self.assert_emit(PrimitiveOp([self.d, self.o2], dict_get_item_op, 1),

--- a/test-data/analysis.test
+++ b/test-data/analysis.test
@@ -9,25 +9,31 @@ def f(a: int) -> None:
         z = 1
 [out]
 L0:
-    x = 1
+    r0 = 1
+    x = r0
     if x == a goto L1 else goto L2 :: int
 L1:
-    y = 1
+    r1 = 1
+    y = r1
     goto L3
 L2:
-    z = 1
+    r2 = 1
+    z = r2
 L3:
-    r0 = None
-    return r0
+    r3 = None
+    return r3
 
-(0, 0)   {a}                     {a, x}
-(0, 1)   {a, x}                  {a, x}
-(1, 0)   {a, x}                  {a, x, y}
-(1, 1)   {a, x, y}               {a, x, y}
-(2, 0)   {a, x}                  {a, x, z}
-(2, 1)   {a, x, z}               {a, x, z}
-(3, 0)   {a, x, y, z}            {a, x, y, z, r0}
-(3, 1)   {a, x, y, z, r0}        {a, x, y, z, r0}
+(0, 0)   {a}                     {a, r0}
+(0, 1)   {a, r0}                 {a, r0, x}
+(0, 2)   {a, r0, x}              {a, r0, x}
+(1, 0)   {a, r0, x}              {a, r0, r1, x}
+(1, 1)   {a, r0, r1, x}          {a, r0, r1, x, y}
+(1, 2)   {a, r0, r1, x, y}       {a, r0, r1, x, y}
+(2, 0)   {a, r0, x}              {a, r0, r2, x}
+(2, 1)   {a, r0, r2, x}          {a, r0, r2, x, z}
+(2, 2)   {a, r0, r2, x, z}       {a, r0, r2, x, z}
+(3, 0)   {a, r0, r1, r2, x, y, z} {a, r0, r1, r2, r3, x, y, z}
+(3, 1)   {a, r0, r1, r2, r3, x, y, z} {a, r0, r1, r2, r3, x, y, z}
 
 [case testSimple_Liveness]
 def f(a: int) -> int:
@@ -38,9 +44,10 @@ def f(a: int) -> int:
         return x
 [out]
 L0:
-    x = 1
     r0 = 1
-    if x == r0 goto L1 else goto L2 :: int
+    x = r0
+    r1 = 1
+    if x == r1 goto L1 else goto L2 :: int
 L1:
     return a
 L2:
@@ -48,9 +55,10 @@ L2:
 L3:
     unreachable
 
-(0, 0)   {a}                     {a, x}
-(0, 1)   {a, x}                  {a, x, r0}
-(0, 2)   {a, x, r0}              {a, x}
+(0, 0)   {a}                     {a, r0}
+(0, 1)   {a, r0}                 {a, x}
+(0, 2)   {a, x}                  {a, r1, x}
+(0, 3)   {a, r1, x}              {a, x}
 (1, 0)   {a}                     {}
 (2, 0)   {x}                     {}
 (3, 0)   {}                      {}
@@ -63,15 +71,21 @@ def f() -> int:
     return x
 [out]
 L0:
-    x = 1
-    y = 1
-    x = 2
+    r0 = 1
+    x = r0
+    r1 = 1
+    y = r1
+    r2 = 2
+    x = r2
     return x
 
-(0, 0)   {}                      {}
-(0, 1)   {}                      {}
-(0, 2)   {}                      {x}
-(0, 3)   {x}                     {}
+(0, 0)   {}                      {r0}
+(0, 1)   {r0}                    {}
+(0, 2)   {}                      {r1}
+(0, 3)   {r1}                    {}
+(0, 4)   {}                      {r2}
+(0, 5)   {r2}                    {x}
+(0, 6)   {x}                     {}
 
 [case testSpecial2_Liveness]
 def f(a: int) -> int:
@@ -81,15 +95,21 @@ def f(a: int) -> int:
     return a
 [out]
 L0:
-    a = 1
-    a = 2
-    a = 3
+    r0 = 1
+    a = r0
+    r1 = 2
+    a = r1
+    r2 = 3
+    a = r2
     return a
 
-(0, 0)   {}                      {}
-(0, 1)   {}                      {}
-(0, 2)   {}                      {a}
-(0, 3)   {a}                     {}
+(0, 0)   {}                      {r0}
+(0, 1)   {r0}                    {}
+(0, 2)   {}                      {r1}
+(0, 3)   {r1}                    {}
+(0, 4)   {}                      {r2}
+(0, 5)   {r2}                    {a}
+(0, 6)   {a}                     {}
 
 [case testSimple_MustDefined]
 def f(a: int) -> None:
@@ -103,24 +123,30 @@ L0:
     r0 = 1
     if a == r0 goto L1 else goto L2 :: int
 L1:
-    y = 1
-    x = 2
+    r1 = 1
+    y = r1
+    r2 = 2
+    x = r2
     goto L3
 L2:
-    x = 2
+    r3 = 2
+    x = r3
 L3:
-    r1 = None
-    return r1
+    r4 = None
+    return r4
 
 (0, 0)   {a}                     {a, r0}
 (0, 1)   {a, r0}                 {a, r0}
-(1, 0)   {a, r0}                 {a, r0, y}
-(1, 1)   {a, r0, y}              {a, r0, y, x}
-(1, 2)   {a, r0, y, x}           {a, r0, y, x}
-(2, 0)   {a, r0}                 {a, r0, x}
-(2, 1)   {a, r0, x}              {a, r0, x}
-(3, 0)   {a, r0, x}              {a, r0, x, r1}
-(3, 1)   {a, r0, x, r1}          {a, r0, x, r1}
+(1, 0)   {a, r0}                 {a, r0, r1}
+(1, 1)   {a, r0, r1}             {a, r0, r1, y}
+(1, 2)   {a, r0, r1, y}          {a, r0, r1, r2, y}
+(1, 3)   {a, r0, r1, r2, y}      {a, r0, r1, r2, x, y}
+(1, 4)   {a, r0, r1, r2, x, y}   {a, r0, r1, r2, x, y}
+(2, 0)   {a, r0}                 {a, r0, r3}
+(2, 1)   {a, r0, r3}             {a, r0, r3, x}
+(2, 2)   {a, r0, r3, x}          {a, r0, r3, x}
+(3, 0)   {a, r0, x}              {a, r0, r4, x}
+(3, 1)   {a, r0, r4, x}          {a, r0, r4, x}
 
 [case testTwoArgs_MustDefined]
 def f(x: int, y: int) -> int:
@@ -155,8 +181,8 @@ L3:
 (1, 1)   {n, r0}                 {n, r0}
 (2, 0)   {n, r0}                 {n, r0, r1}
 (2, 1)   {n, r0, r1}             {n, r0, r1}
-(2, 2)   {n, r0, r1}             {n, r0, r1, m}
-(2, 3)   {n, r0, r1, m}          {n, r0, r1, m}
+(2, 2)   {n, r0, r1}             {m, n, r0, r1}
+(2, 3)   {m, n, r0, r1}          {m, n, r0, r1}
 (3, 0)   {n, r0}                 {n, r0, r2}
 (3, 1)   {n, r0, r2}             {n, r0, r2}
 
@@ -171,41 +197,47 @@ def f(n: int) -> None:
             n = x
 [out]
 L0:
-    x = 1
-    y = 1
-L1:
     r0 = 1
-    if n < r0 goto L2 else goto L6 :: int
+    x = r0
+    r1 = 1
+    y = r1
+L1:
+    r2 = 1
+    if n < r2 goto L2 else goto L6 :: int
 L2:
     n = y
 L3:
-    r1 = 2
-    if n < r1 goto L4 else goto L5 :: int
+    r3 = 2
+    if n < r3 goto L4 else goto L5 :: int
 L4:
-    n = 1
+    r4 = 1
+    n = r4
     n = x
     goto L3
 L5:
     goto L1
 L6:
-    r2 = None
-    return r2
+    r5 = None
+    return r5
 
-(0, 0)   {n}                     {n, x}
-(0, 1)   {n, x}                  {n, x, y}
-(0, 2)   {n, x, y}               {n, x, y}
-(1, 0)   {n, x, y}               {n, x, y, r0}
-(1, 1)   {n, x, y, r0}           {x, y}
+(0, 0)   {n}                     {n, r0}
+(0, 1)   {n, r0}                 {n, x}
+(0, 2)   {n, x}                  {n, r1, x}
+(0, 3)   {n, r1, x}              {n, x, y}
+(0, 4)   {n, x, y}               {n, x, y}
+(1, 0)   {n, x, y}               {n, r2, x, y}
+(1, 1)   {n, r2, x, y}           {x, y}
 (2, 0)   {x, y}                  {n, x, y}
 (2, 1)   {n, x, y}               {n, x, y}
-(3, 0)   {n, x, y}               {n, x, y, r1}
-(3, 1)   {n, x, y, r1}           {n, x, y}
-(4, 0)   {x, y}                  {x, y}
-(4, 1)   {x, y}                  {n, x, y}
-(4, 2)   {n, x, y}               {n, x, y}
+(3, 0)   {n, x, y}               {n, r3, x, y}
+(3, 1)   {n, r3, x, y}           {n, x, y}
+(4, 0)   {x, y}                  {r4, x, y}
+(4, 1)   {r4, x, y}              {x, y}
+(4, 2)   {x, y}                  {n, x, y}
+(4, 3)   {n, x, y}               {n, x, y}
 (5, 0)   {n, x, y}               {n, x, y}
-(6, 0)   {}                      {r2}
-(6, 1)   {r2}                    {}
+(6, 0)   {}                      {r5}
+(6, 1)   {r5}                    {}
 
 [case testCall_Liveness]
 def f(x: int) -> int:
@@ -249,15 +281,15 @@ L6:
     return r0
 
 (0, 0)   {a}                     {a}
-(1, 0)   {a, y, x}               {a, y, x}
-(2, 0)   {a, y, x}               {a, y, x}
-(3, 0)   {a, y, x}               {a, y, x}
-(4, 0)   {a, y, x}               {a, y, x}
-(4, 1)   {a, y, x}               {a, y, x}
-(5, 0)   {a, y, x}               {a, y, x}
-(5, 1)   {a, y, x}               {a, y, x}
-(6, 0)   {a, y, x}               {a, y, x, r0}
-(6, 1)   {a, y, x, r0}           {a, y, x, r0}
+(1, 0)   {a, x, y}               {a, x, y}
+(2, 0)   {a, x, y}               {a, x, y}
+(3, 0)   {a, x, y}               {a, x, y}
+(4, 0)   {a, x, y}               {a, x, y}
+(4, 1)   {a, x, y}               {a, x, y}
+(5, 0)   {a, x, y}               {a, x, y}
+(5, 1)   {a, x, y}               {a, x, y}
+(6, 0)   {a, x, y}               {a, r0, x, y}
+(6, 1)   {a, r0, x, y}           {a, r0, x, y}
 
 [case testTrivial_BorrowedArgument]
 def f(a: int, b: int) -> int:
@@ -276,12 +308,14 @@ def f(a: int) -> int:
 [out]
 L0:
     b = a
-    a = 1
+    r0 = 1
+    a = r0
     return a
 
 (0, 0)   {a}                     {a}
-(0, 1)   {a}                     {}
-(0, 2)   {}                      {}
+(0, 1)   {a}                     {a}
+(0, 2)   {a}                     {}
+(0, 3)   {}                      {}
 
 [case testConditional_BorrowedArgument]
 def f(a: int) -> int:
@@ -295,20 +329,26 @@ def f(a: int) -> int:
 L0:
     if a == a goto L1 else goto L2 :: int
 L1:
-    x = 2
-    a = 1
+    r0 = 2
+    x = r0
+    r1 = 1
+    a = r1
     goto L3
 L2:
-    x = 1
+    r2 = 1
+    x = r2
 L3:
     return x
 
 (0, 0)   {a}                     {a}
 (1, 0)   {a}                     {a}
-(1, 1)   {a}                     {}
-(1, 2)   {}                      {}
+(1, 1)   {a}                     {a}
+(1, 2)   {a}                     {a}
+(1, 3)   {a}                     {}
+(1, 4)   {}                      {}
 (2, 0)   {a}                     {a}
 (2, 1)   {a}                     {a}
+(2, 2)   {a}                     {a}
 (3, 0)   {}                      {}
 
 [case testLoop_BorrowedArgument]
@@ -321,14 +361,16 @@ def f(a: int) -> int:
     return sum
 [out]
 L0:
-    sum = 0
-    i = 0
+    r0 = 0
+    sum = r0
+    r1 = 0
+    i = r1
 L1:
     if i <= a goto L2 else goto L3 :: int
 L2:
     sum = sum + i :: int
-    r0 = 1
-    i = i + r0 :: int
+    r2 = 1
+    i = i + r2 :: int
     goto L1
 L3:
     return sum
@@ -336,6 +378,8 @@ L3:
 (0, 0)   {a}                     {a}
 (0, 1)   {a}                     {a}
 (0, 2)   {a}                     {a}
+(0, 3)   {a}                     {a}
+(0, 4)   {a}                     {a}
 (1, 0)   {a}                     {a}
 (2, 0)   {a}                     {a}
 (2, 1)   {a}                     {a}

--- a/test-data/analysis.test
+++ b/test-data/analysis.test
@@ -246,16 +246,18 @@ def f(x: int) -> int:
 [out]
 L0:
     r0 = 1
-    a = f(r0)
-    r1 = f(a)
-    r2 = r1 + a :: int
-    return r2
+    r1 = f(r0)
+    a = r1
+    r2 = f(a)
+    r3 = r2 + a :: int
+    return r3
 
 (0, 0)   {}                      {r0}
-(0, 1)   {r0}                    {a}
-(0, 2)   {a}                     {a, r1}
-(0, 3)   {a, r1}                 {r2}
-(0, 4)   {r2}                    {}
+(0, 1)   {r0}                    {r1}
+(0, 2)   {r1}                    {a}
+(0, 3)   {a}                     {a, r2}
+(0, 4)   {a, r2}                 {r3}
+(0, 5)   {r3}                    {}
 
 [case testLoop_MaybeDefined]
 def f(a: int) -> None:

--- a/test-data/analysis.test
+++ b/test-data/analysis.test
@@ -169,22 +169,24 @@ L1:
     if n < r0 goto L2 else goto L3 :: int
 L2:
     r1 = 1
-    n = n + r1 :: int
+    r2 = n + r1 :: int
+    n = r2
     m = n
     goto L1
 L3:
-    r2 = None
-    return r2
+    r3 = None
+    return r3
 
 (0, 0)   {n}                     {n}
 (1, 0)   {n}                     {n, r0}
 (1, 1)   {n, r0}                 {n, r0}
 (2, 0)   {n, r0}                 {n, r0, r1}
-(2, 1)   {n, r0, r1}             {n, r0, r1}
-(2, 2)   {n, r0, r1}             {m, n, r0, r1}
-(2, 3)   {m, n, r0, r1}          {m, n, r0, r1}
-(3, 0)   {n, r0}                 {n, r0, r2}
-(3, 1)   {n, r0, r2}             {n, r0, r2}
+(2, 1)   {n, r0, r1}             {n, r0, r1, r2}
+(2, 2)   {n, r0, r1, r2}         {n, r0, r1, r2}
+(2, 3)   {n, r0, r1, r2}         {m, n, r0, r1, r2}
+(2, 4)   {m, n, r0, r1, r2}      {m, n, r0, r1, r2}
+(3, 0)   {n, r0}                 {n, r0, r3}
+(3, 1)   {n, r0, r3}             {n, r0, r3}
 
 [case testMultiPass_Liveness]
 def f(n: int) -> None:
@@ -370,9 +372,11 @@ L0:
 L1:
     if i <= a goto L2 else goto L3 :: int
 L2:
-    sum = sum + i :: int
-    r2 = 1
-    i = i + r2 :: int
+    r2 = sum + i :: int
+    sum = r2
+    r3 = 1
+    r4 = i + r3 :: int
+    i = r4
     goto L1
 L3:
     return sum
@@ -387,6 +391,8 @@ L3:
 (2, 1)   {a}                     {a}
 (2, 2)   {a}                     {a}
 (2, 3)   {a}                     {a}
+(2, 4)   {a}                     {a}
+(2, 5)   {a}                     {a}
 (3, 0)   {a}                     {a}
 
 [case testError]

--- a/test-data/exceptions.test
+++ b/test-data/exceptions.test
@@ -13,15 +13,14 @@ L0:
     dec_ref r0 :: int
     if is_error(r1) goto L3 (error at f:3) else goto L1
 L1:
-    r3 = unbox(int, r1)
+    r2 = unbox(int, r1)
     dec_ref r1
-    if is_error(r3) goto L3 (error at f:3) else goto L2
+    if is_error(r2) goto L3 (error at f:3) else goto L2
 L2:
-    r2 = r3
     return r2
 L3:
-    r4 = <error> :: int
-    return r4
+    r3 = <error> :: int
+    return r3
 
 [case testListAppendAndSetItemError]
 from typing import List
@@ -106,26 +105,25 @@ L2:
     r0 = a[i] :: list
     if is_error(r0) goto L8 (error at sum:6) else goto L3
 L3:
-    r2 = unbox(int, r0)
+    r1 = unbox(int, r0)
     dec_ref r0
-    if is_error(r2) goto L9 (error at sum:6) else goto L4
+    if is_error(r1) goto L9 (error at sum:6) else goto L4
 L4:
-    r1 = r2
-    r5 = sum
+    r4 = sum
     sum = sum + r1 :: int
     dec_ref r1 :: int
+    dec_ref r4 :: int
+    r2 = 1
+    r5 = i
+    i = i + r2 :: int
+    dec_ref r2 :: int
     dec_ref r5 :: int
-    r3 = 1
-    r6 = i
-    i = i + r3 :: int
-    dec_ref r3 :: int
-    dec_ref r6 :: int
     goto L1
 L5:
     return sum
 L6:
-    r4 = <error> :: int
-    return r4
+    r3 = <error> :: int
+    return r3
 L7:
     dec_ref i :: int
     goto L5

--- a/test-data/exceptions.test
+++ b/test-data/exceptions.test
@@ -97,33 +97,35 @@ def sum(a: List[int], l: int) -> int:
     return sum
 [out]
 L0:
-    sum = 0
-    i = 0
+    r0 = 0
+    sum = r0
+    r1 = 0
+    i = r1
 L1:
     if i < l goto L2 else goto L7 :: int
 L2:
-    r0 = a[i] :: list
-    if is_error(r0) goto L8 (error at sum:6) else goto L3
+    r2 = a[i] :: list
+    if is_error(r2) goto L8 (error at sum:6) else goto L3
 L3:
-    r1 = unbox(int, r0)
-    dec_ref r0
-    if is_error(r1) goto L9 (error at sum:6) else goto L4
+    r3 = unbox(int, r2)
+    dec_ref r2
+    if is_error(r3) goto L9 (error at sum:6) else goto L4
 L4:
-    r4 = sum
-    sum = sum + r1 :: int
-    dec_ref r1 :: int
+    r6 = sum
+    sum = sum + r3 :: int
+    dec_ref r3 :: int
+    dec_ref r6 :: int
+    r4 = 1
+    r7 = i
+    i = i + r4 :: int
     dec_ref r4 :: int
-    r2 = 1
-    r5 = i
-    i = i + r2 :: int
-    dec_ref r2 :: int
-    dec_ref r5 :: int
+    dec_ref r7 :: int
     goto L1
 L5:
     return sum
 L6:
-    r3 = <error> :: int
-    return r3
+    r5 = <error> :: int
+    return r5
 L7:
     dec_ref i :: int
     goto L5
@@ -135,4 +137,3 @@ L9:
     dec_ref sum :: int
     dec_ref i :: int
     goto L6
-

--- a/test-data/exceptions.test
+++ b/test-data/exceptions.test
@@ -111,21 +111,21 @@ L3:
     dec_ref r2
     if is_error(r3) goto L9 (error at sum:6) else goto L4
 L4:
-    r6 = sum
-    sum = sum + r3 :: int
+    r4 = sum + r3 :: int
+    dec_ref sum :: int
     dec_ref r3 :: int
-    dec_ref r6 :: int
-    r4 = 1
-    r7 = i
-    i = i + r4 :: int
-    dec_ref r4 :: int
-    dec_ref r7 :: int
+    sum = r4
+    r5 = 1
+    r6 = i + r5 :: int
+    dec_ref i :: int
+    dec_ref r5 :: int
+    i = r6
     goto L1
 L5:
     return sum
 L6:
-    r5 = <error> :: int
-    return r5
+    r7 = <error> :: int
+    return r7
 L7:
     dec_ref i :: int
     goto L5

--- a/test-data/exceptions.test
+++ b/test-data/exceptions.test
@@ -13,14 +13,15 @@ L0:
     dec_ref r0 :: int
     if is_error(r1) goto L3 (error at f:3) else goto L1
 L1:
-    r2 = unbox(int, r1)
+    r3 = unbox(int, r1)
     dec_ref r1
-    if is_error(r2) goto L3 (error at f:3) else goto L2
+    if is_error(r3) goto L3 (error at f:3) else goto L2
 L2:
+    r2 = r3
     return r2
 L3:
-    r3 = <error> :: int
-    return r3
+    r4 = <error> :: int
+    return r4
 
 [case testListAppendAndSetItemError]
 from typing import List
@@ -105,25 +106,26 @@ L2:
     r0 = a[i] :: list
     if is_error(r0) goto L8 (error at sum:6) else goto L3
 L3:
-    r1 = unbox(int, r0)
+    r2 = unbox(int, r0)
     dec_ref r0
-    if is_error(r1) goto L9 (error at sum:6) else goto L4
+    if is_error(r2) goto L9 (error at sum:6) else goto L4
 L4:
-    r4 = sum
+    r1 = r2
+    r5 = sum
     sum = sum + r1 :: int
     dec_ref r1 :: int
-    dec_ref r4 :: int
-    r2 = 1
-    r5 = i
-    i = i + r2 :: int
-    dec_ref r2 :: int
     dec_ref r5 :: int
+    r3 = 1
+    r6 = i
+    i = i + r3 :: int
+    dec_ref r3 :: int
+    dec_ref r6 :: int
     goto L1
 L5:
     return sum
 L6:
-    r3 = <error> :: int
-    return r3
+    r4 = <error> :: int
+    return r4
 L7:
     dec_ref i :: int
     goto L5
@@ -135,3 +137,4 @@ L9:
     dec_ref sum :: int
     dec_ref i :: int
     goto L6
+

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -564,8 +564,8 @@ def g(y):
     r11 :: object
 L0:
     r0 = 1
-    r1 = box(int, r0)
-    r2 = g(r1)
+    r2 = box(int, r0)
+    r1 = g(r2)
     a = [y]
     r3 = 0
     r5 = 1

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -734,8 +734,15 @@ def f(o, p, n, b, t, s, a, l, d):
     d2 :: dict
     r1 :: None
 L0:
+    o = o
+    p = p
+    n = n
+    b = b
+    t = t
+    s = s
     r0 = box(int, n)
     o = r0
+    a = a
     l2 = l
     d2 = d
     r1 = None

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -616,20 +616,25 @@ def f(x: object) -> None:
 [out]
 def f(x):
     x :: object
-    n :: int
-    b :: bool
-    a :: A
-    l :: list
-    t :: tuple[int, A]
-    r0 :: None
+    n, r0 :: int
+    b, r1 :: bool
+    a, r2 :: A
+    l, r3 :: list
+    t, r4 :: tuple[int, A]
+    r5 :: None
 L0:
-    n = unbox(int, x)
-    b = unbox(bool, x)
-    a = cast(A, x)
-    l = cast(list, x)
-    t = unbox(tuple[int, A], x)
-    r0 = None
-    return r0
+    r0 = unbox(int, x)
+    n = r0
+    r1 = unbox(bool, x)
+    b = r1
+    r2 = cast(A, x)
+    a = r2
+    r3 = cast(list, x)
+    l = r3
+    r4 = unbox(tuple[int, A], x)
+    t = r4
+    r5 = None
+    return r5
 
 [case testDownCastSpecialCases]
 from typing import cast, Optional, Tuple
@@ -644,18 +649,22 @@ def f(o, n, t):
     o :: optional[A]
     n :: int
     t :: tuple
-    a :: A
+    a, r0 :: A
     m :: bool
-    r0 :: object
+    r1 :: object
+    r2, r3 :: bool
     tt :: tuple[int, int]
-    r1 :: None
+    r4 :: None
 L0:
-    a = cast(A, o)
-    r0 = box(int, n)
-    m = unbox(bool, r0)
+    r0 = cast(A, o)
+    a = r0
+    r1 = box(int, n)
+    r2 = unbox(bool, r1)
+    r3 = unbox(bool, r2)
+    m = r3
     t = box(tuple[int, int], tt)
-    r1 = None
-    return r1
+    r4 = None
+    return r4
 
 [case testSuccessfulCast]
 from typing import cast, Optional, Tuple, List, Dict

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -656,21 +656,20 @@ def f(o, n, t):
     a, r0 :: A
     m :: bool
     r1 :: object
-    r2, r3 :: bool
+    r2 :: bool
     tt :: tuple[int, int]
-    r4 :: object
-    r5 :: None
+    r3 :: object
+    r4 :: None
 L0:
     r0 = cast(A, o)
     a = r0
     r1 = box(int, n)
     r2 = unbox(bool, r1)
-    r3 = unbox(bool, r2)
-    m = r3
-    r4 = box(tuple[int, int], tt)
-    t = r4
-    r5 = None
-    return r5
+    m = r2
+    r3 = box(tuple[int, int], tt)
+    t = r3
+    r4 = None
+    return r4
 
 [case testSuccessfulCast]
 from typing import cast, Optional, Tuple, List, Dict
@@ -710,15 +709,8 @@ def f(o, p, n, b, t, s, a, l, d):
     d2 :: dict
     r1 :: None
 L0:
-    o = o
-    p = p
-    n = n
-    b = b
-    t = t
-    s = s
     r0 = box(int, n)
     o = r0
-    a = a
     l2 = l
     d2 = d
     r1 = None

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -457,9 +457,9 @@ def f(x):
 L0:
     r0 = module_testmodule :: static
     r1 = r0.factorial
-    r3 = box(int, x)
-    r2 = r1(r3) :: py
-    r4 = unbox(int, r2)
+    r2 = box(int, x)
+    r3 = r1(r2) :: py
+    r4 = unbox(int, r3)
     return r4
 
 [case testPrintFullname]
@@ -477,9 +477,9 @@ L0:
     r0 = module_builtins :: static
     r1 = r0.print
     r2 = 5
-    r4 = box(int, r2)
-    r3 = r1(r4) :: py
-    r5 = cast(None, r3)
+    r3 = box(int, r2)
+    r4 = r1(r3) :: py
+    r5 = cast(None, r4)
     r6 = None
     return r6
 
@@ -496,9 +496,9 @@ L0:
     r0 = 5
     r1 = module_builtins :: static
     r2 = r1.print
-    r4 = box(int, r0)
-    r3 = r2(r4) :: py
-    r5 = cast(None, r3)
+    r3 = box(int, r0)
+    r4 = r2(r3) :: py
+    r5 = cast(None, r4)
     r6 = None
     return r6
 
@@ -586,8 +586,8 @@ def g(y):
     r12 :: object
 L0:
     r0 = 1
-    r2 = box(int, r0)
-    r1 = g(r2)
+    r1 = box(int, r0)
+    r2 = g(r1)
     a = [y]
     r3 = 0
     r4 = 1

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -206,12 +206,13 @@ def f(x: int, y: int) -> int:
     return x
 [out]
 def f(x, y):
-    x, y :: int
+    x, y, r0 :: int
 L0:
 L1:
     if x > y goto L2 else goto L3 :: int
 L2:
-    x = x - y :: int
+    r0 = x - y :: int
+    x = r0
     goto L1
 L3:
     return x
@@ -224,14 +225,15 @@ def f(x: int, y: int) -> int:
     return x
 [out]
 def f(x, y):
-    x, y, r0 :: int
+    x, y, r0, r1 :: int
 L0:
     r0 = 1
     x = r0
 L1:
     if x > y goto L2 else goto L3 :: int
 L2:
-    x = x - y :: int
+    r1 = x - y :: int
+    x = r1
     goto L1
 L3:
     return x
@@ -390,12 +392,13 @@ def f() -> int:
     return x
 [out]
 def f():
-    x, r0, r1 :: int
+    x, r0, r1, r2 :: int
 L0:
     r0 = 0
     x = r0
     r1 = 1
-    x = x + r1 :: int
+    r2 = x + r1 :: int
+    x = r2
     return x
 
 [case testTrue]
@@ -550,15 +553,15 @@ def g(y):
     y :: object
     r0 :: None
     r1 :: int
-    r2 :: list
-    r3 :: object
+    r2 :: object
+    r3 :: list
     r4, r5, r6, r7 :: None
 L0:
     r0 = g(y)
     r1 = 1
-    r3 = box(int, r1)
-    r2 = [r3]
-    r4 = g(r2)
+    r2 = box(int, r1)
+    r3 = [r2]
+    r4 = g(r3)
     r5 = None
     r6 = g(r5)
     r7 = None
@@ -576,31 +579,32 @@ def g(y):
     y :: object
     r0 :: int
     r1, r2 :: object
-    a :: list
-    r3, r4, r5 :: int
-    r6 :: tuple[int, int]
-    r7 :: object
-    r8, r9 :: bool
-    r10 :: object
-    r11 :: int
-    r12 :: object
+    a, r3 :: list
+    r4, r5, r6 :: int
+    r7 :: tuple[int, int]
+    r8 :: object
+    r9, r10 :: bool
+    r11 :: object
+    r12 :: int
+    r13 :: object
 L0:
     r0 = 1
     r1 = box(int, r0)
     r2 = g(r1)
-    a = [y]
-    r3 = 0
-    r4 = 1
-    r5 = 2
-    r6 = (r4, r5)
-    r7 = box(tuple[int, int], r6)
-    r8 = a.__setitem__(r3, r7)
-    r9 = True
-    r10 = box(bool, r9)
-    y = r10
-    r11 = 3
-    r12 = box(int, r11)
-    return r12
+    r3 = [y]
+    a = r3
+    r4 = 0
+    r5 = 1
+    r6 = 2
+    r7 = (r5, r6)
+    r8 = box(tuple[int, int], r7)
+    r9 = a.__setitem__(r4, r8)
+    r10 = True
+    r11 = box(bool, r10)
+    y = r11
+    r12 = 3
+    r13 = box(int, r12)
+    return r13
 
 [case testCoerceToObject2]
 class A:

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -556,9 +556,8 @@ def g(y):
     r0 :: int
     r1, r2 :: object
     a :: list
-    r3 :: int
-    r4 :: tuple[int, int]
-    r5, r6 :: int
+    r3, r4, r5 :: int
+    r6 :: tuple[int, int]
     r7 :: object
     r8, r9 :: bool
     r10 :: int
@@ -569,10 +568,10 @@ L0:
     r1 = g(r2)
     a = [y]
     r3 = 0
-    r5 = 1
-    r6 = 2
-    r4 = (r5, r6)
-    r7 = box(tuple[int, int], r4)
+    r4 = 1
+    r5 = 2
+    r6 = (r4, r5)
+    r7 = box(tuple[int, int], r6)
     r8 = a.__setitem__(r3, r7)
     r9 = True
     y = box(bool, r9)

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -434,10 +434,10 @@ def f(x):
     r0, r1, r2, r3 :: object
     r4 :: int
 L0:
-    r1 = module_testmodule :: static
-    r0 = r1.factorial
+    r0 = module_testmodule :: static
+    r1 = r0.factorial
     r3 = box(int, x)
-    r2 = r0(r3) :: py
+    r2 = r1(r3) :: py
     r4 = unbox(int, r2)
     return r4
 
@@ -453,11 +453,11 @@ def f(x):
     r3, r4 :: object
     r5, r6 :: None
 L0:
-    r1 = module_builtins :: static
-    r0 = r1.print
+    r0 = module_builtins :: static
+    r1 = r0.print
     r2 = 5
     r4 = box(int, r2)
-    r3 = r0(r4) :: py
+    r3 = r1(r4) :: py
     r5 = cast(None, r3)
     r6 = None
     return r6
@@ -473,10 +473,10 @@ def f(x):
     r5, r6 :: None
 L0:
     r0 = 5
-    r2 = module_builtins :: static
-    r1 = r2.print
+    r1 = module_builtins :: static
+    r2 = r1.print
     r4 = box(int, r0)
-    r3 = r1(r4) :: py
+    r3 = r2(r4) :: py
     r5 = cast(None, r3)
     r6 = None
     return r6

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -44,9 +44,10 @@ def f() -> int:
     return y
 [out]
 def f():
-    x, y :: int
+    x, r0, y :: int
 L0:
-    x = 1
+    r0 = 1
+    x = r0
     y = x
     return y
 
@@ -57,13 +58,14 @@ def f(x: int) -> None:
     return
 [out]
 def f(x):
-    x, y :: int
-    r0 :: None
+    x, y, r0 :: int
+    r1 :: None
 L0:
-    y = 1
+    r0 = 1
+    y = r0
     y = x
-    r0 = None
-    return r0
+    r1 = None
+    return r1
 
 [case testIntArithmetic]
 def f(x: int, y: int) -> int:
@@ -84,11 +86,12 @@ def f(x: int, y: int) -> int:
     return x
 [out]
 def f(x, y):
-    x, y :: int
+    x, y, r0 :: int
 L0:
     if x < y goto L1 else goto L2 :: int
 L1:
-    x = 1
+    r0 = 1
+    x = r0
 L2:
     return x
 
@@ -101,14 +104,16 @@ def f(x: int, y: int) -> int:
     return x
 [out]
 def f(x, y):
-    x, y :: int
+    x, y, r0, r1 :: int
 L0:
     if x < y goto L1 else goto L2 :: int
 L1:
-    x = 1
+    r0 = 1
+    x = r0
     goto L3
 L2:
-    x = 2
+    r1 = 2
+    x = r1
 L3:
     return x
 
@@ -121,16 +126,18 @@ def f(x: int, y: int) -> int:
     return x
 [out]
 def f(x, y):
-    x, y :: int
+    x, y, r0, r1 :: int
 L0:
     if x < y goto L1 else goto L3 :: int
 L1:
     if x > y goto L2 else goto L3 :: int
 L2:
-    x = 1
+    r0 = 1
+    x = r0
     goto L4
 L3:
-    x = 2
+    r1 = 2
+    x = r1
 L4:
     return x
 
@@ -143,16 +150,18 @@ def f(x: int, y: int) -> int:
     return x
 [out]
 def f(x, y):
-    x, y :: int
+    x, y, r0, r1 :: int
 L0:
     if x < y goto L2 else goto L1 :: int
 L1:
     if x > y goto L2 else goto L3 :: int
 L2:
-    x = 1
+    r0 = 1
+    x = r0
     goto L4
 L3:
-    x = 2
+    r1 = 2
+    x = r1
 L4:
     return x
 
@@ -163,11 +172,12 @@ def f(x: int, y: int) -> int:
     return x
 [out]
 def f(x, y):
-    x, y :: int
+    x, y, r0 :: int
 L0:
     if not x < y goto L1 else goto L2 :: int
 L1:
-    x = 1
+    r0 = 1
+    x = r0
 L2:
     return x
 
@@ -178,13 +188,14 @@ def f(x: int, y: int) -> int:
     return x
 [out]
 def f(x, y):
-    x, y :: int
+    x, y, r0 :: int
 L0:
     if not x < y goto L2 else goto L1 :: int
 L1:
     if not x > y goto L2 else goto L3 :: int
 L2:
-    x = 1
+    r0 = 1
+    x = r0
 L3:
     return x
 
@@ -213,9 +224,10 @@ def f(x: int, y: int) -> int:
     return x
 [out]
 def f(x, y):
-    x, y :: int
+    x, y, r0 :: int
 L0:
-    x = 1
+    r0 = 1
+    x = r0
 L1:
     if x > y goto L2 else goto L3 :: int
 L2:
@@ -239,12 +251,13 @@ def f() -> None:
     x = 1
 [out]
 def f():
-    x :: int
-    r0 :: None
+    x, r0 :: int
+    r1 :: None
 L0:
-    x = 1
-    r0 = None
-    return r0
+    r0 = 1
+    x = r0
+    r1 = None
+    return r1
 
 [case testImplicitNoneReturnAndIf]
 def f(x: int, y: int) -> None:
@@ -254,18 +267,20 @@ def f(x: int, y: int) -> None:
         y = 2
 [out]
 def f(x, y):
-    x, y :: int
-    r0 :: None
+    x, y, r0, r1 :: int
+    r2 :: None
 L0:
     if x < y goto L1 else goto L2 :: int
 L1:
-    x = 1
+    r0 = 1
+    x = r0
     goto L3
 L2:
-    y = 2
+    r1 = 2
+    y = r1
 L3:
-    r0 = None
-    return r0
+    r2 = None
+    return r2
 
 [case testRecursion]
 def f(n: int) -> int:
@@ -316,21 +331,24 @@ def f(n: int) -> int:
     return x
 [out]
 def f(n):
-    n, r0, x, r1 :: int
+    n, r0, x, r1, r2, r3, r4 :: int
 L0:
     r0 = 0
     if n < r0 goto L1 else goto L2 :: int
 L1:
-    x = 1
+    r1 = 1
+    x = r1
     goto L6
 L2:
-    r1 = 0
-    if n == r1 goto L3 else goto L4 :: int
+    r2 = 0
+    if n == r2 goto L3 else goto L4 :: int
 L3:
-    x = 1
+    r3 = 1
+    x = r3
     goto L5
 L4:
-    x = 2
+    r4 = 2
+    x = r4
 L5:
 L6:
     return x
@@ -351,15 +369,17 @@ def f(n: int) -> int:
     return 0 if n == 0 else 1
 [out]
 def f(n):
-    n, r0, r1 :: int
+    n, r0, r1, r2, r3 :: int
 L0:
     r0 = 0
     if n == r0 goto L1 else goto L2 :: int
 L1:
-    r1 = 0
+    r2 = 0
+    r1 = r2
     goto L3
 L2:
-    r1 = 1
+    r3 = 1
+    r1 = r3
 L3:
     return r1
 
@@ -370,11 +390,12 @@ def f() -> int:
     return x
 [out]
 def f():
-    x, r0 :: int
+    x, r0, r1 :: int
 L0:
-    x = 0
-    r0 = 1
-    x = x + r0 :: int
+    r0 = 0
+    x = r0
+    r1 = 1
+    x = x + r1 :: int
     return x
 
 [case testTrue]

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -560,8 +560,9 @@ def g(y):
     r6 :: tuple[int, int]
     r7 :: object
     r8, r9 :: bool
-    r10 :: int
-    r11 :: object
+    r10 :: object
+    r11 :: int
+    r12 :: object
 L0:
     r0 = 1
     r2 = box(int, r0)
@@ -574,10 +575,11 @@ L0:
     r7 = box(tuple[int, int], r6)
     r8 = a.__setitem__(r3, r7)
     r9 = True
-    y = box(bool, r9)
-    r10 = 3
-    r11 = box(int, r10)
-    return r11
+    r10 = box(bool, r9)
+    y = r10
+    r11 = 3
+    r12 = box(int, r11)
+    return r12
 
 [case testCoerceToObject2]
 class A:
@@ -594,15 +596,17 @@ def f(a, o):
     r1 :: object
     r2 :: bool
     r3 :: int
-    r4 :: None
+    r4 :: object
+    r5 :: None
 L0:
     r0 = 1
     r1 = box(int, r0)
     a.x = r1; r2 = is_error
     r3 = a.n
-    o = box(int, r3)
-    r4 = None
-    return r4
+    r4 = box(int, r3)
+    o = r4
+    r5 = None
+    return r5
 
 [case testDownCast]
 from typing import cast, List, Tuple
@@ -654,7 +658,8 @@ def f(o, n, t):
     r1 :: object
     r2, r3 :: bool
     tt :: tuple[int, int]
-    r4 :: None
+    r4 :: object
+    r5 :: None
 L0:
     r0 = cast(A, o)
     a = r0
@@ -662,9 +667,10 @@ L0:
     r2 = unbox(bool, r1)
     r3 = unbox(bool, r2)
     m = r3
-    t = box(tuple[int, int], tt)
-    r4 = None
-    return r4
+    r4 = box(tuple[int, int], tt)
+    t = r4
+    r5 = None
+    return r5
 
 [case testSuccessfulCast]
 from typing import cast, Optional, Tuple, List, Dict
@@ -699,9 +705,10 @@ def f(o, p, n, b, t, s, a, l, d):
     a :: A
     l :: list
     d :: dict
+    r0 :: object
     l2 :: list
     d2 :: dict
-    r0 :: None
+    r1 :: None
 L0:
     o = o
     p = p
@@ -709,9 +716,11 @@ L0:
     b = b
     t = t
     s = s
-    o = box(int, n)
+    r0 = box(int, n)
+    o = r0
     a = a
     l2 = l
     d2 = d
-    r0 = None
-    return r0
+    r1 = None
+    return r1
+

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -487,11 +487,12 @@ def f() -> str:
     return "some other string"
 [out]
 def f():
-    x, r0 :: str
+    x, r0, r1 :: str
 L0:
-    x = __unicode_0 :: static
-    r0 = __unicode_1 :: static
-    return r0
+    r0 = __unicode_0 :: static
+    x = r0
+    r1 = __unicode_1 :: static
+    return r1
 
 [case testPyMethodCall1]
 from typing import List

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -62,3 +62,33 @@ L0:
     r5 = 1
     r6 = r4 + r5 :: int
     return r6
+
+[case testMethodCall]
+class A:
+    def f(self, x: int, y: str) -> int:
+        return x + 10
+
+def g(a: A) -> None:
+    a.f(1, 'hi')
+[out]
+def f(self, x, y):
+    self :: A
+    x :: int
+    y :: str
+    r0, r1 :: int
+L0:
+    r0 = 10
+    r1 = x + r0 :: int
+    return r1
+def g(a):
+    a :: A
+    r0 :: int
+    r1 :: str
+    r2 :: int
+    r3 :: None
+L0:
+    r0 = 1
+    r1 = __unicode_0 :: static
+    r2 = a.f(r0, r1)
+    r3 = None
+    return r3

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -49,7 +49,8 @@ def f():
     d :: C
     r2 :: int
     r3 :: object
-    r4, r5, r6 :: int
+    r4 :: C
+    r5, r6, r7 :: int
 L0:
     c = C()
     r0 = 5
@@ -57,11 +58,12 @@ L0:
     a = [c]
     r2 = 0
     r3 = a[r2] :: list
-    d = cast(C, r3)
-    r4 = d.x
-    r5 = 1
-    r6 = r4 + r5 :: int
-    return r6
+    r4 = cast(C, r3)
+    d = r4
+    r5 = d.x
+    r6 = 1
+    r7 = r5 + r6 :: int
+    return r7
 
 [case testMethodCall]
 class A:

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -96,3 +96,18 @@ L0:
     r2 = a.f(r0, r1)
     r3 = None
     return r3
+
+[case testForwardUse]
+def g(a: A) -> int:
+    return a.n
+
+class A:
+    n : int
+
+[out]
+def g(a):
+    a :: A
+    r0 :: int
+L0:
+    r0 = a.n
+    return r0

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -45,26 +45,27 @@ def f():
     c, r0 :: C
     r1 :: int
     r2 :: bool
-    a :: list
+    a, r3 :: list
     d :: C
-    r3 :: int
-    r4 :: object
-    r5 :: C
-    r6, r7, r8 :: int
+    r4 :: int
+    r5 :: object
+    r6 :: C
+    r7, r8, r9 :: int
 L0:
     r0 = C()
     c = r0
     r1 = 5
     c.x = r1; r2 = is_error
-    a = [c]
-    r3 = 0
-    r4 = a[r3] :: list
-    r5 = cast(C, r4)
-    d = r5
-    r6 = d.x
-    r7 = 1
-    r8 = r6 + r7 :: int
-    return r8
+    r3 = [c]
+    a = r3
+    r4 = 0
+    r5 = a[r4] :: list
+    r6 = cast(C, r5)
+    d = r6
+    r7 = d.x
+    r8 = 1
+    r9 = r7 + r8 :: int
+    return r9
 
 [case testMethodCall]
 class A:

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -42,28 +42,29 @@ def f() -> int:
     return d.x + 1
 [out]
 def f():
-    c :: C
-    r0 :: int
-    r1 :: bool
+    c, r0 :: C
+    r1 :: int
+    r2 :: bool
     a :: list
     d :: C
-    r2 :: int
-    r3 :: object
-    r4 :: C
-    r5, r6, r7 :: int
+    r3 :: int
+    r4 :: object
+    r5 :: C
+    r6, r7, r8 :: int
 L0:
-    c = C()
-    r0 = 5
-    c.x = r0; r1 = is_error
+    r0 = C()
+    c = r0
+    r1 = 5
+    c.x = r1; r2 = is_error
     a = [c]
-    r2 = 0
-    r3 = a[r2] :: list
-    r4 = cast(C, r3)
-    d = r4
-    r5 = d.x
-    r6 = 1
-    r7 = r5 + r6 :: int
-    return r7
+    r3 = 0
+    r4 = a[r3] :: list
+    r5 = cast(C, r4)
+    d = r5
+    r6 = d.x
+    r7 = 1
+    r8 = r6 + r7 :: int
+    return r8
 
 [case testMethodCall]
 class A:

--- a/test-data/genops-dict.test
+++ b/test-data/genops-dict.test
@@ -43,12 +43,13 @@ def f() -> None:
     d = {}  # type: Dict[bool, int]
 [out]
 def f():
-    d :: dict
-    r0 :: None
+    d, r0 :: dict
+    r1 :: None
 L0:
-    d = {}
-    r0 = None
-    return r0
+    r0 = {}
+    d = r0
+    r1 = None
+    return r1
 
 [case testInDict]
 from typing import Dict
@@ -61,14 +62,13 @@ def f(d: Dict[int, int]) -> bool:
 def f(d):
     d :: dict
     r0 :: int
-    r1 :: bool
-    r2 :: object
-    r3, r4 :: bool
+    r1 :: object
+    r2, r3, r4 :: bool
 L0:
     r0 = 4
-    r2 = box(int, r0)
-    r1 = r2 in d :: dict
-    if r1 goto L1 else goto L2 :: bool
+    r1 = box(int, r0)
+    r2 = r1 in d :: dict
+    if r2 goto L1 else goto L2 :: bool
 L1:
     r3 = True
     return r3
@@ -89,14 +89,13 @@ def f(d: Dict[int, int]) -> bool:
 def f(d):
     d :: dict
     r0 :: int
-    r1 :: bool
-    r2 :: object
-    r3, r4 :: bool
+    r1 :: object
+    r2, r3, r4 :: bool
 L0:
     r0 = 4
-    r2 = box(int, r0)
-    r1 = r2 in d :: dict
-    if not r1 goto L1 else goto L2 :: bool
+    r1 = box(int, r0)
+    r2 = r1 in d :: dict
+    if not r2 goto L1 else goto L2 :: bool
 L1:
     r3 = True
     return r3

--- a/test-data/genops-dict.test
+++ b/test-data/genops-dict.test
@@ -7,12 +7,13 @@ def f(d):
     d :: dict
     r0 :: int
     r1, r2 :: object
-    r3 :: bool
+    r3, r4 :: bool
 L0:
     r0 = 0
     r1 = box(int, r0)
     r2 = d[r1] :: dict
-    r3 = unbox(bool, r2)
+    r4 = unbox(bool, r2)
+    r3 = r4
     return r3
 
 [case testDictSet]

--- a/test-data/genops-dict.test
+++ b/test-data/genops-dict.test
@@ -7,13 +7,12 @@ def f(d):
     d :: dict
     r0 :: int
     r1, r2 :: object
-    r3, r4 :: bool
+    r3 :: bool
 L0:
     r0 = 0
     r1 = box(int, r0)
     r2 = d[r1] :: dict
-    r4 = unbox(bool, r2)
-    r3 = r4
+    r3 = unbox(bool, r2)
     return r3
 
 [case testDictSet]

--- a/test-data/genops-lists.test
+++ b/test-data/genops-lists.test
@@ -77,12 +77,13 @@ def f() -> None:
     x = []  # type: List[int]
 [out]
 def f():
-    x :: list
-    r0 :: None
+    x, r0 :: list
+    r1 :: None
 L0:
-    x = []
-    r0 = None
-    return r0
+    r0 = []
+    x = r0
+    r1 = None
+    return r1
 
 [case testNewListTwoItems]
 from typing import List
@@ -93,15 +94,17 @@ def f():
     x :: list
     r0, r1 :: int
     r2, r3 :: object
-    r4 :: None
+    r4 :: list
+    r5 :: None
 L0:
     r0 = 1
     r1 = 2
     r2 = box(int, r0)
     r3 = box(int, r1)
-    x = [r2, r3]
-    r4 = None
-    return r4
+    r4 = [r2, r3]
+    x = r4
+    r5 = None
+    return r5
 
 [case testListMultiply]
 from typing import List
@@ -111,20 +114,24 @@ def f(a: List[int]) -> None:
 [out]
 def f(a):
     a, b :: list
-    r0, r1, r2 :: int
-    r3 :: list
+    r0 :: int
+    r1 :: list
+    r2, r3 :: int
     r4 :: object
-    r5 :: None
+    r5, r6 :: list
+    r7 :: None
 L0:
     r0 = 2
-    b = a * r0 :: list
-    r1 = 3
-    r2 = 4
-    r4 = box(int, r2)
-    r3 = [r4]
-    b = r1 * r3 :: list
-    r5 = None
-    return r5
+    r1 = a * r0 :: list
+    b = r1
+    r2 = 3
+    r3 = 4
+    r4 = box(int, r3)
+    r5 = [r4]
+    r6 = r2 * r5 :: list
+    b = r6
+    r7 = None
+    return r7
 
 [case testListLen]
 from typing import List

--- a/test-data/genops-lists.test
+++ b/test-data/genops-lists.test
@@ -7,11 +7,12 @@ def f(x):
     x :: list
     r0 :: int
     r1 :: object
-    r2 :: int
+    r2, r3 :: int
 L0:
     r0 = 0
     r1 = x[r0] :: list
-    r2 = unbox(int, r1)
+    r3 = unbox(int, r1)
+    r2 = r3
     return r2
 
 [case testListOfListGet]
@@ -23,11 +24,12 @@ def f(x):
     x :: list
     r0 :: int
     r1 :: object
-    r2 :: list
+    r2, r3 :: list
 L0:
     r0 = 0
     r1 = x[r0] :: list
-    r2 = cast(list, r1)
+    r3 = cast(list, r1)
+    r2 = r3
     return r2
 
 [case testListOfListGet2]
@@ -39,18 +41,20 @@ def f(x):
     x :: list
     r0 :: int
     r1 :: object
-    r2 :: list
-    r3 :: int
-    r4 :: object
-    r5 :: int
+    r2, r3 :: list
+    r4 :: int
+    r5 :: object
+    r6, r7 :: int
 L0:
     r0 = 0
     r1 = x[r0] :: list
-    r2 = cast(list, r1)
-    r3 = 1
-    r4 = r2[r3] :: list
-    r5 = unbox(int, r4)
-    return r5
+    r3 = cast(list, r1)
+    r2 = r3
+    r4 = 1
+    r5 = r2[r4] :: list
+    r7 = unbox(int, r5)
+    r6 = r7
+    return r6
 
 [case testListSet]
 from typing import List

--- a/test-data/genops-lists.test
+++ b/test-data/genops-lists.test
@@ -7,12 +7,11 @@ def f(x):
     x :: list
     r0 :: int
     r1 :: object
-    r2, r3 :: int
+    r2 :: int
 L0:
     r0 = 0
     r1 = x[r0] :: list
-    r3 = unbox(int, r1)
-    r2 = r3
+    r2 = unbox(int, r1)
     return r2
 
 [case testListOfListGet]
@@ -24,12 +23,11 @@ def f(x):
     x :: list
     r0 :: int
     r1 :: object
-    r2, r3 :: list
+    r2 :: list
 L0:
     r0 = 0
     r1 = x[r0] :: list
-    r3 = cast(list, r1)
-    r2 = r3
+    r2 = cast(list, r1)
     return r2
 
 [case testListOfListGet2]
@@ -41,20 +39,18 @@ def f(x):
     x :: list
     r0 :: int
     r1 :: object
-    r2, r3 :: list
-    r4 :: int
-    r5 :: object
-    r6, r7 :: int
+    r2 :: list
+    r3 :: int
+    r4 :: object
+    r5 :: int
 L0:
     r0 = 0
     r1 = x[r0] :: list
-    r3 = cast(list, r1)
-    r2 = r3
-    r4 = 1
-    r5 = r2[r4] :: list
-    r7 = unbox(int, r5)
-    r6 = r7
-    return r6
+    r2 = cast(list, r1)
+    r3 = 1
+    r4 = r2[r3] :: list
+    r5 = unbox(int, r4)
+    return r5
 
 [case testListSet]
 from typing import List

--- a/test-data/genops-optional.test
+++ b/test-data/genops-optional.test
@@ -60,33 +60,35 @@ def f(x: Optional[A], y: Optional[A], z: Optional[int]) -> None:
 def f(x, y, z):
     x, y :: optional[A]
     z :: optional[int]
-    r0 :: A
-    r1 :: int
-    r2 :: object
-    a, r3 :: A
-    r4 :: int
-    r5 :: object
-    r6 :: bool
-    r7 :: None
-    r8 :: bool
-    r9 :: None
+    r0 :: None
+    r1 :: A
+    r2 :: int
+    r3 :: object
+    a, r4 :: A
+    r5 :: int
+    r6 :: object
+    r7 :: bool
+    r8 :: None
+    r9 :: bool
+    r10 :: None
 L0:
-    x = None
-    r0 = A()
+    r0 = None
     x = r0
+    r1 = A()
+    x = r1
     x = y
-    r1 = 1
-    r2 = box(int, r1)
-    z = r2
-    r3 = A()
-    a = r3
-    r4 = 1
-    r5 = box(int, r4)
-    a.a = r5; r6 = is_error
-    r7 = None
-    a.a = r7; r8 = is_error
-    r9 = None
-    return r9
+    r2 = 1
+    r3 = box(int, r2)
+    z = r3
+    r4 = A()
+    a = r4
+    r5 = 1
+    r6 = box(int, r5)
+    a.a = r6; r7 = is_error
+    r8 = None
+    a.a = r8; r9 = is_error
+    r10 = None
+    return r10
 
 [case testBoxOptionalListItem]
 from typing import List, Optional

--- a/test-data/genops-optional.test
+++ b/test-data/genops-optional.test
@@ -124,13 +124,15 @@ def f(x: Optional[A]) -> A:
 [out]
 def f(x):
     x :: optional[A]
-    y, r0 :: A
+    y, r0, r1 :: A
 L0:
     y = A()
     if not x is None goto L1 else goto L2 :: object
 L1:
-    y = cast(A, x)
     r0 = cast(A, x)
-    return r0
+    y = r0
+    r1 = cast(A, x)
+    return r1
 L2:
     return y
+

--- a/test-data/genops-optional.test
+++ b/test-data/genops-optional.test
@@ -60,30 +60,33 @@ def f(x: Optional[A], y: Optional[A], z: Optional[int]) -> None:
 def f(x, y, z):
     x, y :: optional[A]
     z :: optional[int]
-    r0 :: int
-    r1 :: object
-    a :: A
-    r2 :: int
-    r3 :: object
-    r4 :: bool
-    r5 :: None
+    r0 :: A
+    r1 :: int
+    r2 :: object
+    a, r3 :: A
+    r4 :: int
+    r5 :: object
     r6 :: bool
     r7 :: None
+    r8 :: bool
+    r9 :: None
 L0:
     x = None
-    x = A()
+    r0 = A()
+    x = r0
     x = y
-    r0 = 1
-    r1 = box(int, r0)
-    z = r1
-    a = A()
-    r2 = 1
-    r3 = box(int, r2)
-    a.a = r3; r4 = is_error
-    r5 = None
+    r1 = 1
+    r2 = box(int, r1)
+    z = r2
+    r3 = A()
+    a = r3
+    r4 = 1
+    r5 = box(int, r4)
     a.a = r5; r6 = is_error
     r7 = None
-    return r7
+    a.a = r7; r8 = is_error
+    r9 = None
+    return r9
 
 [case testBoxOptionalListItem]
 from typing import List, Optional
@@ -126,15 +129,15 @@ def f(x: Optional[A]) -> A:
 [out]
 def f(x):
     x :: optional[A]
-    y, r0, r1 :: A
+    y, r0, r1, r2 :: A
 L0:
-    y = A()
+    r0 = A()
+    y = r0
     if not x is None goto L1 else goto L2 :: object
 L1:
-    r0 = cast(A, x)
-    y = r0
     r1 = cast(A, x)
-    return r1
+    y = r1
+    r2 = cast(A, x)
+    return r2
 L2:
     return y
-

--- a/test-data/genops-optional.test
+++ b/test-data/genops-optional.test
@@ -61,27 +61,29 @@ def f(x, y, z):
     x, y :: optional[A]
     z :: optional[int]
     r0 :: int
+    r1 :: object
     a :: A
-    r1 :: int
-    r2 :: object
-    r3 :: bool
-    r4 :: None
-    r5 :: bool
-    r6 :: None
+    r2 :: int
+    r3 :: object
+    r4 :: bool
+    r5 :: None
+    r6 :: bool
+    r7 :: None
 L0:
     x = None
     x = A()
     x = y
     r0 = 1
-    z = box(int, r0)
+    r1 = box(int, r0)
+    z = r1
     a = A()
-    r1 = 1
-    r2 = box(int, r1)
-    a.a = r2; r3 = is_error
-    r4 = None
-    a.a = r4; r5 = is_error
-    r6 = None
-    return r6
+    r2 = 1
+    r3 = box(int, r2)
+    a.a = r3; r4 = is_error
+    r5 = None
+    a.a = r5; r6 = is_error
+    r7 = None
+    return r7
 
 [case testBoxOptionalListItem]
 from typing import List, Optional

--- a/test-data/genops-statements.test
+++ b/test-data/genops-statements.test
@@ -5,23 +5,25 @@ def f() -> None:
         x = x + i
 [out]
 def f():
-    x, r0, i, r1 :: int
-    r2 :: None
+    x, r0, r1, i, r2, r3 :: int
+    r4 :: None
 L0:
-    x = 0
-    r0 = 5
-    i = 0
+    r0 = 0
+    x = r0
+    r1 = 5
+    r2 = 0
+    i = r2
 L1:
-    if i < r0 goto L2 else goto L4 :: int
+    if r2 < r1 goto L2 else goto L4 :: int
 L2:
     x = x + i :: int
 L3:
-    r1 = 1
-    i = i + r1 :: int
+    r3 = 1
+    r2 = r2 + r3 :: int
     goto L1
 L4:
-    r2 = None
-    return r2
+    r4 = None
+    return r4
 
 [case testBreak]
 def f() -> None:
@@ -30,19 +32,20 @@ def f() -> None:
       break
 [out]
 def f():
-    n, r0 :: int
-    r1 :: None
+    n, r0, r1 :: int
+    r2 :: None
 L0:
-    n = 0
+    r0 = 0
+    n = r0
 L1:
-    r0 = 5
-    if n < r0 goto L2 else goto L3 :: int
+    r1 = 5
+    if n < r1 goto L2 else goto L3 :: int
 L2:
     goto L3
     goto L1
 L3:
-    r1 = None
-    return r1
+    r2 = None
+    return r2
 
 [case testBreakFor]
 def f() -> None:
@@ -50,22 +53,23 @@ def f() -> None:
         break
 [out]
 def f():
-    r0, n, r1 :: int
-    r2 :: None
+    r0, n, r1, r2 :: int
+    r3 :: None
 L0:
     r0 = 5
-    n = 0
+    r1 = 0
+    n = r1
 L1:
-    if n < r0 goto L2 else goto L4 :: int
+    if r1 < r0 goto L2 else goto L4 :: int
 L2:
     goto L4
 L3:
-    r1 = 1
-    n = n + r1 :: int
+    r2 = 1
+    r1 = r1 + r2 :: int
     goto L1
 L4:
-    r2 = None
-    return r2
+    r3 = None
+    return r3
 
 [case testBreakNested]
 def f() -> None:
@@ -76,17 +80,18 @@ def f() -> None:
         break
 [out]
 def f():
-    n, r0, r1 :: int
-    r2 :: None
+    n, r0, r1, r2 :: int
+    r3 :: None
 L0:
-    n = 0
+    r0 = 0
+    n = r0
 L1:
-    r0 = 5
-    if n < r0 goto L2 else goto L6 :: int
+    r1 = 5
+    if n < r1 goto L2 else goto L6 :: int
 L2:
 L3:
-    r1 = 4
-    if n < r1 goto L4 else goto L5 :: int
+    r2 = 4
+    if n < r2 goto L4 else goto L5 :: int
 L4:
     goto L5
     goto L3
@@ -94,8 +99,8 @@ L5:
     goto L6
     goto L1
 L6:
-    r2 = None
-    return r2
+    r3 = None
+    return r3
 
 [case testContinue]
 def f() -> None:
@@ -104,19 +109,20 @@ def f() -> None:
       continue
 [out]
 def f():
-    n, r0 :: int
-    r1 :: None
+    n, r0, r1 :: int
+    r2 :: None
 L0:
-    n = 0
+    r0 = 0
+    n = r0
 L1:
-    r0 = 5
-    if n < r0 goto L2 else goto L3 :: int
+    r1 = 5
+    if n < r1 goto L2 else goto L3 :: int
 L2:
     goto L1
     goto L1
 L3:
-    r1 = None
-    return r1
+    r2 = None
+    return r2
 
 [case testContinueFor]
 def f() -> None:
@@ -124,22 +130,23 @@ def f() -> None:
         continue
 [out]
 def f():
-    r0, n, r1 :: int
-    r2 :: None
+    r0, n, r1, r2 :: int
+    r3 :: None
 L0:
     r0 = 5
-    n = 0
+    r1 = 0
+    n = r1
 L1:
-    if n < r0 goto L2 else goto L4 :: int
+    if r1 < r0 goto L2 else goto L4 :: int
 L2:
     goto L3
 L3:
-    r1 = 1
-    n = n + r1 :: int
+    r2 = 1
+    r1 = r1 + r2 :: int
     goto L1
 L4:
-    r2 = None
-    return r2
+    r3 = None
+    return r3
 
 [case testContinueNested]
 def f() -> None:
@@ -150,17 +157,18 @@ def f() -> None:
         continue
 [out]
 def f():
-    n, r0, r1 :: int
-    r2 :: None
+    n, r0, r1, r2 :: int
+    r3 :: None
 L0:
-    n = 0
+    r0 = 0
+    n = r0
 L1:
-    r0 = 5
-    if n < r0 goto L2 else goto L6 :: int
+    r1 = 5
+    if n < r1 goto L2 else goto L6 :: int
 L2:
 L3:
-    r1 = 4
-    if n < r1 goto L4 else goto L5 :: int
+    r2 = 4
+    if n < r2 goto L4 else goto L5 :: int
 L4:
     goto L3
     goto L3
@@ -168,8 +176,8 @@ L5:
     goto L1
     goto L1
 L6:
-    r2 = None
-    return r2
+    r3 = None
+    return r3
 
 [case testForList]
 from typing import List
@@ -182,24 +190,24 @@ def f(ls: List[int]) -> int:
 [out]
 def f(ls):
     ls :: list
-    y, r0, r1, x, r2 :: int
-    r3 :: object
-    r4 :: int
+    y, r0, r1, r2, x, r3 :: int
+    r4 :: object
+    r5 :: int
 L0:
-    y = 0
     r0 = 0
-    r1 = 1
+    y = r0
+    r1 = 0
+    r2 = 1
 L1:
-    r2 = len ls :: list
-    if r0 < r2 goto L2 else goto L4 :: int
+    r3 = len ls :: list
+    if r1 < r3 goto L2 else goto L4 :: int
 L2:
-    r3 = ls[r0] :: list
-    r4 = unbox(int, r3)
-    x = r4
+    r4 = ls[r1] :: list
+    r5 = unbox(int, r4)
+    x = r5
     y = y + x :: int
 L3:
-    r0 = r0 + r1 :: int
+    r1 = r1 + r2 :: int
     goto L1
 L4:
     return y
-

--- a/test-data/genops-statements.test
+++ b/test-data/genops-statements.test
@@ -5,8 +5,8 @@ def f() -> None:
         x = x + i
 [out]
 def f():
-    x, r0, r1, i, r2, r3 :: int
-    r4 :: None
+    x, r0, r1, i, r2, r3, r4, r5 :: int
+    r6 :: None
 L0:
     r0 = 0
     x = r0
@@ -16,14 +16,16 @@ L0:
 L1:
     if r2 < r1 goto L2 else goto L4 :: int
 L2:
-    x = x + i :: int
+    r3 = x + i :: int
+    x = r3
 L3:
-    r3 = 1
-    r2 = r2 + r3 :: int
+    r4 = 1
+    r5 = r2 + r4 :: int
+    r2 = r5
     goto L1
 L4:
-    r4 = None
-    return r4
+    r6 = None
+    return r6
 
 [case testBreak]
 def f() -> None:
@@ -53,8 +55,8 @@ def f() -> None:
         break
 [out]
 def f():
-    r0, n, r1, r2 :: int
-    r3 :: None
+    r0, n, r1, r2, r3 :: int
+    r4 :: None
 L0:
     r0 = 5
     r1 = 0
@@ -65,11 +67,12 @@ L2:
     goto L4
 L3:
     r2 = 1
-    r1 = r1 + r2 :: int
+    r3 = r1 + r2 :: int
+    r1 = r3
     goto L1
 L4:
-    r3 = None
-    return r3
+    r4 = None
+    return r4
 
 [case testBreakNested]
 def f() -> None:
@@ -130,8 +133,8 @@ def f() -> None:
         continue
 [out]
 def f():
-    r0, n, r1, r2 :: int
-    r3 :: None
+    r0, n, r1, r2, r3 :: int
+    r4 :: None
 L0:
     r0 = 5
     r1 = 0
@@ -142,11 +145,12 @@ L2:
     goto L3
 L3:
     r2 = 1
-    r1 = r1 + r2 :: int
+    r3 = r1 + r2 :: int
+    r1 = r3
     goto L1
 L4:
-    r3 = None
-    return r3
+    r4 = None
+    return r4
 
 [case testContinueNested]
 def f() -> None:
@@ -192,7 +196,7 @@ def f(ls):
     ls :: list
     y, r0, r1, r2, x, r3 :: int
     r4 :: object
-    r5 :: int
+    r5, r6, r7 :: int
 L0:
     r0 = 0
     y = r0
@@ -205,9 +209,11 @@ L2:
     r4 = ls[r1] :: list
     r5 = unbox(int, r4)
     x = r5
-    y = y + x :: int
+    r6 = y + x :: int
+    y = r6
 L3:
-    r1 = r1 + r2 :: int
+    r7 = r1 + r2 :: int
+    r1 = r7
     goto L1
 L4:
     return y

--- a/test-data/genops-statements.test
+++ b/test-data/genops-statements.test
@@ -184,6 +184,7 @@ def f(ls):
     ls :: list
     y, r0, r1, x, r2 :: int
     r3 :: object
+    r4 :: int
 L0:
     y = 0
     r0 = 0
@@ -193,10 +194,12 @@ L1:
     if r0 < r2 goto L2 else goto L4 :: int
 L2:
     r3 = ls[r0] :: list
-    x = unbox(int, r3)
+    r4 = unbox(int, r3)
+    x = r4
     y = y + x :: int
 L3:
     r0 = r0 + r1 :: int
     goto L1
 L4:
     return y
+

--- a/test-data/genops-statements.test
+++ b/test-data/genops-statements.test
@@ -194,26 +194,27 @@ def f(ls: List[int]) -> int:
 [out]
 def f(ls):
     ls :: list
-    y, r0, r1, r2, x, r3 :: int
-    r4 :: object
-    r5, r6, r7 :: int
+    y, r0, r1, r2, r3, x, r4 :: int
+    r5 :: object
+    r6, r7, r8 :: int
 L0:
     r0 = 0
     y = r0
-    r1 = 0
-    r2 = 1
+    r2 = 0
+    r1 = r2
+    r3 = 1
 L1:
-    r3 = len ls :: list
-    if r1 < r3 goto L2 else goto L4 :: int
+    r4 = len ls :: list
+    if r1 < r4 goto L2 else goto L4 :: int
 L2:
-    r4 = ls[r1] :: list
-    r5 = unbox(int, r4)
-    x = r5
-    r6 = y + x :: int
-    y = r6
+    r5 = ls[r1] :: list
+    r6 = unbox(int, r5)
+    x = r6
+    r7 = y + x :: int
+    y = r7
 L3:
-    r7 = r1 + r2 :: int
-    r1 = r7
+    r8 = r1 + r3 :: int
+    r1 = r8
     goto L1
 L4:
     return y

--- a/test-data/genops-statements.test
+++ b/test-data/genops-statements.test
@@ -14,14 +14,14 @@ L0:
     r2 = 0
     i = r2
 L1:
-    if r2 < r1 goto L2 else goto L4 :: int
+    if i < r1 goto L2 else goto L4 :: int
 L2:
     r3 = x + i :: int
     x = r3
 L3:
     r4 = 1
-    r5 = r2 + r4 :: int
-    r2 = r5
+    r5 = i + r4 :: int
+    i = r5
     goto L1
 L4:
     r6 = None
@@ -62,13 +62,13 @@ L0:
     r1 = 0
     n = r1
 L1:
-    if r1 < r0 goto L2 else goto L4 :: int
+    if n < r0 goto L2 else goto L4 :: int
 L2:
     goto L4
 L3:
     r2 = 1
-    r3 = r1 + r2 :: int
-    r1 = r3
+    r3 = n + r2 :: int
+    n = r3
     goto L1
 L4:
     r4 = None
@@ -140,13 +140,13 @@ L0:
     r1 = 0
     n = r1
 L1:
-    if r1 < r0 goto L2 else goto L4 :: int
+    if n < r0 goto L2 else goto L4 :: int
 L2:
     goto L3
 L3:
     r2 = 1
-    r3 = r1 + r2 :: int
-    r1 = r3
+    r3 = n + r2 :: int
+    n = r3
     goto L1
 L4:
     r4 = None

--- a/test-data/genops-tuple.test
+++ b/test-data/genops-tuple.test
@@ -56,12 +56,13 @@ def f(x):
     r0 :: tuple
     r1 :: int
     r2 :: object
-    r3 :: bool
+    r3, r4 :: bool
 L0:
     r0 = tuple x :: list
     r1 = 1
     r2 = r0[r1] :: tuple
-    r3 = unbox(bool, r2)
+    r4 = unbox(bool, r2)
+    r3 = r4
     return r3
 
 [case testSequenceTupleLen]
@@ -88,7 +89,7 @@ def f():
     r2 :: tuple[int, int]
     r3 :: int
     r4 :: object
-    r5 :: int
+    r5, r6 :: int
 L0:
     r0 = 1
     r1 = 2
@@ -96,5 +97,7 @@ L0:
     t = box(tuple[int, int], r2)
     r3 = 1
     r4 = t[r3] :: tuple
-    r5 = unbox(int, r4)
+    r6 = unbox(int, r4)
+    r5 = r6
     return r5
+

--- a/test-data/genops-tuple.test
+++ b/test-data/genops-tuple.test
@@ -87,17 +87,19 @@ def f():
     t :: tuple
     r0, r1 :: int
     r2 :: tuple[int, int]
-    r3 :: int
-    r4 :: object
-    r5, r6 :: int
+    r3 :: object
+    r4 :: int
+    r5 :: object
+    r6, r7 :: int
 L0:
     r0 = 1
     r1 = 2
     r2 = (r0, r1)
-    t = box(tuple[int, int], r2)
-    r3 = 1
-    r4 = t[r3] :: tuple
-    r6 = unbox(int, r4)
-    r5 = r6
-    return r5
+    r3 = box(tuple[int, int], r2)
+    t = r3
+    r4 = 1
+    r5 = t[r4] :: tuple
+    r7 = unbox(int, r5)
+    r6 = r7
+    return r6
 

--- a/test-data/genops-tuple.test
+++ b/test-data/genops-tuple.test
@@ -56,13 +56,12 @@ def f(x):
     r0 :: tuple
     r1 :: int
     r2 :: object
-    r3, r4 :: bool
+    r3 :: bool
 L0:
     r0 = tuple x :: list
     r1 = 1
     r2 = r0[r1] :: tuple
-    r4 = unbox(bool, r2)
-    r3 = r4
+    r3 = unbox(bool, r2)
     return r3
 
 [case testSequenceTupleLen]
@@ -90,7 +89,7 @@ def f():
     r3 :: object
     r4 :: int
     r5 :: object
-    r6, r7 :: int
+    r6 :: int
 L0:
     r0 = 1
     r1 = 2
@@ -99,7 +98,6 @@ L0:
     t = r3
     r4 = 1
     r5 = t[r4] :: tuple
-    r7 = unbox(int, r5)
-    r6 = r7
+    r6 = unbox(int, r5)
     return r6
 

--- a/test-data/genops-tuple.test
+++ b/test-data/genops-tuple.test
@@ -23,13 +23,16 @@ def f() -> int:
 def f():
     t :: tuple[bool, int]
     r0 :: bool
-    r1, r2 :: int
+    r1 :: int
+    r2 :: tuple[bool, int]
+    r3 :: int
 L0:
     r0 = True
     r1 = 1
-    t = (r0, r1)
-    r2 = t[1]
-    return r2
+    r2 = (r0, r1)
+    t = r2
+    r3 = t[1]
+    return r3
 
 [case testTupleLen]
 from typing import Tuple
@@ -81,15 +84,16 @@ def f() -> int:
 [out]
 def f():
     t :: tuple
-    r0 :: tuple[int, int]
-    r1, r2, r3 :: int
+    r0, r1 :: int
+    r2 :: tuple[int, int]
+    r3 :: int
     r4 :: object
     r5 :: int
 L0:
-    r1 = 1
-    r2 = 2
-    r0 = (r1, r2)
-    t = box(tuple[int, int], r0)
+    r0 = 1
+    r1 = 2
+    r2 = (r0, r1)
+    t = box(tuple[int, int], r2)
     r3 = 1
     r4 = t[r3] :: tuple
     r5 = unbox(int, r4)

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -470,15 +470,14 @@ L0:
     r1 = 0
     r2 = b[r1] :: list
     dec_ref r1 :: int
-    r4 = unbox(int, r2)
+    r3 = unbox(int, r2)
     dec_ref r2
-    r3 = r4
-    r5 = box(int, r3)
-    r6 = a.__setitem__(r0, r5)
+    r4 = box(int, r3)
+    r5 = a.__setitem__(r0, r4)
     dec_ref r0 :: int
-    dec_ref r5
-    r7 = None
-    return r7
+    dec_ref r4
+    r6 = None
+    return r6
 
 [case testTupleRefcount]
 from typing import Tuple

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -86,10 +86,12 @@ def f(a: int, b: int) -> int:
 [out]
 L0:
     r0 = 1
-    x = a + r0 :: int
+    r1 = a + r0 :: int
     dec_ref r0 :: int
-    y = x + a :: int
+    x = r1
+    r2 = x + a :: int
     dec_ref x :: int
+    y = r2
     return y
 
 [case testArgumentsInAssign]
@@ -188,9 +190,10 @@ L2:
     goto L4
 L3:
     r2 = 1
-    y = a + r2 :: int
+    r3 = a + r2 :: int
     dec_ref a :: int
     dec_ref r2 :: int
+    y = r3
     return y
 L4:
     inc_ref a :: int
@@ -217,9 +220,10 @@ L2:
     a = r1
 L3:
     r2 = 1
-    y = a + r2 :: int
+    r3 = a + r2 :: int
     dec_ref a :: int
     dec_ref r2 :: int
+    y = r3
     return y
 L4:
     inc_ref a :: int
@@ -265,19 +269,20 @@ def f(a: int) -> int:
 [out]
 L0:
     r0 = 1
-    a = a + r0 :: int
+    r1 = a + r0 :: int
     dec_ref r0 :: int
-    r1 = 1
-    x = r1
+    a = r1
     r2 = 1
-    r4 = x
-    x = x + r2 :: int
-    dec_ref r2 :: int
-    dec_ref r4 :: int
-    r3 = a + x :: int
+    x = r2
+    r3 = 1
+    r4 = x + r3 :: int
+    dec_ref x :: int
+    dec_ref r3 :: int
+    x = r4
+    r5 = a + x :: int
     dec_ref a :: int
     dec_ref x :: int
-    return r3
+    return r5
 
 [case testIncrement2]
 def f() -> None:
@@ -288,13 +293,13 @@ L0:
     r0 = 1
     x = r0
     r1 = 1
-    r3 = x
-    x = x + r1 :: int
-    dec_ref r1 :: int
+    r2 = x + r1 :: int
     dec_ref x :: int
-    dec_ref r3 :: int
-    r2 = None
-    return r2
+    dec_ref r1 :: int
+    x = r2
+    dec_ref x :: int
+    r3 = None
+    return r3
 
 [case testAdd1]
 def f() -> None:
@@ -305,12 +310,13 @@ L0:
     r0 = 1
     y = r0
     r1 = 1
-    x = y + r1 :: int
+    r2 = y + r1 :: int
     dec_ref y :: int
     dec_ref r1 :: int
+    x = r2
     dec_ref x :: int
-    r2 = None
-    return r2
+    r3 = None
+    return r3
 
 [case testAdd2]
 def f(a: int) -> int:
@@ -320,11 +326,12 @@ def f(a: int) -> int:
     return x
 [out]
 L0:
-    a = a + a :: int
+    r0 = a + a :: int
+    a = r0
     x = a
-    r0 = x
-    x = x + x :: int
-    dec_ref r0 :: int
+    r1 = x + x :: int
+    dec_ref x :: int
+    x = r1
     return x
 
 [case testAdd3]
@@ -334,9 +341,11 @@ def f(a: int) -> int:
     return y
 [out]
 L0:
-    x = a + a :: int
-    y = x + x :: int
+    r0 = a + a :: int
+    x = r0
+    r1 = x + x :: int
     dec_ref x :: int
+    y = r1
     return y
 
 [case testAdd4]
@@ -346,15 +355,17 @@ def f(a: int) -> None:
     z = y + y
 [out]
 L0:
-    x = a + a :: int
+    r0 = a + a :: int
+    x = r0
     dec_ref x :: int
-    r0 = 1
-    y = r0
-    z = y + y :: int
+    r1 = 1
+    y = r1
+    r2 = y + y :: int
     dec_ref y :: int
+    z = r2
     dec_ref z :: int
-    r1 = None
-    return r1
+    r3 = None
+    return r3
 
 [case testAdd5]
 def f(a: int) -> None:
@@ -363,16 +374,17 @@ def f(a: int) -> None:
     x = x + x
 [out]
 L0:
-    a = a + a :: int
+    r0 = a + a :: int
+    a = r0
     dec_ref a :: int
-    r0 = 1
-    x = r0
-    r2 = x
-    x = x + x :: int
+    r1 = 1
+    x = r1
+    r2 = x + x :: int
     dec_ref x :: int
-    dec_ref r2 :: int
-    r1 = None
-    return r1
+    x = r2
+    dec_ref x :: int
+    r3 = None
+    return r3
 
 [case testReturnInMiddleOfFunction]
 def f() -> int:
@@ -429,14 +441,14 @@ L0:
 L1:
     if i <= a goto L2 else goto L4 :: int
 L2:
-    r3 = sum
-    sum = sum + i :: int
+    r2 = sum + i :: int
+    dec_ref sum :: int
+    sum = r2
+    r3 = 1
+    r4 = i + r3 :: int
+    dec_ref i :: int
     dec_ref r3 :: int
-    r2 = 1
-    r4 = i
-    i = i + r2 :: int
-    dec_ref r2 :: int
-    dec_ref r4 :: int
+    i = r4
     goto L1
 L3:
     return sum
@@ -469,12 +481,13 @@ L0:
     r1 = 1
     r2 = box(int, r0)
     r3 = box(int, r1)
-    a = [r2, r3]
+    r4 = [r2, r3]
     dec_ref r2
     dec_ref r3
+    a = r4
     dec_ref a
-    r4 = 0
-    return r4
+    r5 = 0
+    return r5
 
 [case testReturnList]
 from typing import List
@@ -483,10 +496,10 @@ def f(x: int) -> List[int]:
 [out]
 L0:
     inc_ref x :: int
-    r1 = box(int, x)
-    r0 = [r1]
-    dec_ref r1
-    return r0
+    r0 = box(int, x)
+    r1 = [r0]
+    dec_ref r0
+    return r1
 
 [case testListSet]
 from typing import List
@@ -544,17 +557,18 @@ def f() -> None:
 [out]
 L0:
     r0 = C()
-    a = [r0]
+    r1 = [r0]
     dec_ref r0
-    r1 = 0
-    r2 = a[r1] :: list
+    a = r1
+    r2 = 0
+    r3 = a[r2] :: list
     dec_ref a
-    dec_ref r1 :: int
-    r3 = cast(C, r2)
-    d = r3
+    dec_ref r2 :: int
+    r4 = cast(C, r3)
+    d = r4
     dec_ref d
-    r4 = None
-    return r4
+    r5 = None
+    return r5
 
 [case testUnaryBranchSpecialCase]
 def f(x: bool) -> int:

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -14,7 +14,8 @@ def f() -> int:
     return x
 [out]
 L0:
-    x = 1
+    r0 = 1
+    x = r0
     return x
 
 [case testLocalVars]
@@ -25,7 +26,8 @@ def f() -> int:
     return x
 [out]
 L0:
-    x = 1
+    r0 = 1
+    x = r0
     y = x
     x = y
     return x
@@ -38,14 +40,15 @@ def f() -> int:
     return y + z
 [out]
 L0:
-    x = 1
+    r0 = 1
+    x = r0
     inc_ref x :: int
     y = x
     z = x
-    r0 = y + z :: int
+    r1 = y + z :: int
     dec_ref y :: int
     dec_ref z :: int
-    return r0
+    return r1
 
 [case testFreeAtReturn]
 def f() -> int:
@@ -56,21 +59,23 @@ def f() -> int:
     return y
 [out]
 L0:
-    x = 1
-    y = 2
     r0 = 1
-    if x == r0 goto L3 else goto L4 :: int
+    x = r0
+    r1 = 2
+    y = r1
+    r2 = 1
+    if x == r2 goto L3 else goto L4 :: int
 L1:
     return x
 L2:
     return y
 L3:
     dec_ref y :: int
-    dec_ref r0 :: int
+    dec_ref r2 :: int
     goto L1
 L4:
     dec_ref x :: int
-    dec_ref r0 :: int
+    dec_ref r2 :: int
     goto L2
 
 [case testArgumentsInOps]
@@ -100,11 +105,12 @@ L0:
     dec_ref x :: int
     inc_ref a :: int
     y = a
-    x = 1
-    r0 = x + y :: int
+    r0 = 1
+    x = r0
+    r1 = x + y :: int
     dec_ref x :: int
     dec_ref y :: int
-    return r0
+    return r1
 
 [case testAssignToArgument1]
 def f(a: int) -> int:
@@ -113,7 +119,8 @@ def f(a: int) -> int:
     return y
 [out]
 L0:
-    a = 1
+    r0 = 1
+    a = r0
     y = a
     return y
 
@@ -125,14 +132,17 @@ def f(a: int) -> int:
     return a
 [out]
 L0:
-    a = 1
+    r0 = 1
+    a = r0
     dec_ref a :: int
-    a = 2
+    r1 = 2
+    a = r1
     dec_ref a :: int
-    a = 3
+    r2 = 3
+    a = r2
     return a
 
-[case testAssignToArgument2]
+[case testAssignToArgument3]
 def f(a: int) -> int:
     x = 1
     a = x
@@ -140,7 +150,8 @@ def f(a: int) -> int:
     return a
 [out]
 L0:
-    x = 1
+    r0 = 1
+    x = r0
     inc_ref x :: int
     a = x
     y = x
@@ -167,17 +178,19 @@ def f(a: int) -> int:
 L0:
     if a == a goto L1 else goto L2 :: int
 L1:
-    a = 1
+    r0 = 1
+    a = r0
     goto L3
 L2:
-    x = 2
+    r1 = 2
+    x = r1
     dec_ref x :: int
     goto L4
 L3:
-    r0 = 1
-    y = a + r0 :: int
+    r2 = 1
+    y = a + r2 :: int
     dec_ref a :: int
-    dec_ref r0 :: int
+    dec_ref r2 :: int
     return y
 L4:
     inc_ref a :: int
@@ -195,16 +208,18 @@ def f(a: int) -> int:
 L0:
     if a == a goto L1 else goto L2 :: int
 L1:
-    x = 2
+    r0 = 2
+    x = r0
     dec_ref x :: int
     goto L4
 L2:
-    a = 1
+    r1 = 1
+    a = r1
 L3:
-    r0 = 1
-    y = a + r0 :: int
+    r2 = 1
+    y = a + r2 :: int
     dec_ref a :: int
-    dec_ref r0 :: int
+    dec_ref r2 :: int
     return y
 L4:
     inc_ref a :: int
@@ -219,7 +234,8 @@ def f(a: int) -> int:
 L0:
     if a == a goto L1 else goto L3 :: int
 L1:
-    a = 1
+    r0 = 1
+    a = r0
 L2:
     return a
 L3:
@@ -234,10 +250,11 @@ def f(a: int) -> int:
     return x + a
 [out]
 L0:
-    x = 1
-    r0 = x + a :: int
+    r0 = 1
+    x = r0
+    r1 = x + a :: int
     dec_ref x :: int
-    return r0
+    return r1
 
 [case testIncrement1]
 def f(a: int) -> int:
@@ -250,16 +267,17 @@ L0:
     r0 = 1
     a = a + r0 :: int
     dec_ref r0 :: int
-    x = 1
     r1 = 1
-    r3 = x
-    x = x + r1 :: int
-    dec_ref r1 :: int
-    dec_ref r3 :: int
-    r2 = a + x :: int
+    x = r1
+    r2 = 1
+    r4 = x
+    x = x + r2 :: int
+    dec_ref r2 :: int
+    dec_ref r4 :: int
+    r3 = a + x :: int
     dec_ref a :: int
     dec_ref x :: int
-    return r2
+    return r3
 
 [case testIncrement2]
 def f() -> None:
@@ -267,15 +285,16 @@ def f() -> None:
     x = x + 1
 [out]
 L0:
-    x = 1
     r0 = 1
-    r2 = x
-    x = x + r0 :: int
-    dec_ref r0 :: int
+    x = r0
+    r1 = 1
+    r3 = x
+    x = x + r1 :: int
+    dec_ref r1 :: int
     dec_ref x :: int
-    dec_ref r2 :: int
-    r1 = None
-    return r1
+    dec_ref r3 :: int
+    r2 = None
+    return r2
 
 [case testAdd1]
 def f() -> None:
@@ -283,14 +302,15 @@ def f() -> None:
     x = y + 1
 [out]
 L0:
-    y = 1
     r0 = 1
-    x = y + r0 :: int
+    y = r0
+    r1 = 1
+    x = y + r1 :: int
     dec_ref y :: int
-    dec_ref r0 :: int
+    dec_ref r1 :: int
     dec_ref x :: int
-    r1 = None
-    return r1
+    r2 = None
+    return r2
 
 [case testAdd2]
 def f(a: int) -> int:
@@ -328,12 +348,13 @@ def f(a: int) -> None:
 L0:
     x = a + a :: int
     dec_ref x :: int
-    y = 1
+    r0 = 1
+    y = r0
     z = y + y :: int
     dec_ref y :: int
     dec_ref z :: int
-    r0 = None
-    return r0
+    r1 = None
+    return r1
 
 [case testAdd5]
 def f(a: int) -> None:
@@ -344,13 +365,14 @@ def f(a: int) -> None:
 L0:
     a = a + a :: int
     dec_ref a :: int
-    x = 1
-    r1 = x
+    r0 = 1
+    x = r0
+    r2 = x
     x = x + x :: int
     dec_ref x :: int
-    dec_ref r1 :: int
-    r0 = None
-    return r0
+    dec_ref r2 :: int
+    r1 = None
+    return r1
 
 [case testReturnInMiddleOfFunction]
 def f() -> int:
@@ -363,21 +385,25 @@ def f() -> int:
     return x + y - a
 [out]
 L0:
-    x = 1
-    y = 2
-    z = 3
+    r0 = 1
+    x = r0
+    r1 = 2
+    y = r1
+    r2 = 3
+    z = r2
     if z == z goto L3 else goto L4 :: int
 L1:
     return z
 L2:
-    a = 1
-    r0 = x + y :: int
+    r3 = 1
+    a = r3
+    r4 = x + y :: int
     dec_ref x :: int
     dec_ref y :: int
-    r1 = r0 - a :: int
-    dec_ref r0 :: int
+    r5 = r4 - a :: int
+    dec_ref r4 :: int
     dec_ref a :: int
-    return r1
+    return r5
 L3:
     dec_ref x :: int
     dec_ref y :: int
@@ -396,19 +422,21 @@ def f(a: int) -> int:
     return sum
 [out]
 L0:
-    sum = 0
-    i = 0
+    r0 = 0
+    sum = r0
+    r1 = 0
+    i = r1
 L1:
     if i <= a goto L2 else goto L4 :: int
 L2:
-    r1 = sum
+    r3 = sum
     sum = sum + i :: int
-    dec_ref r1 :: int
-    r0 = 1
-    r2 = i
-    i = i + r0 :: int
-    dec_ref r0 :: int
+    dec_ref r3 :: int
+    r2 = 1
+    r4 = i
+    i = i + r2 :: int
     dec_ref r2 :: int
+    dec_ref r4 :: int
     goto L1
 L3:
     return sum

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -526,13 +526,14 @@ def f() -> None:
     c.x = C()
 [out]
 L0:
-    c = C()
     r0 = C()
-    c.x = r0; r1 = is_error
+    c = r0
+    r1 = C()
+    c.x = r1; r2 = is_error
     dec_ref c
-    dec_ref r0
-    r2 = None
-    return r2
+    dec_ref r1
+    r3 = None
+    return r3
 
 [case testCastRefCount]
 class C: pass

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -470,14 +470,15 @@ L0:
     r1 = 0
     r2 = b[r1] :: list
     dec_ref r1 :: int
-    r3 = unbox(int, r2)
+    r4 = unbox(int, r2)
     dec_ref r2
-    r4 = box(int, r3)
-    r5 = a.__setitem__(r0, r4)
+    r3 = r4
+    r5 = box(int, r3)
+    r6 = a.__setitem__(r0, r5)
     dec_ref r0 :: int
-    dec_ref r4
-    r6 = None
-    return r6
+    dec_ref r5
+    r7 = None
+    return r7
 
 [case testTupleRefcount]
 from typing import Tuple
@@ -521,10 +522,11 @@ L0:
     r2 = a[r1] :: list
     dec_ref a
     dec_ref r1 :: int
-    d = cast(C, r2)
+    r3 = cast(C, r2)
+    d = r3
     dec_ref d
-    r3 = None
-    return r3
+    r4 = None
+    return r4
 
 [case testUnaryBranchSpecialCase]
 def f(x: bool) -> int:

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -252,12 +252,19 @@ def f(a: int) -> int:
     x = 1
     x = x
     return x + a
+-- This is correct but bad code
 [out]
 L0:
+    inc_ref a :: int
+    a = a
     r0 = 1
     x = r0
+    inc_ref x :: int
+    dec_ref x :: int
+    x = x
     r1 = x + a :: int
     dec_ref x :: int
+    dec_ref a :: int
     return r1
 
 [case testIncrement1]

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -317,15 +317,31 @@ assert f(a) is a
 assert g(None) == 1
 assert g(a) == 2
 
-[case testUnicodeLiteral]
+[case testStr]
 def f() -> str:
     return 'some string'
 def g() -> str:
     return 'some\a \v \t \x7f " \n \0string 🐍'
+def tostr(x: int) -> str:
+    return str(x)
+def concat(x: str, y: str) -> str:
+    return x + y
+def eq(x: str) -> int:
+    if x == 'foo':
+        return 0
+    elif x != 'bar':
+        return 1
+    return 2
+
 [file driver.py]
-from native import f, g
+from native import f, g, tostr, concat, eq
 assert f() == 'some string'
 assert g() == 'some\a \v \t \x7f " \n \0string 🐍'
+assert tostr(57) == '57'
+assert concat('foo', 'bar') == 'foobar'
+assert eq('foo') == 0
+assert eq('zar') == 1
+assert eq('bar') == 2
 
 [case testDictUpdate]
 from typing import Dict
@@ -382,3 +398,29 @@ Traceback (most recent call last):
   File "tmp/py/native.py", line 6, in g
     x[5] = 2
 IndexError: list assignment index out of range
+
+[case testGenericEquality]
+def eq(a: object, b: object) -> bool:
+    if a == b:
+        return True
+    else:
+        return False
+def ne(a: object, b: object) -> bool:
+    if a != b:
+        return True
+    else:
+        return False
+def f(o: object) -> bool:
+    if [1, 2] == o:
+        return True
+    else:
+        return False
+[file driver.py]
+from native import eq, ne, f
+assert eq('xz', 'x' + 'z')
+assert not eq('x', 'y')
+assert not ne('xz', 'x' + 'z')
+assert ne('x', 'y')
+assert f([1, 2])
+assert not f([2, 2])
+assert not f(1)

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -43,18 +43,28 @@ print(count(5))
 6
 
 [case testFor]
+from typing import List
 def count(n: int) -> None:
     for i in range(n):
         print(i)
+def list_iter(l: List[int]) -> None:
+    for i in l:
+        print(i)
 [file driver.py]
-from native import count
+from native import count, list_iter
 count(5)
+list_iter(list(reversed(range(5))))
 [out]
 0
 1
 2
 3
 4
+4
+3
+2
+1
+0
 
 [case testRecursiveFibonacci]
 def fib(n: int) -> int:

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -42,6 +42,20 @@ print(count(5))
 2
 6
 
+[case testFor]
+def count(n: int) -> None:
+    for i in range(n):
+        print(i)
+[file driver.py]
+from native import count
+count(5)
+[out]
+0
+1
+2
+3
+4
+
 [case testRecursiveFibonacci]
 def fib(n: int) -> int:
     if n <= 1:
@@ -293,31 +307,15 @@ assert f(a) is a
 assert g(None) == 1
 assert g(a) == 2
 
-[case testStr]
+[case testUnicodeLiteral]
 def f() -> str:
     return 'some string'
 def g() -> str:
     return 'some\a \v \t \x7f " \n \0string 🐍'
-def tostr(x: int) -> str:
-    return str(x)
-def concat(x: str, y: str) -> str:
-    return x + y
-def eq(x: str) -> int:
-    if x == 'foo':
-        return 0
-    elif x != 'bar':
-        return 1
-    return 2
-
 [file driver.py]
-from native import f, g, tostr, concat, eq
+from native import f, g
 assert f() == 'some string'
 assert g() == 'some\a \v \t \x7f " \n \0string 🐍'
-assert tostr(57) == '57'
-assert concat('foo', 'bar') == 'foobar'
-assert eq('foo') == 0
-assert eq('zar') == 1
-assert eq('bar') == 2
 
 [case testDictUpdate]
 from typing import Dict
@@ -374,29 +372,3 @@ Traceback (most recent call last):
   File "tmp/py/native.py", line 6, in g
     x[5] = 2
 IndexError: list assignment index out of range
-
-[case testGenericEquality]
-def eq(a: object, b: object) -> bool:
-    if a == b:
-        return True
-    else:
-        return False
-def ne(a: object, b: object) -> bool:
-    if a != b:
-        return True
-    else:
-        return False
-def f(o: object) -> bool:
-    if [1, 2] == o:
-        return True
-    else:
-        return False
-[file driver.py]
-from native import eq, ne, f
-assert eq('xz', 'x' + 'z')
-assert not eq('x', 'y')
-assert not ne('xz', 'x' + 'z')
-assert ne('x', 'y')
-assert f([1, 2])
-assert not f([2, 2])
-assert not f(1)


### PR DESCRIPTION
Overhaul the intermediate representation to be more like LLVM's. (Though not exactly the same, since they do real SSA and this is at most "half-ssa".)

Instead of having operations have explicit registers as their operands and destinations, ops instead serve as *intrinsic* temporaries.

The old `Register` type, which was used to represent operands to `Op`s and the result of expressions, is replaced with a new `Value` type, which is the root of a class hierarchy. 
Every `Value` has an associated `RType` (and a new `RVoid` is added for operations that produce no useful output.) and a name. `Op` then becomes a subclass of `Value`, with the value being the result of the op. We then add a new `Register` type as a subclass of `Value`, used for arguments, locals, and temporaries that need multiple assignments (because of loops or branches). The `Assign` op assigns a `Value` source to a `Register` destination.

This allows `genops` to be simpler, eliminating almost allocation of temporaries. Making `RType` intrinsic to values allows cleaning up and eliminating a lot of code that messes around with types.

One downside is that a lot of computations have an extra assignment now. The C compiler will fix that up, but it still makes the generated code uglier. This also resulted in a lot of test churn.
