### PR TITLE
Run flake8 incrementally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ test_capi
 /.pytest_cache
 /dmypy.json
 /.dmypy.json
+/.mypyc-flake8-cache.json


### PR DESCRIPTION
Don't lint files that have not changed since the previous clean flake8
run. This speeds up typical lint runtimes by about a second or so on
my laptop. The savings might not be that big right now, but as we add
more code they will add up.

This might break some cross-module checks that flake8 might perform,
but we can disable these if they turn out to be a problem.

Manually removing the .mypyc-flake8-cache.json file will force a full
flake8 run.