### PR TITLE
Implement generic primitive operations

### DIFF
--- a/mypyc/ops_dict.py
+++ b/mypyc/ops_dict.py
@@ -18,7 +18,7 @@ def emit_get_item(emitter: EmitterInterface, args: List[str], dest: str) -> None
 
 
 dict_get_item_op = method_op(
-    name='builtins.dict.__getitem__',
+    name='__getitem__',
     arg_types=[dict_rprimitive, object_rprimitive],
     result_type=object_rprimitive,
     error_kind=ERR_MAGIC,
@@ -26,7 +26,7 @@ dict_get_item_op = method_op(
 
 
 dict_set_item_op = method_op(
-    name='builtins.dict.__setitem__',
+    name='__setitem__',
     arg_types=[dict_rprimitive, object_rprimitive, object_rprimitive],
     result_type=bool_rprimitive,
     error_kind=ERR_FALSE,
@@ -54,9 +54,9 @@ binary_op(op='in',
 # differs (when the second argument has no keys) should never typecheck for us, so the
 # difference is irrelevant.
 dict_update_op = method_op(
-    name='builtins.dict.update',
+    name='update',
     arg_types=[dict_rprimitive, object_rprimitive],
-    result_type=None,
+    result_type=bool_rprimitive,
     error_kind=ERR_FALSE,
     emit=simple_emit('{dest} = PyDict_Update({args[0]}, {args[1]}) != -1;'))
 

--- a/mypyc/ops_list.py
+++ b/mypyc/ops_list.py
@@ -29,7 +29,7 @@ new_list_op = custom_op(arg_types=[object_rprimitive],
 
 
 list_get_item_op = method_op(
-    name='builtins.list.__getitem__',
+    name='__getitem__',
     arg_types=[list_rprimitive, int_rprimitive],
     result_type=object_rprimitive,
     error_kind=ERR_MAGIC,
@@ -37,7 +37,7 @@ list_get_item_op = method_op(
 
 
 list_set_item_op = method_op(
-    name='builtins.list.__setitem__',
+    name='__setitem__',
     arg_types=[list_rprimitive, int_rprimitive, object_rprimitive],
     result_type=bool_rprimitive,
     error_kind=ERR_FALSE,
@@ -45,9 +45,9 @@ list_set_item_op = method_op(
 
 
 list_append_op = method_op(
-    name='builtins.list.append',
+    name='append',
     arg_types=[list_rprimitive, object_rprimitive],
-    result_type=None,
+    result_type=bool_rprimitive,
     error_kind=ERR_FALSE,
     emit=simple_emit('{dest} = PyList_Append({args[0]}, {args[1]}) != -1;'))
 

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -4,9 +4,9 @@ from typing import List
 
 from mypyc.ops import (
     EmitterInterface, PrimitiveOp, none_rprimitive, bool_rprimitive, object_rprimitive, ERR_NEVER,
-    ERR_MAGIC
+    ERR_MAGIC, ERR_FALSE
 )
-from mypyc.ops_primitive import name_ref_op, simple_emit, binary_op
+from mypyc.ops_primitive import name_ref_op, simple_emit, binary_op, unary_op, method_op
 
 
 def emit_none(emitter: EmitterInterface, args: List[str], dest: str) -> None:
@@ -19,18 +19,20 @@ none_op = name_ref_op('builtins.None',
                       error_kind=ERR_NEVER,
                       emit=emit_none)
 
-
 true_op = name_ref_op('builtins.True',
                       result_type=bool_rprimitive,
                       error_kind=ERR_NEVER,
                       emit=simple_emit('{dest} = 1;'))
-
 
 false_op = name_ref_op('builtins.False',
                        result_type=bool_rprimitive,
                        error_kind=ERR_NEVER,
                        emit=simple_emit('{dest} = 0;'))
 
+
+#
+# Fallback primitive operations that operate on 'object' operands
+#
 
 for op, opid in [('==', 'Py_EQ'),
                  ('!=', 'Py_NE'),
@@ -43,4 +45,71 @@ for op, opid in [('==', 'Py_EQ'),
               arg_types=[object_rprimitive, object_rprimitive],
               result_type=object_rprimitive,
               error_kind=ERR_MAGIC,
-              emit=simple_emit('{dest} = PyObject_RichCompare({args[0]}, {args[1]}, %s);' % opid))
+              emit=simple_emit('{dest} = PyObject_RichCompare({args[0]}, {args[1]}, %s);' % opid),
+              priority=0)
+
+for op, funcname in [('+', 'PyNumber_Add'),
+                     ('-', 'PyNumber_Subtract'),
+                     ('*', 'PyNumber_Multiply'),
+                     ('//', 'PyNumber_FloorDivide'),
+                     ('/', 'PyNumber_TrueDivide'),
+                     ('%', 'PyNumber_Remainder'),
+                     ('<<', 'PyNumber_Lshift'),
+                     ('>>', 'PyNumber_Rshift'),
+                     ('&', 'PyNumber_And'),
+                     ('^', 'PyNumber_Xor'),
+                     ('|', 'PyNumber_Or')]:
+    binary_op(op=op,
+              arg_types=[object_rprimitive, object_rprimitive],
+              result_type=object_rprimitive,
+              error_kind=ERR_MAGIC,
+              emit=simple_emit('{dest} = %s({args[0]}, {args[1]});' % funcname),
+              priority=0)
+
+binary_op(op='**',
+          arg_types=[object_rprimitive, object_rprimitive],
+          result_type=object_rprimitive,
+          error_kind=ERR_MAGIC,
+          emit=simple_emit('{dest} = PyNumber_Power({args[0]}, {args[1]}, Py_None);'),
+          priority=0)
+
+
+def emit_in(emitter: EmitterInterface, args: List[str], dest: str) -> None:
+    temp = emitter.temp_name()
+    emitter.emit_lines('int %s = PySequence_Contains(%s, %s);' % (temp, args[1], args[0]),
+                       'if (%s < 0)' % temp,
+                       '    %s = %s;' % (dest, bool_rprimitive.c_error_value()),
+                       'else',
+                       '    %s = %s;' % (dest, temp))
+
+
+binary_op('in',
+          arg_types=[object_rprimitive, object_rprimitive],
+          result_type=bool_rprimitive,
+          error_kind=ERR_MAGIC,
+          emit=emit_in,
+          priority=0)
+
+for op, funcname in [('-', 'PyNumber_Negative'),
+                     ('+', 'PyNumber_Positive'),
+                     ('~', 'PyNumber_Invert')]:
+    unary_op(op=op,
+             arg_type=object_rprimitive,
+             result_type=object_rprimitive,
+             error_kind=ERR_MAGIC,
+             emit=simple_emit('{dest} = %s({args[0]});' % funcname),
+             priority=0)
+
+method_op('__getitem__',
+          arg_types=[object_rprimitive, object_rprimitive],
+          result_type=object_rprimitive,
+          error_kind=ERR_MAGIC,
+          emit=simple_emit('{dest} = PyObject_GetItem({args[0]}, {args[1]});'),
+          priority=0)
+
+method_op('__setitem__',
+          arg_types=[object_rprimitive, object_rprimitive, object_rprimitive],
+          result_type=bool_rprimitive,
+          error_kind=ERR_FALSE,
+          emit=simple_emit('{dest} = PyObject_SetItem({args[0]}, {args[1]}, {args[2]}) >= 0;'),
+          priority=0)

--- a/mypyc/ops_str.py
+++ b/mypyc/ops_str.py
@@ -37,12 +37,10 @@ binary_op(op='==',
           arg_types=[str_rprimitive, str_rprimitive],
           result_type=bool_rprimitive,
           error_kind=ERR_MAGIC,
-          emit=emit_str_compare('== 0'),
-          priority=1)
+          emit=emit_str_compare('== 0'))
 
 binary_op(op='!=',
           arg_types=[str_rprimitive, str_rprimitive],
           result_type=bool_rprimitive,
           error_kind=ERR_MAGIC,
-          emit=emit_str_compare('!= 0'),
-          priority=1)
+          emit=emit_str_compare('!= 0'))

--- a/mypyc/ops_tuple.py
+++ b/mypyc/ops_tuple.py
@@ -14,7 +14,7 @@ from mypyc.ops_primitive import method_op, func_op, simple_emit
 
 
 tuple_get_item_op = method_op(
-    name='builtins.tuple.__getitem__',
+    name='__getitem__',
     arg_types=[tuple_rprimitive, int_rprimitive],
     result_type=object_rprimitive,
     error_kind=ERR_MAGIC,

--- a/test-data/exceptions.test
+++ b/test-data/exceptions.test
@@ -35,17 +35,19 @@ L0:
     dec_ref r0
     if not r1 goto L3 (error at f:3) else goto L1 :: bool
 L1:
-    inc_ref z :: int
-    r2 = box(int, z)
-    r3 = x.__setitem__(y, r2)
+    r2 = None
     dec_ref r2
-    if not r3 goto L3 (error at f:4) else goto L2 :: bool
+    inc_ref z :: int
+    r3 = box(int, z)
+    r4 = x.__setitem__(y, r3)
+    dec_ref r3
+    if not r4 goto L3 (error at f:4) else goto L2 :: bool
 L2:
-    r4 = None
-    return r4
-L3:
-    r5 = <error> :: None
+    r5 = None
     return r5
+L3:
+    r6 = <error> :: None
+    return r6
 
 [case testOptionalHandling]
 from typing import Optional

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -747,3 +747,17 @@ L0:
     d2 = d
     r1 = None
     return r1
+
+[case testGenericSetItem]
+from typing import Any
+def f(x: Any, y: Any, z: Any) -> None:
+    x[y] = z
+[out]
+def f(x, y, z):
+    x, y, z :: object
+    r0 :: bool
+    r1 :: None
+L0:
+    r0 = x.__setitem__(y, z)
+    r1 = None
+    return r1

--- a/test-data/genops-dict.test
+++ b/test-data/genops-dict.test
@@ -23,17 +23,16 @@ def f(d: Dict[int, bool]) -> None:
 def f(d):
     d :: dict
     r0 :: int
-    r1 :: object
-    r2 :: bool
-    r3 :: object
+    r1 :: bool
+    r2, r3 :: object
     r4 :: bool
     r5 :: None
 L0:
     r0 = 0
-    r1 = box(int, r0)
-    r2 = False
-    r3 = box(bool, r2)
-    r4 = d.__setitem__(r1, r3)
+    r1 = False
+    r2 = box(int, r0)
+    r3 = box(bool, r1)
+    r4 = d.__setitem__(r2, r3)
     r5 = None
     return r5
 
@@ -113,8 +112,9 @@ def f(a: Dict[int, int], b: Dict[int, int]) -> None:
 def f(a, b):
     a, b :: dict
     r0 :: bool
-    r1 :: None
+    r1, r2 :: None
 L0:
     r0 = a.update(b)
     r1 = None
-    return r1
+    r2 = None
+    return r2

--- a/test-data/genops-lists.test
+++ b/test-data/genops-lists.test
@@ -155,9 +155,10 @@ def f(a, x):
     x :: int
     r0 :: object
     r1 :: bool
-    r2 :: None
+    r2, r3 :: None
 L0:
     r0 = box(int, x)
     r1 = a.append(r0)
     r2 = None
-    return r2
+    r3 = None
+    return r3

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -627,4 +627,6 @@ L0:
     r1 = a.append(r0)
     dec_ref r0
     r2 = None
-    return r2
+    dec_ref r2
+    r3 = None
+    return r3

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -424,3 +424,109 @@ assert ne('x', 'y')
 assert f([1, 2])
 assert not f([2, 2])
 assert not f(1)
+
+[case testGenericBinaryOps]
+from typing import Any
+def add(x: Any, y: Any) -> Any:
+    return x + y
+def subtract(x: Any, y: Any) -> Any:
+    return x - y
+def multiply(x: Any, y: Any) -> Any:
+    return x * y
+def floor_div(x: Any, y: Any) -> Any:
+    return x // y
+def true_div(x: Any, y: Any) -> Any:
+    return x / y
+def remainder(x: Any, y: Any) -> Any:
+    return x % y
+def power(x: Any, y: Any) -> Any:
+    return x ** y
+def lshift(x: Any, y: Any) -> Any:
+    return x << y
+def rshift(x: Any, y: Any) -> Any:
+    return x >> y
+def num_and(x: Any, y: Any) -> Any:
+    return x & y
+def num_xor(x: Any, y: Any) -> Any:
+    return x ^ y
+def num_or(x: Any, y: Any) -> Any:
+    return x | y
+def lt(x: Any, y: Any) -> Any:
+    if x < y:
+        return True
+    else:
+        return False
+def le(x: Any, y: Any) -> Any:
+    if x <= y:
+        return True
+    else:
+        return False
+def gt(x: Any, y: Any) -> Any:
+    if x > y:
+        return True
+    else:
+        return False
+def ge(x: Any, y: Any) -> Any:
+    if x >= y:
+        return True
+    else:
+        return False
+def contains(x: Any, y: Any) -> Any:
+    if x in y:
+        return True
+    else:
+        return False
+[file driver.py]
+from native import *
+assert add(5, 6) == 11
+assert add('x', 'y') == 'xy'
+assert subtract(8, 3) == 5
+assert multiply(8, 3) == 24
+assert floor_div(8, 3) == 2
+assert true_div(7, 2) == 3.5
+assert remainder(11, 4) == 3
+assert remainder('%.3d', 5) == '005'
+assert remainder('%d-%s', (5, 'xy')) == '5-xy'
+assert power(3, 4) == 81
+assert lshift(5, 3) == 40
+assert rshift(41, 3) == 5
+assert num_and(99, 56) == 32
+assert num_xor(99, 56) == 91
+assert num_or(99, 56) == 123
+assert lt('a', 'b')
+assert not lt('a', 'a')
+assert not lt('b', 'a')
+assert not gt('a', 'b')
+assert not gt('a', 'a')
+assert gt('b', 'a')
+assert le('a', 'b')
+assert le('a', 'a')
+assert not le('b', 'a')
+assert not ge('a', 'b')
+assert ge('a', 'a')
+assert ge('b', 'a')
+assert contains('x', 'axb')
+assert not contains('X', 'axb')
+assert contains('x', {'x', 'y'})
+
+[case testGenericMiscOps]
+from typing import Any
+def neg(x: Any) -> Any:
+    return -x
+def pos(x: Any) -> Any:
+    return +x
+def invert(x: Any) -> Any:
+    return ~x
+def get_item(o: Any, k: Any) -> Any:
+    return o[k]
+def set_item(o: Any, k: Any, v: Any) -> Any:
+    o[k] = v
+[file driver.py]
+from native import *
+assert neg(6) == -6
+assert pos(6) == 6
+assert invert(6) == -7
+d = {'x': 5}
+assert get_item(d, 'x') == 5
+set_item(d, 'y', 6)
+assert d['y'] == 6


### PR DESCRIPTION
Implement various binary ops, unary ops and get/set item for `object`
operands.

Generate an explicit `None` value from operations that have a `None`
result type, for consistency. This generates some redundant ops that we
should optimize away at some point.

Also, simplify primitive op generation and support primitive
op priorities more generally. Default to priority 1 instead 0
for convenience.

Fixes #45.