### PR TITLE
Support attribute access and calls with Any values

### DIFF
--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -448,14 +448,6 @@ static PyObject *CPySequenceTuple_GetItem(PyObject *tuple, CPyTagged index) {
     }
 }
 
-static inline PyObject *CPyObject_GetAttrString(PyObject *obj, const char *attr_name) {
-    PyObject *result = PyObject_GetAttrString(obj, attr_name);
-    if (result == NULL) {
-        abort();
-    }
-    return result;
-}
-
 static PyCodeObject *CPy_CreateCodeObject(const char *filename, const char *funcname, int line) {
     PyObject *filename_obj = PyUnicode_FromString(filename);
     PyObject *funcname_obj = PyUnicode_FromString(funcname);

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -189,8 +189,8 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
 
     def visit_py_get_attr(self, op: PyGetAttr) -> None:
         dest = self.reg(op)
-        left = self.reg(op.left)
-        self.emit_line('{} = CPyObject_GetAttrString({}, "{}");'.format(dest, left, op.right))
+        obj = self.reg(op.obj)
+        self.emit_line('{} = PyObject_GetAttrString({}, "{}");'.format(dest, obj, op.attr))
 
     def visit_tuple_get(self, op: TupleGet) -> None:
         dest = self.reg(op)

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -739,7 +739,7 @@ class PyCall(RegisterOp):
         s = env.format('%r(%s)', self.function, args)
         if not self.is_void:
             s = env.format('%r = ', self) + s
-        return s + ' :: py'
+        return s + ' :: object'
 
     def sources(self) -> List[Value]:
         return self.args[:] + [self.function]
@@ -772,7 +772,7 @@ class PyMethodCall(RegisterOp):
         s = env.format('%r.%r(%s)', self.obj, self.method, args)
         if not self.is_void:
             s = env.format('%r = ', self) + s
-        return s + ' :: py'
+        return s + ' :: object'
 
     def sources(self) -> List[Value]:
         return self.args[:] + [self.obj, self.method]
@@ -782,21 +782,21 @@ class PyMethodCall(RegisterOp):
 
 
 class PyGetAttr(RegisterOp):
-    """dest = left.right :: py"""
+    """dest = obj.attr :: object"""
 
     error_kind = ERR_MAGIC
 
-    def __init__(self, type: RType, left: Value, right: str, line: int) -> None:
+    def __init__(self, obj: Value, attr: str, line: int) -> None:
         super().__init__(line)
-        self.left = left
-        self.right = right
-        self.type = type
+        self.obj = obj
+        self.attr = attr
+        self.type = object_rprimitive
 
     def sources(self) -> List[Value]:
-        return [self.left]
+        return [self.obj]
 
     def to_str(self, env: Environment) -> str:
-        return env.format('%r = %r.%s', self, self.left, self.right)
+        return env.format('%r = %r.%s :: object', self, self.obj, self.attr)
 
     def can_raise(self) -> bool:
         return True

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -501,9 +501,9 @@ def f(x):
     r4 :: int
 L0:
     r0 = module_testmodule :: static
-    r1 = r0.factorial
+    r1 = r0.factorial :: object
     r2 = box(int, x)
-    r3 = r1(r2) :: py
+    r3 = r1(r2) :: object
     r4 = unbox(int, r3)
     return r4
 
@@ -520,10 +520,10 @@ def f(x):
     r5, r6 :: None
 L0:
     r0 = module_builtins :: static
-    r1 = r0.print
+    r1 = r0.print :: object
     r2 = 5
     r3 = box(int, r2)
-    r4 = r1(r3) :: py
+    r4 = r1(r3) :: object
     r5 = cast(None, r4)
     r6 = None
     return r6
@@ -540,9 +540,9 @@ def f(x):
 L0:
     r0 = 5
     r1 = module_builtins :: static
-    r2 = r1.print
+    r2 = r1.print :: object
     r3 = box(int, r0)
-    r4 = r2(r3) :: py
+    r4 = r2(r3) :: object
     r5 = cast(None, r4)
     r6 = None
     return r6
@@ -577,11 +577,11 @@ def f(x):
     r5 :: int
 L0:
     r0 = __unicode_0 :: static
-    r1 = x.r0() :: py
+    r1 = x.r0() :: object
     r2 = unbox(int, r1)
     y = r2
     r3 = __unicode_0 :: static
-    r4 = x.r3() :: py
+    r4 = x.r3() :: object
     r5 = unbox(int, r4)
     return r5
 

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -614,7 +614,7 @@ def g(x: List[int], y: List[int]) -> None:
 L0:
     r0 = __unicode_0 :: static
     inc_ref r0
-    r1 = x.r0(y) :: py
+    r1 = x.r0(y) :: object
     dec_ref r0
     r2 = cast(None, r1)
     dec_ref r2

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -530,3 +530,59 @@ d = {'x': 5}
 assert get_item(d, 'x') == 5
 set_item(d, 'y', 6)
 assert d['y'] == 6
+
+[case testAnyAttributeAndMethodAccess]
+from typing import Any, List
+class C:
+    a: int
+    def m(self, x: int, a: List[int]) -> int:
+        return self.a + x + a[0]
+def get_a(x: Any) -> Any:
+    return x.a
+def call_m(x: Any) -> Any:
+    return x.m(1, [3])
+[file driver.py]
+from native import C, get_a, call_m
+class D:
+    def m(self, x, a):
+        return self.a + x + a[0]
+
+c = C()
+c.a = 6
+d = D()
+d.a = 2
+assert get_a(c) == 6
+assert get_a(d) == 2
+assert call_m(c) == 10
+assert call_m(d) == 6
+try:
+    get_a(object())
+except AttributeError:
+    pass
+else:
+    assert False
+try:
+    call_m(object())
+except AttributeError:
+    pass
+else:
+    assert False
+
+[case testAnyCall]
+from typing import Any
+def call(f: Any) -> Any:
+    return f(1, 'x')
+[file driver.py]
+from native import call
+def f(x, y):
+    return (x, y)
+def g(x): pass
+
+assert call(f) == (1, 'x')
+for bad in g, 1:
+    try:
+        call(bad)
+    except TypeError:
+        pass
+    else:
+        assert False, bad


### PR DESCRIPTION
Also make pretty-printed PR more consistent by using
`:: object` instead of `:: py`.