### PR TITLE
Make LoadStatic produce borrowed values

### DIFF
--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -245,18 +245,18 @@ class BorrowedArgumentsVisitor(BaseAnalysisVisitor):
 def analyze_borrowed_arguments(
         blocks: List[BasicBlock],
         cfg: CFG,
-        args: Set[Value]) -> AnalysisResult[Value]:
+        borrowed: Set[Value]) -> AnalysisResult[Value]:
     """Calculate arguments that can use references borrowed from the caller.
 
     When assigning to an argument, it no longer is borrowed.
     """
     return run_analysis(blocks=blocks,
                         cfg=cfg,
-                        gen_and_kill=BorrowedArgumentsVisitor(args),
-                        initial=args,
+                        gen_and_kill=BorrowedArgumentsVisitor(borrowed),
+                        initial=borrowed,
                         backward=False,
                         kind=MUST_ANALYSIS,
-                        universe=args)
+                        universe=borrowed)
 
 
 class UndefinedVisitor(BaseAnalysisVisitor):

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -242,7 +242,8 @@ class IRBuilder(NodeVisitor[Value]):
 
         for arg in fdef.arguments:
             assert arg.variable.type, "Function argument missing type"
-            self.environment.add_local(arg.variable, self.type_to_rtype(arg.variable.type))
+            self.environment.add_local(arg.variable, self.type_to_rtype(arg.variable.type),
+                                       is_arg=True)
         self.ret_type = self.convert_return_type(fdef)
         fdef.body.accept(self)
 

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -336,9 +336,9 @@ class Environment:
         reg.name = name
         self.indexes[reg] = len(self.indexes)
 
-    def add_local(self, var: Var, typ: RType) -> 'Register':
+    def add_local(self, var: Var, typ: RType, is_arg: bool = False) -> 'Register':
         assert isinstance(var, Var)
-        reg = Register(typ, var.line)
+        reg = Register(typ, var.line, is_arg = is_arg)
 
         self.symtable[var] = reg
         self.add(reg, var.name())
@@ -413,6 +413,7 @@ class Value:
     line = -1
     name = '?'
     type = void_rtype  # type: RType
+    is_borrowed = False
 
     def __init__(self, line: int) -> None:
         self.line = line
@@ -427,10 +428,12 @@ class Value:
 
 
 class Register(Value):
-    def __init__(self, type: RType, line: int = -1, name: str = '') -> None:
+    def __init__(self, type: RType, line: int = -1, is_arg: bool = False, name: str = '') -> None:
         super().__init__(line)
         self.name = name
         self.type = type
+        self.is_arg = is_arg
+        self.is_borrowed = is_arg
 
     def to_str(self, env: Environment) -> str:
         return self.name
@@ -1024,6 +1027,7 @@ class LoadStatic(RegisterOp):
     """dest = name :: static"""
 
     error_kind = ERR_NEVER
+    is_borrowed = True
 
     def __init__(self, type: RType, identifier: str, line: int = -1) -> None:
         super().__init__(line)

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -613,9 +613,7 @@ def g(x: List[int], y: List[int]) -> None:
 [out]
 L0:
     r0 = __unicode_0 :: static
-    inc_ref r0
     r1 = x.r0(y) :: object
-    dec_ref r0
     r2 = cast(None, r1)
     dec_ref r2
     r3 = None


### PR DESCRIPTION
To do this we add an `is_borrowed` flag to values, allowing
being borrowed to be generalized beyond arguments.

This allows us to avoid refcount traffic when invoking python methods.

Fixes #66