### PR TITLE
 Basic support for user-defined generics 

### DIFF
--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -8,6 +8,7 @@ from mypyc.common import PREFIX, NATIVE_PREFIX, REG_PREFIX
 from mypyc.emit import Emitter
 from mypyc.emitfunc import native_function_header
 from mypyc.ops import ClassIR, FuncIR, RType, Environment, type_struct_name, object_rprimitive
+from mypyc.sametype import is_same_type
 
 
 def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
@@ -395,6 +396,8 @@ def generate_setter(cl: ClassIR,
     emitter.emit_line('if (value != NULL) {')
     if rtype.is_unboxed:
         emitter.emit_unbox('value', 'tmp', rtype, custom_failure='return -1;', declare_dest=True)
+    elif is_same_type(rtype, object_rprimitive):
+        emitter.emit_line('PyObject *tmp = value;')
     else:
         emitter.emit_cast('value', 'tmp', rtype, declare_dest=True)
         emitter.emit_lines('if (!tmp)',

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -785,6 +785,10 @@ class IRBuilder(NodeVisitor[Value]):
                 node = node['__init__'].node
                 if isinstance(node, FuncDef) and isinstance(node.type, CallableType):
                     signature = bind_self(node.type)
+                    # "__init__" has None return, but the type object returns
+                    # in instance.  Take the instance return type from the
+                    # inferred callee type, which we can trust since it can't
+                    # be erased from a type variable.
                     inferred_sig = self.types[callee]
                     assert isinstance(inferred_sig, CallableType)
                     signature = signature.copy_modified(ret_type=inferred_sig.ret_type)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -110,6 +110,7 @@ class Mapper:
             return object_rprimitive
         elif isinstance(typ, TypeVarType):
             # Erase type variable to upper bound.
+            # TODO: Erase to object if object has value restriction -- or union (once supported)?
             assert not typ.values, 'TypeVar with value restriction not supported'
             return self.type_to_rtype(typ.upper_bound)
         assert False, '%s unsupported' % type(typ)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -202,14 +202,14 @@ class IRBuilder(NodeVisitor[Value]):
         self.classes.append(ir)
         self.mapper.type_to_ir[cdef.info] = ir
 
-        for name, node in sorted(cdef.info.names.items(), key=lambda x: x[0]):
+        for name, node in cdef.info.names.items():
             if isinstance(node.node, Var):
                 assert node.node.type, "Class member missing type"
                 ir.attributes.append((name, self.type_to_rtype(node.node.type)))
 
     def visit_class_def(self, cdef: ClassDef) -> Value:
         ir = self.mapper.type_to_ir[cdef.info]
-        for name, node in cdef.info.names.items():
+        for name, node in sorted(cdef.info.names.items(), key=lambda x: x[0]):
             if isinstance(node.node, FuncDef):
                 func = self.gen_func_def(node.node, cdef.name)
                 self.functions.append(func)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -202,7 +202,7 @@ class IRBuilder(NodeVisitor[Value]):
         self.classes.append(ir)
         self.mapper.type_to_ir[cdef.info] = ir
 
-        for name, node in cdef.info.names.items():
+        for name, node in sorted(cdef.info.names.items(), key=lambda x: x[0]):
             if isinstance(node.node, Var):
                 assert node.node.type, "Class member missing type"
                 ir.attributes.append((name, self.type_to_rtype(node.node.type)))

--- a/mypyc/test/test_genops.py
+++ b/mypyc/test/test_genops.py
@@ -28,6 +28,7 @@ files = [
     'genops-optional.test',
     'genops-tuple.test',
     'genops-any.test',
+    'genops-generics.test',
 ]
 
 

--- a/test-data/genops-generics.test
+++ b/test-data/genops-generics.test
@@ -1,0 +1,139 @@
+[case testGenericFunction]
+from typing import TypeVar, List
+T = TypeVar('T')
+def f(x: T) -> T:
+    return x
+def g(x: List[T]) -> List[T]:
+    return [x[0]]
+def h(x: int, y: List[int]) -> None:
+    x = f(x)
+    y = g(y)
+[out]
+def f(x):
+    x :: object
+L0:
+    return x
+def g(x):
+    x :: list
+    r0 :: int
+    r1 :: object
+    r2 :: list
+L0:
+    r0 = 0
+    r1 = x[r0] :: list
+    r2 = [r1]
+    return r2
+def h(x, y):
+    x :: int
+    y :: list
+    r0, r1 :: object
+    r2 :: int
+    r3 :: list
+    r4 :: None
+L0:
+    r0 = box(int, x)
+    r1 = f(r0)
+    r2 = unbox(int, r1)
+    x = r2
+    r3 = g(y)
+    y = r3
+    r4 = None
+    return r4
+
+[case testGenericAttrAndTypeApplication]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class C(Generic[T]):
+    x: T
+def f() -> None:
+    c = C[int]()
+    c.x = 1
+    2 + c.x
+[out]
+def f():
+    c, r0 :: C
+    r1 :: int
+    r2 :: object
+    r3 :: bool
+    r4 :: int
+    r5 :: object
+    r6, r7 :: int
+    r8 :: None
+L0:
+    r0 = C()
+    c = r0
+    r1 = 1
+    r2 = box(int, r1)
+    c.x = r2; r3 = is_error
+    r4 = 2
+    r5 = c.x
+    r6 = unbox(int, r5)
+    r7 = r4 + r6 :: int
+    r8 = None
+    return r8
+
+[case testGenericMethod]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class C(Generic[T]):
+    x: T
+    def __init__(self, x: T) -> None:
+        self.x = x
+    def get(self) -> T:
+        return self.x
+    def set(self, y: T) -> None:
+        self.x = y
+def f(x: C[int]) -> None:
+    y = x.get()
+    x.set(y + 1)
+    x = C(2)
+[out]
+def __init__(self, x):
+    self :: C
+    x :: object
+    r0 :: bool
+    r1 :: None
+L0:
+    self.x = x; r0 = is_error
+    r1 = None
+    return r1
+def get(self):
+    self :: C
+    r0 :: object
+L0:
+    r0 = self.x
+    return r0
+def set(self, y):
+    self :: C
+    y :: object
+    r0 :: bool
+    r1 :: None
+L0:
+    self.x = y; r0 = is_error
+    r1 = None
+    return r1
+def f(x):
+    x :: C
+    y :: int
+    r0 :: object
+    r1, r2, r3 :: int
+    r4 :: object
+    r5 :: None
+    r6 :: int
+    r7 :: object
+    r8 :: C
+    r9 :: None
+L0:
+    r0 = x.get()
+    r1 = unbox(int, r0)
+    y = r1
+    r2 = 1
+    r3 = y + r2 :: int
+    r4 = box(int, r3)
+    r5 = x.set(r4)
+    r6 = 2
+    r7 = box(int, r6)
+    r8 = C(r7)
+    x = r8
+    r9 = None
+    return r9

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -197,3 +197,32 @@ from native import A, foo
 a = A(10)
 assert a.foo() == 11
 assert foo() == 21
+
+[case testGenericClass]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class C(Generic[T]):
+    x: T
+    def __init__(self, x: T) -> None:
+        self.x = x
+    def get(self) -> T:
+        return self.x
+    def set(self, y: T) -> None:
+        self.x = y
+
+def f(c: C[int]) -> int:
+    y = c.get()
+    d = C[int](2)
+    c.set(c.get() + 1 + d.get())
+    c.x = c.x + 2
+    return c.x
+
+[file driver.py]
+from native import C, f
+c = C(6)
+assert f(c) == 11
+c.x = 'x'
+assert c.x == 'x'
+c.set([1])
+assert c.x == [1]
+assert c.get() == [1]


### PR DESCRIPTION
Support defining simple generic functions and classes. Support type
applications (no-ops at runtime).

The idea is to erase type variable types to the upper bound, and to
use the declared function signatures and attribute types when
generating coercions instead of the inferred types, since the latter
are generally too precise. For the rest we just rely on the existing
machinery to add implicit coercions.

Fixes #93.