### PR TITLE
Implement emit_cast for unboxed types

### DIFF
--- a/test-data/run.test
+++ b/test-data/run.test
@@ -310,6 +310,10 @@ def g(x: Optional[A]) -> int:
     if x is not None:
         return 2
     return 3
+
+def h(x: Optional[int], y: Optional[bool]) -> None:
+    pass
+
 [file driver.py]
 from native import f, g, A
 a = A()


### PR DESCRIPTION
This is needed to handle Optional[int] and Optional[bool],
unfortunately.