### PR TITLE
Implement initial support for single inheritance

### DIFF
--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -193,7 +193,7 @@ def generate_vtable(cl: ClassIR,
                     vtable_name: str,
                     emitter: Emitter) -> None:
     emitter.emit_line('static CPyVTableItem {}[] = {{'.format(vtable_name))
-    for attr, rtype in cl.attributes:
+    for attr in cl.attributes:
         emitter.emit_line('(CPyVTableItem){},'.format(native_getter_name(cl.name, attr)))
         emitter.emit_line('(CPyVTableItem){},'.format(native_setter_name(cl.name, attr)))
     for fn in cl.methods:
@@ -327,7 +327,7 @@ def generate_methods_table(cl: ClassIR,
 
 
 def generate_getseter_declarations(cl: ClassIR, emitter: Emitter) -> None:
-    for attr, rtype in cl.attributes:
+    for attr in cl.attributes:
         emitter.emit_line('static PyObject *')
         emitter.emit_line('{}({} *self, void *closure);'.format(getter_name(cl.name, attr),
                                                             cl.struct_name()))
@@ -342,7 +342,7 @@ def generate_getseters_table(cl: ClassIR,
                              emitter: Emitter) -> None:
 
     emitter.emit_line('static PyGetSetDef {}[] = {{'.format(name))
-    for attr, rtype in cl.attributes:
+    for attr in cl.attributes:
         emitter.emit_line('{{"{}",'.format(attr))
         emitter.emit_line(' (getter){}, (setter){},'.format(getter_name(cl.name, attr),
                                                             setter_name(cl.name, attr)))

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -148,14 +148,14 @@ def generate_object_struct(cl: ClassIR, emitter: Emitter) -> None:
     emitter.emit_lines('typedef struct {',
                        'PyObject_HEAD',
                        'CPyVTableItem *vtable;')
-    for attr, rtype in cl.attributes:
+    for attr, rtype in cl.attributes.items():
         emitter.emit_line('{}{};'.format(rtype.ctype_spaced(), attr))
     emitter.emit_line('}} {};'.format(cl.struct_name()))
 
 
 def generate_native_getters_and_setters(cl: ClassIR,
                                         emitter: Emitter) -> None:
-    for attr, rtype in cl.attributes:
+    for attr, rtype in cl.attributes.items():
         # Native getter
         emitter.emit_line('{}{}({} *self)'.format(rtype.ctype_spaced(),
                                                native_getter_name(cl.name, attr),
@@ -216,7 +216,7 @@ def generate_setup_for_class(cl: ClassIR,
     emitter.emit_line('if (self == NULL)')
     emitter.emit_line('    return NULL;')
     emitter.emit_line('self->vtable = {};'.format(vtable_name))
-    for attr, rtype in cl.attributes:
+    for attr, rtype in cl.attributes.items():
         emitter.emit_line('self->{} = {};'.format(attr, rtype.c_undefined_value()))
     emitter.emit_line('return (PyObject *)self;')
     emitter.emit_line('}')
@@ -282,7 +282,7 @@ def generate_traverse_for_class(cl: ClassIR,
     emitter.emit_line('{}({} *self, visitproc visit, void *arg)'.format(func_name,
                                                                         cl.struct_name()))
     emitter.emit_line('{')
-    for attr, rtype in cl.attributes:
+    for attr, rtype in cl.attributes.items():
         emitter.emit_gc_visit('self->{}'.format(attr), rtype)
     emitter.emit_line('return 0;')
     emitter.emit_line('}')
@@ -294,7 +294,7 @@ def generate_clear_for_class(cl: ClassIR,
     emitter.emit_line('static int')
     emitter.emit_line('{}({} *self)'.format(func_name, cl.struct_name()))
     emitter.emit_line('{')
-    for attr, rtype in cl.attributes:
+    for attr, rtype in cl.attributes.items():
         emitter.emit_gc_clear('self->{}'.format(attr), rtype)
     emitter.emit_line('return 0;')
     emitter.emit_line('}')
@@ -352,7 +352,7 @@ def generate_getseters_table(cl: ClassIR,
 
 
 def generate_getseters(cl: ClassIR, emitter: Emitter) -> None:
-    for i, (attr, rtype) in enumerate(cl.attributes):
+    for i, (attr, rtype) in enumerate(cl.attributes.items()):
         generate_getter(cl, attr, rtype, emitter)
         emitter.emit_line('')
         generate_setter(cl, attr, rtype, emitter)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -205,7 +205,7 @@ class IRBuilder(NodeVisitor[Value]):
         for name, node in cdef.info.names.items():
             if isinstance(node.node, Var):
                 assert node.node.type, "Class member missing type"
-                ir.attributes.append((name, self.type_to_rtype(node.node.type)))
+                ir.attributes[name] = self.type_to_rtype(node.node.type)
 
     def visit_class_def(self, cdef: ClassDef) -> Value:
         ir = self.mapper.type_to_ir[cdef.info]

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -183,15 +183,20 @@ class IRBuilder(NodeVisitor[Value]):
             # built-in primitives.
             return INVALID_VALUE
 
+        classes = [node for node in mypyfile.defs if isinstance(node, ClassDef)]
+
         # First pass: Build ClassIRs and TypeInfo-to-ClassIR mapping.
-        for node in mypyfile.defs:
-            if isinstance(node, ClassDef):
-                self.prepare_class_def(node)
+        for cls in classes:
+            self.prepare_class_def(cls)
 
         # Second pass: Generate ops.
         self.current_module_name = mypyfile.fullname()
         for node in mypyfile.defs:
             node.accept(self)
+
+        # Third pass: compute vtables
+        for cls in classes:
+            self.mapper.type_to_ir[cls.info].compute_vtable()
 
         return INVALID_VALUE
 

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -289,10 +289,8 @@ class RInstance(RType):
         assert False, '%r has no attribute %r' % (self.name, name)
 
     def attr_type(self, name: str) -> RType:
-        for i, (attr, rtype) in enumerate(self.class_ir.attributes):
-            if attr == name:
-                return rtype
-        assert False, '%r has no attribute %r' % (self.name, name)
+        assert name in self.class_ir.attributes, '%r has no attribute %r' % (self.name, name)
+        return self.class_ir.attributes[name]
 
     def __repr__(self) -> str:
         return '<RInstance %s>' % self.name
@@ -1232,7 +1230,7 @@ class ClassIR:
 
     def __init__(self, name: str) -> None:
         self.name = name
-        self.attributes = []  # type: List[Tuple[str, RType]]
+        self.attributes = OrderedDict()  # type: OrderedDict[str, RType]
         self.methods = []  # type: List[FuncIR]
 
     def struct_name(self) -> str:

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -27,8 +27,7 @@ class SubtypeVisitor(RTypeVisitor[bool]):
         self.right = right
 
     def visit_rinstance(self, left: RInstance) -> bool:
-        # TODO: Inheritance
-        return isinstance(self.right, RInstance) and self.right.name == left.name
+        return isinstance(self.right, RInstance) and self.right.class_ir in left.class_ir.mro
 
     def visit_roptional(self, left: ROptional) -> bool:
         return isinstance(self.right, ROptional) and is_subtype(left.value_type,

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -40,8 +40,9 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.tt = self.env.add_local(
             Var('tt'), RTuple([RTuple([int_rprimitive, bool_rprimitive]), bool_rprimitive]))
         ir = ClassIR('A')
-        ir.attributes = OrderedDict(x=bool_rprimitive, y=int_rprimitive)
+        ir.attributes = OrderedDict([('x', bool_rprimitive), ('y', int_rprimitive)])
         ir.compute_vtable()
+        ir.mro = [ir]
         self.r = self.env.add_local(Var('r'), RInstance(ir))
 
         self.context = EmitterContext()

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -41,6 +41,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
             Var('tt'), RTuple([RTuple([int_rprimitive, bool_rprimitive]), bool_rprimitive]))
         ir = ClassIR('A')
         ir.attributes = OrderedDict(x=bool_rprimitive, y=int_rprimitive)
+        ir.compute_vtable()
         self.r = self.env.add_local(Var('r'), RInstance(ir))
 
         self.context = EmitterContext()

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -1,5 +1,7 @@
 import unittest
 
+from collections import OrderedDict
+
 from mypy.nodes import Var
 from mypy.test.helpers import assert_string_arrays_equal
 
@@ -38,7 +40,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.tt = self.env.add_local(
             Var('tt'), RTuple([RTuple([int_rprimitive, bool_rprimitive]), bool_rprimitive]))
         ir = ClassIR('A')
-        ir.attributes = [('x', bool_rprimitive), ('y', int_rprimitive)]
+        ir.attributes = OrderedDict(x=bool_rprimitive, y=int_rprimitive)
         self.r = self.env.add_local(Var('r'), RInstance(ir))
 
         self.context = EmitterContext()

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -141,3 +141,38 @@ L1:
 L2:
     r6 = 1
     return r6
+
+[case testSubclass]
+class A:
+    def __init__(self) -> None:
+        self.x = 10
+class B(A):
+    def __init__(self) -> None:
+        self.x = 20
+        self.y = 30
+[out]
+-- This is totally useless because we don't print any class info!!
+def __init__(self):
+    self :: A
+    r0 :: int
+    r1 :: bool
+    r2 :: None
+L0:
+    r0 = 10
+    self.x = r0; r1 = is_error
+    r2 = None
+    return r2
+def __init__(self):
+    self :: B
+    r0 :: int
+    r1 :: bool
+    r2 :: int
+    r3 :: bool
+    r4 :: None
+L0:
+    r0 = 20
+    self.x = r0; r1 = is_error
+    r2 = 30
+    self.y = r2; r3 = is_error
+    r4 = None
+    return r4

--- a/test-data/run-bench.test
+++ b/test-data/run-bench.test
@@ -1,3 +1,4 @@
+-- TODO: build some generic benchmark harness
 [case testBenchmarkTree]
 from typing import Optional
 class Node:
@@ -75,3 +76,78 @@ if os.environ.get('MYPYC_RUN_BENCH') == '1':
     print("Sum (fast) speedup:", ifsum/nfsum)
     print("Sum (fast) method speedup:", ifsum2/nfsum2)
     print("Build speedup:", ibuild/nbuild)
+
+[case testBenchmarkVisitorTree]
+from typing import cast
+class Tree:
+    def accept(self, v: 'TreeVisitor') -> object:
+        pass
+class Leaf(Tree):
+    def accept(self, v: 'TreeVisitor') -> object:
+        return v.visit_leaf(self)
+class Node(Tree):
+    def __init__(self, value: int, left: Tree, right: Tree) -> None:
+        self.value = value
+        self.left = left
+        self.right = right
+    def accept(self, v: 'TreeVisitor') -> object:
+        return v.visit_node(self)
+
+class TreeVisitor:
+    def visit_leaf(self, x: Leaf) -> object: pass
+    def visit_node(self, x: Node) -> object: pass
+
+class SumVisitor(TreeVisitor):
+    def sum(self, x: Tree) -> int:
+        return cast(int, x.accept(self))
+    def visit_leaf(self, x: Leaf) -> object:
+        return 0
+    def visit_node(self, x: Node) -> object:
+        return x.value + self.sum(x.left) + self.sum(x.right)
+
+def sum_tree(x: Tree) -> int:
+    return SumVisitor().sum(x)
+
+def lol(n: int) -> Tree:
+    if n == 0:
+        return Leaf()
+    child = lol(n - 1)
+    return Node(n, child, child)
+
+def bench_sum_tree(x: Tree) -> None:
+    for i in range(100000):
+        sum_tree(x)
+
+[file driver.py]
+from typing import Optional
+import native
+import interpreted
+from timeit import timeit
+from time import time
+import os
+
+def dumb_time(f):
+    t0 = time()
+    f()
+    t1 = time()
+    return t1 - t0
+
+def basic_test(m):
+    tree = m.lol(5)
+    assert(m.sum_tree(tree) == 57)
+    return tree
+
+def test(m):
+    tree = basic_test(m)
+
+    g = {**globals(), **locals()}
+    fsum = dumb_time(lambda: m.bench_sum_tree(tree))
+    return fsum
+
+basic_test(native)
+
+if os.environ.get('MYPYC_RUN_BENCH') == '1':
+    nfsum = test(native)
+    ifsum = test(interpreted)
+    print(nfsum)
+    print("Sum speedup:", ifsum/nfsum)

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -226,3 +226,36 @@ assert c.x == 'x'
 c.set([1])
 assert c.x == [1]
 assert c.get() == [1]
+
+[case testSubclass]
+from typing import Tuple
+
+class A:
+    def __init__(self) -> None:
+        self.x = 10
+    def hi(self, suffix: str) -> str:
+        return str(self.x) + suffix
+class B(A):
+    def __init__(self) -> None:
+        self.x = 20
+        self.y = 'world'
+    def hi(self, suffix: str) -> str:
+        return 'hello ' + str(self.y) + suffix
+
+def use_a(x: A) -> Tuple[int, str]:
+    return (x.x, x.hi(''))
+def use_b(x: B) -> str:
+    return x.hi('')
+
+[file driver.py]
+from native import A, B, use_a, use_b
+a = A()
+b = B()
+assert use_a(a) == (10, '10')
+assert use_a(b) == (20, 'hello world')
+assert a.x == 10
+assert b.x == 20
+assert b.y == 'world'
+assert a.hi('!') == '10!'
+assert b.hi('!') == 'hello world!'
+assert use_b(b) == 'hello world'


### PR DESCRIPTION
This doesn't handle subclasses changing method signatures (which will require generating compatibility methods, and using the compatibility method in the base class part of the vtable and the real one in the subclass part).

My plan is to make a follow-up PR that addresses that and cleans up a bunch of the ugliness in this PR.