### PR TITLE
Eliminate the `Label` type, use `BasicBlock` directly

### DIFF
--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -49,7 +49,7 @@ class Emitter:
         assert self._indent >= 0
 
     def label(self, label: Label) -> str:
-        return 'CPyL%d' % label
+        return 'CPyL%s' % label.label
 
     def reg(self, reg: Value) -> str:
         return REG_PREFIX + reg.name

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -5,7 +5,7 @@ from typing import List, Set, Dict, Optional
 
 from mypyc.common import REG_PREFIX
 from mypyc.ops import (
-    Environment, Label, Value, Register, RType, RTuple, RInstance, ROptional,
+    Environment, BasicBlock, Value, Register, RType, RTuple, RInstance, ROptional,
     RPrimitive, type_struct_name, is_int_rprimitive, is_float_rprimitive, is_bool_rprimitive,
     short_name, is_list_rprimitive, is_dict_rprimitive, is_tuple_rprimitive, is_none_rprimitive,
     object_rprimitive, is_str_rprimitive
@@ -48,7 +48,7 @@ class Emitter:
         self._indent -= 4
         assert self._indent >= 0
 
-    def label(self, label: Label) -> str:
+    def label(self, label: BasicBlock) -> str:
         return 'CPyL%s' % label.label
 
     def reg(self, reg: Value) -> str:
@@ -65,7 +65,7 @@ class Emitter:
         for line in lines:
             self.emit_line(line)
 
-    def emit_label(self, label: Label) -> None:
+    def emit_label(self, label: BasicBlock) -> None:
         # Extra semicolon prevents an error when the next line declares a tempvar
         self.fragments.append('{}: ;\n'.format(self.label(label)))
 

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -7,7 +7,8 @@ from mypyc.emit import Emitter
 from mypyc.ops import (
     FuncIR, OpVisitor, Goto, Branch, Return, Assign, LoadInt, LoadErrorValue, GetAttr, SetAttr,
     LoadStatic, TupleGet, TupleSet, Call, PyCall, PyGetAttr, IncRef, DecRef, Box, Cast, Unbox,
-    Label, Value, Register, RType, RTuple, MethodCall, PyMethodCall, PrimitiveOp, EmitterInterface,
+    BasicBlock, Value, Register, RType, RTuple, MethodCall, PyMethodCall, PrimitiveOp,
+    EmitterInterface,
     PySetAttr, Unreachable, is_int_rprimitive
 )
 
@@ -272,7 +273,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
 
     # Helpers
 
-    def label(self, label: Label) -> str:
+    def label(self, label: BasicBlock) -> str:
         return self.emitter.label(label)
 
     def reg(self, reg: Value) -> str:

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -50,6 +50,10 @@ def generate_native_function(fn: FuncIR,
                                                                prefix=REG_PREFIX,
                                                                name=r.name))
 
+    # Before we emit the blocks, give them all labels
+    for i, block in enumerate(fn.blocks):
+        block.label = i
+
     for block in fn.blocks:
         body.emit_label(block)
         for op in block.ops:

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -47,7 +47,7 @@ def generate_native_function(fn: FuncIR, emitter: Emitter, source_path: str) -> 
                                                                 name=r.name))
 
     for block in fn.blocks:
-        body.emit_label(block.label)
+        body.emit_label(block)
         for op in block.ops:
             op.accept(visitor)
 

--- a/mypyc/exceptions.py
+++ b/mypyc/exceptions.py
@@ -33,7 +33,8 @@ def insert_exception_handling(ir: FuncIR) -> None:
 
 
 def add_handler_block(ir: FuncIR) -> BasicBlock:
-    block = BasicBlock.new(ir.blocks)
+    block = BasicBlock()
+    ir.blocks.append(block)
     op = LoadErrorValue(ir.ret_type)
     block.ops.append(op)
     ir.env.add_op(op)
@@ -57,7 +58,7 @@ def split_blocks_at_errors(blocks: List[BasicBlock],
             op = ops[i]
             if isinstance(op, RegisterOp) and op.error_kind != ERR_NEVER:
                 # Split
-                next_block.activate(new_blocks)
+                new_blocks.append(next_block)
                 new_block = next_block
                 next_block = BasicBlock()
                 new_block.ops.extend(ops[i0:i + 1])
@@ -92,7 +93,7 @@ def split_blocks_at_errors(blocks: List[BasicBlock],
                 i0 = i
             else:
                 i += 1
-        next_block.activate(new_blocks)
+        new_blocks.append(next_block)
         next_block.ops.extend(ops[i0:i + 1])
         if i0 == 0:
             mapping[block] = next_block

--- a/mypyc/exceptions.py
+++ b/mypyc/exceptions.py
@@ -9,7 +9,7 @@ We need to split basic blocks on each error check since branches can
 only be placed at the end of a basic block.
 """
 
-from typing import Optional, List
+from typing import Optional, List, Dict
 
 from mypyc.ops import (
     FuncIR, BasicBlock, Label, LoadErrorValue, Return, Goto, Branch, ERR_NEVER, ERR_MAGIC,
@@ -33,13 +33,12 @@ def insert_exception_handling(ir: FuncIR) -> None:
 
 
 def add_handler_block(ir: FuncIR) -> Label:
-    block = BasicBlock(Label(len(ir.blocks)))
+    block = BasicBlock.new(ir.blocks)
     op = LoadErrorValue(ir.ret_type)
     block.ops.append(op)
     ir.env.add_op(op)
     block.ops.append(Return(op))
-    ir.blocks.append(block)
-    return block.label
+    return block
 
 
 def split_blocks_at_errors(blocks: List[BasicBlock],
@@ -53,11 +52,14 @@ def split_blocks_at_errors(blocks: List[BasicBlock],
         ops = block.ops
         i0 = 0
         i = 0
+        next_block = BasicBlock()
         while i < len(ops) - 1:
             op = ops[i]
             if isinstance(op, RegisterOp) and op.error_kind != ERR_NEVER:
                 # Split
-                new_block = BasicBlock(Label(len(new_blocks)))
+                next_block.activate(new_blocks)
+                new_block = next_block
+                next_block = BasicBlock()
                 new_block.ops.extend(ops[i0:i + 1])
 
                 if op.error_kind == ERR_MAGIC:
@@ -77,7 +79,7 @@ def split_blocks_at_errors(blocks: List[BasicBlock],
 
                 branch = Branch(op,
                                 true_label=error_label,
-                                false_label=Label(new_block.label + 1),
+                                false_label=next_block,
                                 op=variant,
                                 line=op.line)
                 branch.negated = negated
@@ -85,17 +87,15 @@ def split_blocks_at_errors(blocks: List[BasicBlock],
                 partial_ops.add(branch)  # Only tweak true label of these
                 new_block.ops.append(branch)
                 if i0 == 0:
-                    mapping[block.label] = new_block.label
-                new_blocks.append(new_block)
+                    mapping[block] = new_block
                 i += 1
                 i0 = i
             else:
                 i += 1
-        new_block = BasicBlock(Label(len(new_blocks)))
-        new_block.ops.extend(ops[i0:i + 1])
+        next_block.activate(new_blocks)
+        next_block.ops.extend(ops[i0:i + 1])
         if i0 == 0:
-            mapping[block.label] = new_block.label
-        new_blocks.append(new_block)
+            mapping[block] = next_block
     # Adjust all labels to reflect the new blocks.
     for block in new_blocks:
         for op in block.ops:

--- a/mypyc/exceptions.py
+++ b/mypyc/exceptions.py
@@ -12,7 +12,7 @@ only be placed at the end of a basic block.
 from typing import Optional, List, Dict
 
 from mypyc.ops import (
-    FuncIR, BasicBlock, Label, LoadErrorValue, Return, Goto, Branch, ERR_NEVER, ERR_MAGIC,
+    FuncIR, BasicBlock, LoadErrorValue, Return, Goto, Branch, ERR_NEVER, ERR_MAGIC,
     ERR_FALSE, INVALID_VALUE, RegisterOp
 )
 
@@ -32,7 +32,7 @@ def insert_exception_handling(ir: FuncIR) -> None:
         ir.blocks = split_blocks_at_errors(ir.blocks, error_label, ir.name)
 
 
-def add_handler_block(ir: FuncIR) -> Label:
+def add_handler_block(ir: FuncIR) -> BasicBlock:
     block = BasicBlock.new(ir.blocks)
     op = LoadErrorValue(ir.ret_type)
     block.ops.append(op)
@@ -42,7 +42,7 @@ def add_handler_block(ir: FuncIR) -> Label:
 
 
 def split_blocks_at_errors(blocks: List[BasicBlock],
-                           error_label: Label,
+                           error_label: BasicBlock,
                            func: str) -> List[BasicBlock]:
     new_blocks = []  # type: List[BasicBlock]
     mapping = {}

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1440,7 +1440,9 @@ class IRBuilder(NodeVisitor[Value]):
         self.new_block()
 
     def new_block(self) -> BasicBlock:
-        return BasicBlock.new(self.blocks[-1])
+        block = BasicBlock()
+        self.blocks[-1].append(block)
+        return block
 
     def goto_new_block(self) -> BasicBlock:
         goto = Goto(INVALID_LABEL)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -40,7 +40,7 @@ from mypy.checkmember import bind_self
 
 from mypyc.common import MAX_SHORT_INT
 from mypyc.ops import (
-    BasicBlock, Environment, Op, LoadInt, RType, Value, Register, Label, Return, FuncIR, Assign,
+    BasicBlock, Environment, Op, LoadInt, RType, Value, Register, Return, FuncIR, Assign,
     Branch, Goto, RuntimeArg, Call, Box, Unbox, Cast, RTuple, Unreachable, TupleGet, TupleSet,
     ClassIR, RInstance, ModuleIR, GetAttr, SetAttr, LoadStatic, PyGetAttr, PyCall, ROptional,
     c_module_name, PyMethodCall, MethodCall, INVALID_VALUE, INVALID_LABEL, int_rprimitive,

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -408,22 +408,15 @@ class BasicBlock:
     as the final op in a block. Manually inserting error checking ops
     would be boring and error-prone.
 
+    Block labels are used for pretty printing and emitting C code, and get
+    filled in by those passes.
+
     Ops that may terminate the program aren't treated as exits.
     """
 
     def __init__(self, label: int = -1) -> None:
         self.label = label
         self.ops = []  # type: List[Op]
-
-    def activate(self, blocks: List['BasicBlock']) -> None:
-        self.label = len(blocks)
-        blocks.append(self)
-
-    @staticmethod
-    def new(blocks: List['BasicBlock']) -> 'BasicBlock':
-        block = BasicBlock()
-        block.activate(blocks)
-        return block
 
 
 # This is used for placeholder labels which aren't assigned yet (but will
@@ -1406,6 +1399,10 @@ class OpVisitor(Generic[T]):
 
 
 def format_blocks(blocks: List[BasicBlock], env: Environment) -> List[str]:
+    # First label all of the blocks
+    for i, block in enumerate(blocks):
+        block.label = i
+
     lines = []
     for i, block in enumerate(blocks):
         i == len(blocks) - 1

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -368,8 +368,8 @@ class Environment:
                 elif typespec == 'f':
                     result.append('%f' % arg)
                 elif typespec == 'l':
-                    # ew
-                    if isinstance(arg, BasicBlock): arg = arg.label
+                    if isinstance(arg, BasicBlock):
+                        arg = arg.label
                     result.append('L%s' % arg)
                 elif typespec == 's':
                     result.append(str(arg))
@@ -412,7 +412,7 @@ class BasicBlock:
     Ops that may terminate the program aren't treated as exits.
     """
 
-    def __init__(self, label: Union[str, int] = -1) -> None:
+    def __init__(self, label: int = -1) -> None:
         self.label = label
         self.ops = []  # type: List[Op]
 
@@ -427,11 +427,9 @@ class BasicBlock:
         return block
 
 
-Label = BasicBlock
-
 # This is used for placeholder labels which aren't assigned yet (but will
 # be eventually. It's kind of a hack.
-INVALID_LABEL = BasicBlock("<INVALID>")
+INVALID_LABEL = BasicBlock(-88888)
 
 
 ERR_NEVER = 0  # Never generates an exception
@@ -503,7 +501,7 @@ class Goto(Op):
 
     error_kind = ERR_NEVER
 
-    def __init__(self, label: Label, line: int = -1) -> None:
+    def __init__(self, label: BasicBlock, line: int = -1) -> None:
         super().__init__(line)
         self.label = label
 
@@ -534,8 +532,8 @@ class Branch(Op):
         IS_ERROR: ('is_error(%r)', ''),
     }
 
-    def __init__(self, left: Value, true_label: Label,
-                 false_label: Label, op: int, line: int = -1) -> None:
+    def __init__(self, left: Value, true_label: BasicBlock,
+                 false_label: BasicBlock, op: int, line: int = -1) -> None:
         super().__init__(line)
         self.left = left
         self.true = true_label

--- a/mypyc/refcount.py
+++ b/mypyc/refcount.py
@@ -201,7 +201,8 @@ def after_branch_increfs(label: BasicBlock,
 
 
 def add_block(ops: Iterable[Op], blocks: List[BasicBlock], label: BasicBlock) -> BasicBlock:
-    block = BasicBlock.new(blocks)
+    block = BasicBlock()
+    blocks.append(block)
     block.ops.extend(ops)
     block.ops.append(Goto(label))
     return block

--- a/mypyc/refcount.py
+++ b/mypyc/refcount.py
@@ -70,7 +70,7 @@ def transform_block(block: BasicBlock,
     old_ops = block.ops
     ops = []  # type: List[Op]
     for i, op in enumerate(old_ops):
-        key = (block.label, i)
+        key = (block, i)
         if isinstance(op, (Assign, Cast, Box)):
             dest = op.dest if isinstance(op, Assign) else op
             # These operations just copy/steal a reference and don't create new
@@ -136,7 +136,7 @@ def insert_branch_inc_and_decrefs(
               a = 1
           return a  # a is borrowed if condition is false and unborrowed if true
     """
-    prev_key = (block.label, len(block.ops) - 1)
+    prev_key = (block, len(block.ops) - 1)
     source_live_regs = pre_live[prev_key]
     source_borrowed = post_borrow[prev_key]
     if isinstance(block.ops[-1], Branch):
@@ -201,8 +201,7 @@ def after_branch_increfs(label: Label,
 
 
 def add_block(ops: Iterable[Op], blocks: List[BasicBlock], label: Label) -> Label:
-    block = BasicBlock(Label(len(blocks)))
+    block = BasicBlock.new(blocks)
     block.ops.extend(ops)
     block.ops.append(Goto(label))
-    blocks.append(block)
-    return block.label
+    return block

--- a/mypyc/refcount.py
+++ b/mypyc/refcount.py
@@ -27,7 +27,7 @@ from mypyc.analysis import (
 )
 from mypyc.ops import (
     FuncIR, BasicBlock, Assign, RegisterOp, DecRef, IncRef, Branch, Goto, Environment,
-    Return, Op, Label, Cast, Box, RType,
+    Return, Op, Cast, Box, RType,
     Value, Register,
 )
 
@@ -172,7 +172,7 @@ def insert_branch_inc_and_decrefs(
             goto.label = add_block(new_opcodes, blocks, goto.label)
 
 
-def after_branch_decrefs(label: Label,
+def after_branch_decrefs(label: BasicBlock,
                          pre_live: AnalysisDict[Value],
                          source_borrowed: Set[Value],
                          source_live_regs: Set[Value],
@@ -187,7 +187,7 @@ def after_branch_decrefs(label: Label,
     return []
 
 
-def after_branch_increfs(label: Label,
+def after_branch_increfs(label: BasicBlock,
                          pre_borrow: AnalysisDict[Value],
                          source_borrowed: Set[Value],
                          env: Environment) -> List[Op]:
@@ -200,7 +200,7 @@ def after_branch_increfs(label: Label,
     return []
 
 
-def add_block(ops: Iterable[Op], blocks: List[BasicBlock], label: Label) -> Label:
+def add_block(ops: Iterable[Op], blocks: List[BasicBlock], label: BasicBlock) -> BasicBlock:
     block = BasicBlock.new(blocks)
     block.ops.extend(ops)
     block.ops.append(Goto(label))

--- a/mypyc/test/test_analysis.py
+++ b/mypyc/test/test_analysis.py
@@ -82,10 +82,12 @@ class TestAnalysis(MypycDataSuite):
                         assert False, 'No recognized _AnalysisName suffix in test case'
 
                     actual.append('')
-                    for key in sorted(analysis_result.before.keys()):
+                    for key in sorted(analysis_result.before.keys(),
+                                      key=lambda x: (x[0].label, x[1])):
                         pre = ', '.join(sorted(reg.name
                                                for reg in analysis_result.before[key]))
                         post = ', '.join(sorted(reg.name
                                                 for reg in analysis_result.after[key]))
-                        actual.append('%-8s %-23s %s' % (key, '{%s}' % pre, '{%s}' % post))
+                        actual.append('%-8s %-23s %s' % ((key[0].label, key[1]),
+                                                         '{%s}' % pre, '{%s}' % post))
             assert_test_output(testcase, actual, 'Invalid source code output')

--- a/mypyc/test/test_emit.py
+++ b/mypyc/test/test_emit.py
@@ -3,7 +3,7 @@ import unittest
 from mypy.nodes import Var
 
 from mypyc.emit import Emitter, EmitterContext
-from mypyc.ops import Environment, RType, int_rprimitive, Label
+from mypyc.ops import Environment, RType, int_rprimitive, BasicBlock
 
 
 class TestEmitter(unittest.TestCase):
@@ -14,7 +14,7 @@ class TestEmitter(unittest.TestCase):
         self.emitter = Emitter(self.context, self.env)
 
     def test_label(self) -> None:
-        assert self.emitter.label(Label(4)) == 'CPyL4'
+        assert self.emitter.label(BasicBlock(4)) == 'CPyL4'
 
     def test_reg(self) -> None:
         assert self.emitter.reg(self.n) == 'cpy_r_n'

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -264,7 +264,7 @@ class TestGenerateFunction(unittest.TestCase):
         self.arg = RuntimeArg('arg', int_rprimitive)
         self.env = Environment()
         self.reg = self.env.add_local(self.var, int_rprimitive)
-        self.block = BasicBlock(Label(0))
+        self.block = BasicBlock(0)
 
     def test_simple(self) -> None:
         self.block.ops.append(Return(self.reg))

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -9,7 +9,7 @@ from mypyc.ops import (
     Environment, BasicBlock, FuncIR, RuntimeArg, RType, Goto, Return, LoadInt, Assign,
     IncRef, DecRef, Branch, Call, Unbox, Box, RTuple, TupleGet, GetAttr, PrimitiveOp,
     RegisterOp,
-    ClassIR, RInstance, SetAttr, Op, Label, Value, int_rprimitive, bool_rprimitive,
+    ClassIR, RInstance, SetAttr, Op, Value, int_rprimitive, bool_rprimitive,
     list_rprimitive, dict_rprimitive, object_rprimitive,
 )
 from mypyc.emit import Emitter, EmitterContext
@@ -51,7 +51,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.visitor = FunctionEmitterVisitor(self.emitter, self.declarations, 'func', 'prog.py')
 
     def test_goto(self) -> None:
-        self.assert_emit(Goto(Label(2)),
+        self.assert_emit(Goto(BasicBlock(2)),
                          "goto CPyL2;")
 
     def test_return(self) -> None:
@@ -113,13 +113,13 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """)
 
     def test_branch(self) -> None:
-        self.assert_emit(Branch(self.b, Label(8), Label(9), Branch.BOOL_EXPR),
+        self.assert_emit(Branch(self.b, BasicBlock(8), BasicBlock(9), Branch.BOOL_EXPR),
                          """if (cpy_r_b) {
                                 goto CPyL8;
                             } else
                                 goto CPyL9;
                          """)
-        b = Branch(self.b, Label(8), Label(9), Branch.BOOL_EXPR)
+        b = Branch(self.b, BasicBlock(8), BasicBlock(9), Branch.BOOL_EXPR)
         b.negated = True
         self.assert_emit(b,
                          """if (!cpy_r_b) {


### PR DESCRIPTION
This brings control flow into more consistency with the intrinsic representations used for `Value`s.

It should enable reworking a bunch of genops to not need backpatching, which I think will make it simpler, though it might be six of one, half dozen of another?