### PR TITLE
Support Callable Types

### DIFF
--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -860,3 +860,16 @@ L0:
     max_32_bit = r6
     r7 = None
     return r7
+
+[case testCallableTypes]
+def absolute_value(x: int) -> int:
+    return x if x > 0 else -x
+
+def call_native_function(x: int) -> int:
+    return absolute_value(x)
+
+def load_float() -> None:
+    x = 5.0
+
+def call_python_function(x: int) -> int:
+    return int(x)

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -862,14 +862,78 @@ L0:
     return r7
 
 [case testCallableTypes]
+from typing import Callable
 def absolute_value(x: int) -> int:
     return x if x > 0 else -x
 
 def call_native_function(x: int) -> int:
     return absolute_value(x)
 
-def load_float() -> None:
-    x = 5.0
-
 def call_python_function(x: int) -> int:
     return int(x)
+
+def return_float() -> float:
+    return 5.0
+
+def return_callable_type() -> Callable[[], float]:
+    return return_float
+
+def call_callable_type() -> float:
+    f = return_callable_type()
+    return f()
+[out]
+def absolute_value(x):
+    x, r0 :: int
+    r1 :: bool
+    r2, r3 :: int
+L0:
+    r0 = 0
+    r1 = x > r0 :: int
+    if r1 goto L1 else goto L2 :: bool
+L1:
+    r2 = x
+    goto L3
+L2:
+    r3 = -x :: int
+    r2 = r3
+L3:
+    return r2
+def call_native_function(x):
+    x, r0 :: int
+L0:
+    r0 = absolute_value(x)
+    return r0
+def call_python_function(x):
+    x :: int
+    r0, r1, r2, r3 :: object
+    r4 :: int
+L0:
+    r0 = module_builtins :: static
+    r1 = r0.int :: object
+    r2 = box(int, x)
+    r3 = r1(r2) :: object
+    r4 = unbox(int, r3)
+    return r4
+def return_float():
+    r0 :: float
+L0:
+    r0 = __float_0 :: static
+    return r0
+def return_callable_type():
+    r0 :: object
+    r1 :: str
+    r2 :: object
+L0:
+    r0 = _globals :: static
+    r1 = __unicode_1 :: static
+    r2 = r0[r1] :: dict
+    return r2
+def call_callable_type():
+    f, r0, r1 :: object
+    r2 :: float
+L0:
+    r0 = return_callable_type()
+    f = r0
+    r1 = f() :: object
+    r2 = cast(float, r1)
+    return r2

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -788,17 +788,31 @@ def absolute_value(x: int) -> int:
 def call_native_function(x: int) -> int:
     return absolute_value(x)
 
-def load_float() -> float:
-    return 5.0
-
-def return_callable_type() -> Callable[[], float]:
-    return load_float
-
 def call_python_function(x: int) -> int:
     return int(x)
 
+def return_float() -> float:
+    return 5.0
+
+def return_callable_type() -> Callable[[], float]:
+    return return_float
+
+def call_callable_type() -> float:
+    f = return_callable_type()
+    return f()
+
 [file driver.py]
-from native import call_native_function, call_python_function
-y = call_native_function(1)
-y = call_python_function(1)
-print(y)
+from native import call_native_function, call_python_function, return_callable_type, call_callable_type
+w = call_native_function(1)
+x = call_python_function(1)
+y = return_callable_type()
+z = call_callable_type()
+print(w)
+print(x)
+print(y())
+print(z)
+[out]
+1
+1
+5.0
+5.0

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -779,3 +779,26 @@ def f() -> None:
 [file driver.py]
 from native import f
 f()
+
+[case testCallableTypes]
+from typing import Callable
+def absolute_value(x: int) -> int:
+    return x if x > 0 else -x
+
+def call_native_function(x: int) -> int:
+    return absolute_value(x)
+
+def load_float() -> float:
+    return 5.0
+
+def return_callable_type() -> Callable[[], float]:
+    return load_float
+
+def call_python_function(x: int) -> int:
+    return int(x)
+
+[file driver.py]
+from native import call_native_function, call_python_function
+y = call_native_function(1)
+y = call_python_function(1)
+print(y)

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -801,18 +801,23 @@ def call_callable_type() -> float:
     f = return_callable_type()
     return f()
 
+def return_passed_in_callable_type(f: Callable[[], float]) -> Callable[[], float]:
+    return f
+
+def call_passed_in_callable_type(f: Callable[[], float]) -> float:
+    return f()
+
 [file driver.py]
-from native import call_native_function, call_python_function, return_callable_type, call_callable_type
-w = call_native_function(1)
-x = call_python_function(1)
-y = return_callable_type()
-z = call_callable_type()
-print(w)
-print(x)
-print(y())
-print(z)
-[out]
-1
-1
-5.0
-5.0
+from native import call_native_function, call_python_function, return_float, return_callable_type, call_callable_type, return_passed_in_callable_type, call_passed_in_callable_type
+a = call_native_function(1)
+b = call_python_function(1)
+c = return_callable_type()
+d = call_callable_type()
+e = return_passed_in_callable_type(return_float)
+f = call_passed_in_callable_type(return_float)
+assert a == 1
+assert b == 1
+assert c() == 5.0
+assert d == 5.0
+assert e() == 5.0
+assert f == 5.0


### PR DESCRIPTION
Callable types are now supported by loading the PyObject * items in
_globals that correspond with their functions, using LoadStatic
and a dictionary lookup.

This fixes #94.