### PR TITLE
Use PyObject_GetAttr instead of PyObject_GetAttrString

### DIFF
--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -193,7 +193,8 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
     def visit_py_get_attr(self, op: PyGetAttr) -> None:
         dest = self.reg(op)
         obj = self.reg(op.obj)
-        self.emit_line('{} = PyObject_GetAttrString({}, "{}");'.format(dest, obj, op.attr))
+        attr = self.reg(op.attr)
+        self.emit_line('{} = PyObject_GetAttr({}, {});'.format(dest, obj, attr))
 
     def visit_py_set_attr(self, op: PySetAttr) -> None:
         dest = self.reg(op)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -785,7 +785,11 @@ class IRBuilder(NodeVisitor[Value]):
             if isinstance(obj.type, RInstance):
                 return self.add(GetAttr(obj, expr.name, expr.line))
             else:
-                return self.add(PyGetAttr(obj, expr.name, expr.line))
+                return self.py_get_attr(obj, expr.name, expr.line)
+
+    def py_get_attr(self, obj: Value, attr: str, line: int) -> Value:
+        key = self.load_static_unicode(attr)
+        return self.add(PyGetAttr(obj, key, line))
 
     def py_call(self, function: Value, args: List[Value],
                 target_type: RType, line: int) -> Value:
@@ -1325,7 +1329,7 @@ class IRBuilder(NodeVisitor[Value]):
         module = '.'.join(expr.node.fullname().split('.')[:-1])
         name = expr.node.fullname().split('.')[-1]
         left = self.add(LoadStatic(object_rprimitive, c_module_name(module)))
-        return self.add(PyGetAttr(left, name, expr.line))
+        return self.py_get_attr(left, name, expr.line)
 
     def coerce(self, src: Value, target_type: RType, line: int) -> Value:
         """Generate a coercion/cast from one type to other (only if needed).

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -787,17 +787,17 @@ class PyGetAttr(RegisterOp):
 
     error_kind = ERR_MAGIC
 
-    def __init__(self, obj: Value, attr: str, line: int) -> None:
+    def __init__(self, obj: Value, attr: Value, line: int) -> None:
         super().__init__(line)
         self.obj = obj
         self.attr = attr
         self.type = object_rprimitive
 
     def sources(self) -> List[Value]:
-        return [self.obj]
+        return [self.obj, self.attr]
 
     def to_str(self, env: Environment) -> str:
-        return env.format('%r = %r.%s :: object', self, self.obj, self.attr)
+        return env.format('%r = %r.%r :: object', self, self.obj, self.attr)
 
     def can_raise(self) -> bool:
         return True

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -497,15 +497,18 @@ def factorial(x: int) -> int:
 [out]
 def f(x):
     x :: int
-    r0, r1, r2, r3 :: object
-    r4 :: int
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: int
 L0:
     r0 = module_testmodule :: static
-    r1 = r0.factorial :: object
-    r2 = box(int, x)
-    r3 = r1(r2) :: object
-    r4 = unbox(int, r3)
-    return r4
+    r1 = __unicode_0 :: static
+    r2 = r0.r1 :: object
+    r3 = box(int, x)
+    r4 = r2(r3) :: object
+    r5 = unbox(int, r4)
+    return r5
 
 [case testFromImport]
 from testmodule import g
@@ -538,19 +541,22 @@ def f(x: int) -> None:
 [out]
 def f(x):
     x :: int
-    r0, r1 :: object
-    r2 :: int
-    r3, r4 :: object
-    r5, r6 :: None
+    r0 :: object
+    r1 :: str
+    r2 :: object
+    r3 :: int
+    r4, r5 :: object
+    r6, r7 :: None
 L0:
     r0 = module_builtins :: static
-    r1 = r0.print :: object
-    r2 = 5
-    r3 = box(int, r2)
-    r4 = r1(r3) :: object
-    r5 = cast(None, r4)
-    r6 = None
-    return r6
+    r1 = __unicode_0 :: static
+    r2 = r0.r1 :: object
+    r3 = 5
+    r4 = box(int, r3)
+    r5 = r2(r4) :: object
+    r6 = cast(None, r5)
+    r7 = None
+    return r7
 
 [case testPrint]
 import builtins
@@ -559,17 +565,20 @@ def f(x: int) -> None:
 [out]
 def f(x):
     x, r0 :: int
-    r1, r2, r3, r4 :: object
-    r5, r6 :: None
+    r1 :: object
+    r2 :: str
+    r3, r4, r5 :: object
+    r6, r7 :: None
 L0:
     r0 = 5
     r1 = module_builtins :: static
-    r2 = r1.print :: object
-    r3 = box(int, r0)
-    r4 = r2(r3) :: object
-    r5 = cast(None, r4)
-    r6 = None
-    return r6
+    r2 = __unicode_0 :: static
+    r3 = r1.r2 :: object
+    r4 = box(int, r0)
+    r5 = r3(r4) :: object
+    r6 = cast(None, r5)
+    r7 = None
+    return r7
 
 [case testUnicodeLiteral]
 def f() -> str:
@@ -929,19 +938,22 @@ L0:
     return r0
 def call_python_function(x):
     x :: int
-    r0, r1, r2, r3 :: object
-    r4 :: int
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: int
 L0:
     r0 = module_builtins :: static
-    r1 = r0.int :: object
-    r2 = box(int, x)
-    r3 = r1(r2) :: object
-    r4 = unbox(int, r3)
-    return r4
+    r1 = __unicode_0 :: static
+    r2 = r0.r1 :: object
+    r3 = box(int, x)
+    r4 = r2(r3) :: object
+    r5 = unbox(int, r4)
+    return r5
 def return_float():
     r0 :: float
 L0:
-    r0 = __float_0 :: static
+    r0 = __float_1 :: static
     return r0
 def return_callable_type():
     r0 :: object
@@ -949,7 +961,7 @@ def return_callable_type():
     r2 :: object
 L0:
     r0 = _globals :: static
-    r1 = __unicode_1 :: static
+    r1 = __unicode_2 :: static
     r2 = r0[r1] :: dict
     return r2
 def call_callable_type():


### PR DESCRIPTION
It turns out that PyObject_GetAttr using an already created string
object is quite a bit faster (~60% on a microbenchmark).