### PR TITLE
Support Arbitrary lvalues in Operator Assignment

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -409,7 +409,10 @@ class IRBuilder(NodeVisitor[Value]):
                 return reg
             assert False, target.base.type
         if isinstance(target, AssignmentTargetAttr):
-            return self.add(GetAttr(target.obj, target.attr, line))
+            if isinstance(target.obj.type, RInstance):
+                return self.add(GetAttr(target.obj, target.attr, line))
+            else:
+                return self.py_get_attr(target.obj, target.attr, line)
 
         assert False, 'Unsupported lvalue: %r' % target
 

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -366,26 +366,10 @@ class IRBuilder(NodeVisitor[Value]):
     def visit_operator_assignment_stmt(self, stmt: OperatorAssignmentStmt) -> Value:
         target = self.get_assignment_target(stmt.lvalue)
         rreg = self.accept(stmt.rvalue)
-
-        if isinstance(target, AssignmentTargetRegister):
-            res = self.binary_op(target.register, rreg, stmt.op, stmt.line)
-            res = self.coerce(res, target.type, stmt.line)
-            self.add(Assign(target.register, res))
-            return INVALID_VALUE
-        if isinstance(target, AssignmentTargetIndex):
-            res = self.add(PrimitiveOp([target.base, target.index], list_get_item_op, stmt.line))
-            res = self.binary_op(res, rreg, stmt.op, stmt.line)
-            res = self.coerce(res, target.type, stmt.line)
-            self.add(PrimitiveOp([target.base, target.index, res], list_set_item_op, stmt.line))
-            return INVALID_VALUE
-        if isinstance(target, AssignmentTargetAttr):
-            res = self.add(GetAttr(target.obj, target.attr, stmt.line))
-            res = self.binary_op(res, rreg, stmt.op, stmt.line)
-            res = self.coerce(res, target.type, stmt.line)
-            self.add(SetAttr(target.obj, target.attr, res, stmt.line))
-            return INVALID_VALUE
-
-        assert False, 'Unsupported lvalue: %r' % target
+        res = self.read_from_target(target, stmt.line)
+        res = self.binary_op(res, rreg, stmt.op, stmt.line)
+        self.assign_to_target(target, res, res.line)
+        return INVALID_VALUE
 
     def get_assignment_target(self, lvalue: Lvalue) -> AssignmentTarget:
         if isinstance(lvalue, NameExpr):
@@ -412,26 +396,43 @@ class IRBuilder(NodeVisitor[Value]):
 
         assert False, 'Unsupported lvalue: %r' % lvalue
 
+    def read_from_target(self, target: AssignmentTarget, line: int) -> Value:
+        if isinstance(target, AssignmentTargetRegister):
+            return target.register
+        if isinstance(target, AssignmentTargetIndex):
+            reg = self.translate_special_method_call(target.base,
+                                                     '__getitem__',
+                                                     [target.index],
+                                                     None,
+                                                     line)
+            if reg is not None:
+                return reg
+            assert False, target.base.type
+        if isinstance(target, AssignmentTargetAttr):
+            return self.add(GetAttr(target.obj, target.attr, line))
+
+        assert False, 'Unsupported lvalue: %r' % target
+
     def assign_to_target(self,
                          target: AssignmentTarget,
-                         rvalue: Expression) -> Value:
-        rvalue_reg = self.accept(rvalue)
+                         rvalue_reg: Value,
+                         line: int) -> Value:
         if isinstance(target, AssignmentTargetRegister):
-            rvalue_reg = self.coerce(rvalue_reg, target.type, rvalue.line)
+            rvalue_reg = self.coerce(rvalue_reg, target.type, line)
             return self.add(Assign(target.register, rvalue_reg))
         elif isinstance(target, AssignmentTargetAttr):
             if isinstance(target.obj_type, RInstance):
-                rvalue_reg = self.coerce(rvalue_reg, target.type, rvalue.line)
-                return self.add(SetAttr(target.obj, target.attr, rvalue_reg, rvalue.line))
+                rvalue_reg = self.coerce(rvalue_reg, target.type, line)
+                return self.add(SetAttr(target.obj, target.attr, rvalue_reg, line))
             else:
-                return self.add(PySetAttr(target.obj, target.attr, rvalue_reg, rvalue.line))
+                return self.add(PySetAttr(target.obj, target.attr, rvalue_reg, line))
         elif isinstance(target, AssignmentTargetIndex):
             target_reg2 = self.translate_special_method_call(
                 target.base,
                 '__setitem__',
                 [target.index, rvalue_reg],
                 None,
-                rvalue.line)
+                line)
             if target_reg2 is not None:
                 return target_reg2
 
@@ -443,7 +444,8 @@ class IRBuilder(NodeVisitor[Value]):
                lvalue: Lvalue,
                rvalue: Expression) -> AssignmentTarget:
         target = self.get_assignment_target(lvalue)
-        self.assign_to_target(target, rvalue)
+        rvalue_reg = self.accept(rvalue)
+        self.assign_to_target(target, rvalue_reg, rvalue.line)
         return target
 
     def visit_if_stmt(self, stmt: IfStmt) -> Value:

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -176,3 +176,33 @@ L0:
     self.y = r2; r3 = is_error
     r4 = None
     return r4
+
+[case testAttrLvalue]
+class O(object):
+    def __init__(self) -> None:
+        self.x = 1
+
+def increment(o: O) -> O:
+    o.x += 1
+    return o
+[out]
+def __init__(self):
+    self :: O
+    r0 :: int
+    r1 :: bool
+    r2 :: None
+L0:
+    r0 = 1
+    self.x = r0; r1 = is_error
+    r2 = None
+    return r2
+def increment(o):
+    o :: O
+    r0, r1, r2 :: int
+    r3 :: bool
+L0:
+    r0 = 1
+    r1 = o.x
+    r2 = r1 + r0 :: int
+    o.x = r2; r3 = is_error
+    return o

--- a/test-data/genops-dict.test
+++ b/test-data/genops-dict.test
@@ -118,3 +118,35 @@ L0:
     r1 = None
     r2 = None
     return r2
+
+[case testDictKeyLvalue]
+from typing import Dict
+def increment(d: Dict[str, int]) -> Dict[str, int]:
+    for k in d:
+        d[k] += 1
+    return d
+[out]
+def increment(d):
+    d :: dict
+    k, r0, r1 :: object
+    r2 :: str
+    r3 :: int
+    r4, r5, r6 :: object
+    r7, r8 :: bool
+L0:
+    r0 = iter d :: object
+L1:
+    r1 = next r0 :: object
+    if is_error(r1) goto L3 else goto L2
+L2:
+    k = r1
+    r2 = cast(str, k)
+    r3 = 1
+    r4 = d[r2] :: dict
+    r5 = box(int, r3)
+    r6 = r4 + r5
+    r7 = d.__setitem__(r2, r6) :: dict
+    goto L1
+L3:
+    r8 = no_err_occurred 
+    return d

--- a/test-data/genops-lists.test
+++ b/test-data/genops-lists.test
@@ -162,3 +162,39 @@ L0:
     r2 = None
     r3 = None
     return r3
+
+[case testIndexLvalue]
+from typing import List
+def increment(l: List[int]) -> List[int]:
+    for i in range(len(l)):
+        l[i] += 1
+    return l
+[out]
+def increment(l):
+    l :: list
+    r0, i, r1 :: int
+    r2 :: bool
+    r3 :: int
+    r4, r5, r6 :: object
+    r7 :: bool
+    r8, r9 :: int
+L0:
+    r0 = len l :: list
+    r1 = 0
+    i = r1
+L1:
+    r2 = i < r0 :: int
+    if r2 goto L2 else goto L4 :: bool
+L2:
+    r3 = 1
+    r4 = l[i] :: list
+    r5 = box(int, r3)
+    r6 = r4 + r5
+    r7 = l.__setitem__(i, r6) :: list
+L3:
+    r8 = 1
+    r9 = i + r8 :: int
+    i = r9
+    goto L1
+L4:
+    return l

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -835,13 +835,17 @@ assert e() == 5.0
 assert f == 5.0
 
 [case testArbitraryLvalues]
-from typing import List, Dict
+from typing import List, Dict, Any
 
 class O(object):
     def __init__(self) -> None:
         self.x = 1
 
-def increment_attr(o: O) -> O:
+def increment_attr(a: Any) -> Any:
+    a.x += 1
+    return a
+
+def increment_attr_o(o: O) -> O:
     o.x += 1
     return o
 
@@ -856,7 +860,13 @@ def increment_all_keys(d: Dict[str, int]) -> Dict[str, int]:
     return d
 
 [file driver.py]
-from native import O, increment_attr, increment_all_indices, increment_all_keys
-assert increment_attr(O()).x == 2
+from native import O, increment_attr, increment_attr_o, increment_all_indices, increment_all_keys
+
+class P(object):
+    def __init__(self) -> None:
+        self.x = 0
+
+assert increment_attr(P()).x == 1
+assert increment_attr_o(O()).x == 2
 assert increment_all_indices([1, 2, 3]) == [2, 3, 4]
 assert increment_all_keys({'a':1, 'b':2, 'c':3}) == {'a':2, 'b':3, 'c':4}

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -835,7 +835,7 @@ assert e() == 5.0
 assert f == 5.0
 
 [case testArbitraryLvalues]
-from typing import List
+from typing import List, Dict
 
 class O(object):
     def __init__(self) -> None:
@@ -850,7 +850,13 @@ def increment_all_indices(l: List[int]) -> List[int]:
         l[i] += 1
     return l
 
+def increment_all_keys(d: Dict[str, int]) -> Dict[str, int]:
+    for k in d:
+        d[k] += 1
+    return d
+
 [file driver.py]
-from native import O, increment_attr, increment_all_indices
+from native import O, increment_attr, increment_all_indices, increment_all_keys
 assert increment_attr(O()).x == 2
 assert increment_all_indices([1, 2, 3]) == [2, 3, 4]
+assert increment_all_keys({'a':1, 'b':2, 'c':3}) == {'a':2, 'b':3, 'c':4}

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -833,3 +833,24 @@ assert c() == 5.0
 assert d == 5.0
 assert e() == 5.0
 assert f == 5.0
+
+[case testArbitraryLvalues]
+from typing import List
+
+class O(object):
+    def __init__(self) -> None:
+        self.x = 1
+
+def increment_attr(o: O) -> O:
+    o.x += 1
+    return o
+
+def increment_all_indices(l: List[int]) -> List[int]:
+    for i in range(len(l)):
+        l[i] += 1
+    return l
+
+[file driver.py]
+from native import O, increment_attr, increment_all_indices
+assert increment_attr(O()).x == 2
+assert increment_all_indices([1, 2, 3]) == [2, 3, 4]


### PR DESCRIPTION
Support lvalues for lists indices and object attributes. The
following things, for example, are now valid:
    obj.attr += 1
    l[idx] += 1

This fixes #124.