### PR TITLE
Basic support for compiling multiple modules at a time

### DIFF
--- a/mypyc/buildc.py
+++ b/mypyc/buildc.py
@@ -128,8 +128,10 @@ def build_shared_lib_for_modules(cpath: str) -> str:
     base_name = 'stuff'
     out_file = 'lib%s.so' % base_name
     cmd = ['clang'] + basic_flags + ['-o', out_file, cpath] + py_flags + warning_flags
-    print(cmd)
-    subprocess.check_call(cmd)
+    try:
+        subprocess.check_call(cmd)
+    except subprocess.CalledProcessError as err:
+        raise BuildError(err.output)
     return out_file
 
 

--- a/mypyc/buildc.py
+++ b/mypyc/buildc.py
@@ -83,12 +83,12 @@ setup(name='{package_name}',
 shim_format = """\
 #include <Python.h>
 
-PyObject *x_PyInit_{modname}(void);
+PyObject *CPyInit_{modname}(void);
 
 PyMODINIT_FUNC
 PyInit_{modname}(void)
 {{
-    return x_PyInit_{modname}();
+    return CPyInit_{modname}();
 }}
 """
 

--- a/mypyc/buildc.py
+++ b/mypyc/buildc.py
@@ -41,7 +41,6 @@ def build_c_extension(cpath: str, module_name: str, preserve_setup: bool = False
         tempdir = '.'
     else:
         tempdir = tempfile.mkdtemp()
-    include_dir = os.path.join(os.path.dirname(__file__), '..', 'lib-rt')
     try:
         setup_path = os.path.join(tempdir, 'setup.py')
         basename = os.path.basename(cpath)

--- a/mypyc/buildc.py
+++ b/mypyc/buildc.py
@@ -30,7 +30,7 @@ class BuildError(Exception):
         self.output = output
 
 
-def build_c_extension(cpath: str) -> str:
+def build_c_extension(cpath: str, module_name: str) -> str:
     tempdir = tempfile.mkdtemp()
     include_dir = os.path.join(os.path.dirname(__file__), '..', 'lib-rt')
     try:
@@ -46,7 +46,7 @@ def build_c_extension(cpath: str) -> str:
             subprocess.check_output(['python', setup_path, 'build'], stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as err:
             raise BuildError(err.output)
-        so_path = glob.glob('build/*/*.so')
+        so_path = glob.glob('build/*/%s*.so' % module_name)
         assert len(so_path) == 1
         return so_path[0]
     finally:

--- a/mypyc/buildc.py
+++ b/mypyc/buildc.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+from typing import List
 
 
 # TODO: Make compiler arguments platform-specific.
@@ -24,6 +25,10 @@ setup(name='{package_name}',
 """
 
 
+def include_dir() -> str:
+    return os.path.join(os.path.dirname(__file__), '..', 'lib-rt')
+
+
 class BuildError(Exception):
     def __init__(self, output: bytes) -> None:
         super().__init__('Build failed')
@@ -32,7 +37,6 @@ class BuildError(Exception):
 
 def build_c_extension(cpath: str, module_name: str) -> str:
     tempdir = tempfile.mkdtemp()
-    include_dir = os.path.join(os.path.dirname(__file__), '..', 'lib-rt')
     try:
         setup_path = os.path.join(tempdir, 'setup.py')
         basename = os.path.basename(cpath)
@@ -41,7 +45,7 @@ def build_c_extension(cpath: str, module_name: str) -> str:
             f.write(setup_format.format(
                 cpath=cpath,
                 package_name=package_name,
-                include_dir=include_dir))
+                include_dir=include_dir()))
         try:
             subprocess.check_output(['python', setup_path, 'build'], stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as err:
@@ -51,3 +55,79 @@ def build_c_extension(cpath: str, module_name: str) -> str:
         return so_path[0]
     finally:
         shutil.rmtree(tempdir)
+
+
+# TODO: Make compiler arguments platform-specific.
+setup_format_shim = """\
+from distutils.core import setup, Extension
+
+module = Extension('{package_name}',
+                   sources=['{cpath}'],
+                   extra_compile_args=['-Wno-unused-function', '-Wno-unused-label', '-Werror',
+                                       '-Wno-unreachable-code'],
+                   libraries=['{sharedlib}'],
+                   library_dirs=['{libdir}'])
+
+setup(name='{package_name}',
+      version='1.0',
+      description='{package_name}',
+      include_dirs=['{include_dir}'],
+      ext_modules=[module])
+"""
+
+shim_format = """\
+#include <Python.h>
+
+PyObject *x_PyInit_{modname}(void);
+
+PyMODINIT_FUNC
+PyInit_{modname}(void)
+{{
+    return x_PyInit_{modname}();
+}}
+"""
+
+
+def build_c_extension_shim(module_name: str, shared_lib: str) -> str:
+    tempdir = tempfile.mkdtemp()
+    cpath = os.path.join(tempdir, '%s.c' % module_name)
+    with open(cpath, 'w') as f:
+        f.write(shim_format.format(modname=module_name))
+    try:
+        setup_path = os.path.join(tempdir, 'setup.py')
+        basename = os.path.basename(cpath)
+        package_name = os.path.splitext(basename)[0]
+        with open(setup_path, 'w') as f:
+            f.write(setup_format_shim.format(
+                package_name=package_name,
+                cpath=cpath,
+                sharedlib='stuff',
+                libdir='.',
+                include_dir=include_dir()))
+        try:
+            subprocess.check_output(['python', setup_path, 'build'], stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as err:
+            raise BuildError(err.output)
+        so_path = glob.glob('build/*/%s*.so' % module_name)
+        assert len(so_path) == 1
+        return so_path[0]
+    finally:
+        shutil.rmtree(tempdir)
+
+
+def build_shared_lib_for_modules(cpath: str) -> str:
+    """Build the shared lib for a set of modules."""
+    basic_flags = ['-arch', 'x86_64', '-shared', '-I', include_dir()]
+    warning_flags = ['-Wno-unused-label', '-Wno-unused-function', '-Wno-unreachable-code']
+    py_flags = get_python_flags()
+    base_name = 'stuff'
+    out_file = 'lib%s.so' % base_name
+    cmd = ['clang'] + basic_flags + ['-o', out_file, cpath] + py_flags + warning_flags
+    print(cmd)
+    subprocess.check_call(cmd)
+    return out_file
+
+
+def get_python_flags() -> List[str]:
+    out = subprocess.check_output(['python-config', '--cflags', '--ldflags']).decode()
+    return out.strip().split()

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -10,6 +10,7 @@ from mypyc.ops import (
     short_name, is_list_rprimitive, is_dict_rprimitive, is_tuple_rprimitive, is_none_rprimitive,
     object_rprimitive, is_str_rprimitive
 )
+from mypyc.namegen import NameGenerator
 
 
 class HeaderDeclaration:
@@ -19,10 +20,11 @@ class HeaderDeclaration:
 
 
 class EmitterContext:
-    """Shared emitter state for an entire module."""
+    """Shared emitter state for an entire compilation unit."""
 
-    def __init__(self) -> None:
+    def __init__(self, module_names: List[str]) -> None:
         self.temp_counter = 0
+        self.names = NameGenerator(module_names)
 
         # A map of a C identifier to whatever the C identifier declares. Currently this is
         # used for declaring structs and the key corresponds to the name of the struct.
@@ -35,6 +37,7 @@ class Emitter:
 
     def __init__(self, context: EmitterContext, env: Optional[Environment] = None) -> None:
         self.context = context
+        self.names = context.names
         self.env = env or Environment()
         self.fragments = []  # type: List[str]
         self._indent = 0

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -6,7 +6,7 @@ from typing import List, Set, Dict, Optional
 from mypyc.common import REG_PREFIX
 from mypyc.ops import (
     Environment, Label, Value, Register, RType, RTuple, RInstance, ROptional,
-    RPrimitive, type_struct_name, is_int_rprimitive, is_float_rprimitive, is_bool_rprimitive,
+    RPrimitive, is_int_rprimitive, is_float_rprimitive, is_bool_rprimitive,
     short_name, is_list_rprimitive, is_dict_rprimitive, is_tuple_rprimitive, is_none_rprimitive,
     object_rprimitive, is_str_rprimitive
 )
@@ -199,7 +199,9 @@ class Emitter:
             if declare_dest:
                 self.emit_line('PyObject *{};'.format(dest))
             self.emit_lines(
-                'if (PyObject_TypeCheck({}, &{}))'.format(src, type_struct_name(typ.name)),
+                'if (PyObject_TypeCheck({}, &{}))'.format(
+                    src,
+                    typ.class_ir.type_struct_name(self.names)),
                 '    {} = {};'.format(dest, src),
                 'else {',
                 err,

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -65,6 +65,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
                  func_name: str,
                  source_path: str) -> None:
         self.emitter = emitter
+        self.names = emitter.names
         self.declarations = declarations
         self.env = self.emitter.env
         self.func_name = func_name
@@ -167,7 +168,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         self.emit_line('%s = CPY_GET_ATTR(%s, %d, %s, %s);' % (
             dest, obj,
             rtype.getter_index(op.attr),
-            rtype.struct_name(),
+            rtype.struct_name(self.names),
             rtype.attr_type(op.attr).ctype))
 
     def visit_set_attr(self, op: SetAttr) -> None:
@@ -181,7 +182,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
             obj,
             rtype.setter_index(op.attr),
             src,
-            rtype.struct_name(),
+            rtype.struct_name(self.names),
             rtype.attr_type(op.attr).ctype))
 
     def visit_load_static(self, op: LoadStatic) -> None:
@@ -232,7 +233,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         assert method is not None
         mtype = native_function_type(method)
         self.emit_line('{}CPY_GET_METHOD({}, {}, {}, {})({});'.format(
-            dest, obj, method_idx, rtype.struct_name(), mtype, args))
+            dest, obj, method_idx, rtype.struct_name(self.names), mtype, args))
 
     def visit_py_call(self, op: PyCall) -> None:
         dest = self.get_dest_assign(op)

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -220,7 +220,9 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
     def visit_call(self, op: Call) -> None:
         dest = self.get_dest_assign(op)
         args = ', '.join(self.reg(arg) for arg in op.args)
-        self.emit_line('%s%s%s(%s);' % (dest, NATIVE_PREFIX, op.fn, args))
+        module_name, name = op.fn.rsplit('.', 1)
+        cname = self.names.private_name(module_name, name)
+        self.emit_line('%s%s%s(%s);' % (dest, NATIVE_PREFIX, cname, args))
 
     def visit_method_call(self, op: MethodCall) -> None:
         dest = self.get_dest_assign(op)

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -147,8 +147,16 @@ class ModuleGenerator:
                            '};')
         emitter.emit_line()
 
-        # Emit module init function
-        emitter.emit_lines('PyObject * x_PyInit_{}(void)'.format(module_name),
+        # Emit module init function. If we are compiling just one module, this
+        # will be the C API init function. If we are compiling 2+ modules, we
+        # generate a shared library for the modules and shims that call into
+        # the shared library, and in this case we use an internal module
+        # initialized function that will be called by the shim.
+        if len(self.modules) == 1:
+            declaration = 'PyMODINIT_FUNC PyInit_{}(void)'
+        else:
+            declaration = 'PyObject *x_PyInit_{}(void)'
+        emitter.emit_lines(declaration.format(module_name),
                            '{',
                            'PyObject *m;')
         for cl in module.classes:

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -161,7 +161,7 @@ class ModuleGenerator:
         if len(self.modules) == 1:
             declaration = 'PyMODINIT_FUNC PyInit_{}(void)'
         else:
-            declaration = 'PyObject *x_PyInit_{}(void)'
+            declaration = 'PyObject *CPyInit_{}(void)'
         emitter.emit_lines(declaration.format(module_name),
                            '{',
                            'PyObject *m;')

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -55,8 +55,8 @@ def compile_module_to_c(sources: List[BuildSource], module_names: List[str], opt
 
 def generate_function_declaration(fn: FuncIR, emitter: Emitter) -> None:
     emitter.emit_lines(
-        '{};'.format(native_function_header(fn)),
-        '{};'.format(wrapper_function_header(fn)))
+        '{};'.format(native_function_header(fn, emitter.names)),
+        '{};'.format(wrapper_function_header(fn, emitter.names)))
 
 
 def encode_as_c_string(s: str) -> Tuple[str, int]:
@@ -73,7 +73,8 @@ class ModuleGenerator:
                  source_paths: Dict[str, str]) -> None:
         self.modules = modules
         self.source_paths = source_paths
-        self.context = EmitterContext()
+        self.context = EmitterContext([name for name, _ in modules])
+        self.names = self.context.names
 
     def generate_c_for_modules(self) -> str:
         emitter = Emitter(self.context)
@@ -127,7 +128,7 @@ class ModuleGenerator:
             emitter.emit_line(
                 ('{{"{name}", (PyCFunction){prefix}{name}, METH_VARARGS | METH_KEYWORDS, '
                  'NULL /* docstring */}},').format(
-                    name=fn.cname,
+                    name=fn.cname(self.names),
                     prefix=PREFIX))
         emitter.emit_line('{NULL, NULL, 0, NULL}')
         emitter.emit_line('};')

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -126,6 +126,8 @@ class ModuleGenerator:
         module_prefix = emitter.names.private_name(module_name)
         emitter.emit_line('static PyMethodDef {}module_methods[] = {{'.format(module_prefix))
         for fn in module.functions:
+            if fn.class_name is not None:
+                continue
             emitter.emit_line(
                 ('{{"{name}", (PyCFunction){prefix}{cname}, METH_VARARGS | METH_KEYWORDS, '
                  'NULL /* docstring */}},').format(
@@ -160,7 +162,7 @@ class ModuleGenerator:
                            '{',
                            'PyObject *m;')
         for cl in module.classes:
-            type_struct = cl.type_struct
+            type_struct = cl.type_struct_name(emitter.names)
             emitter.emit_lines('if (PyType_Ready(&{}) < 0)'.format(type_struct),
                                '    return NULL;')
         emitter.emit_lines('m = PyModule_Create(&{}module);'.format(module_prefix),
@@ -199,7 +201,7 @@ class ModuleGenerator:
 
         for cl in module.classes:
             name = cl.name
-            type_struct = cl.type_struct
+            type_struct = cl.type_struct_name(emitter.names)
             emitter.emit_lines(
                 'Py_INCREF(&{});'.format(type_struct),
                 'PyModule_AddObject(m, "{}", (PyObject *)&{});'.format(name, type_struct))

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -25,8 +25,8 @@ class MarkedDeclaration:
         self.mark = False
 
 
-def compile_module_to_c(sources: List[BuildSource], module_names: List[str], options: Options,
-                        alt_lib_path: str) -> str:
+def compile_modules_to_c(sources: List[BuildSource], module_names: List[str], options: Options,
+                         alt_lib_path: str) -> str:
     """Compile Python module(s) to C that can be used from Python C extension modules."""
     assert options.strict_optional, 'strict_optional must be turned on'
     result = build(sources=sources,
@@ -148,7 +148,7 @@ class ModuleGenerator:
         emitter.emit_line()
 
         # Emit module init function
-        emitter.emit_lines('PyMODINIT_FUNC PyInit_{}(void)'.format(module_name),
+        emitter.emit_lines('PyObject * x_PyInit_{}(void)'.format(module_name),
                            '{',
                            'PyObject *m;')
         for cl in module.classes:

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -36,8 +36,8 @@ def compile_modules_to_c(sources: List[BuildSource], module_names: List[str], op
         raise CompileError(result.errors)
 
     # Generate basic IR, with missing exception and refcount handling.
-    modules = [(module_name, genops.build_ir(result.files[module_name], result.types))
-               for module_name in module_names]
+    file_nodes = [result.files[name] for name in module_names]
+    modules = genops.build_ir(file_nodes, result.types)
     # Insert exception handling.
     for _, module in modules:
         for fn in module.functions:

--- a/mypyc/emitwrapper.py
+++ b/mypyc/emitwrapper.py
@@ -21,6 +21,7 @@ def generate_wrapper_function(fn: FuncIR, emitter: Emitter) -> None:
     emitter.emit_line('{} {{'.format(wrapper_function_header(fn, emitter.names)))
 
     # If fn is a method, then the first argument is a self param
+    print('>>>', fn.cname(emitter.names), fn.args)
     real_args = fn.args[:]
     if fn.class_name:
         arg = real_args.pop(0)

--- a/mypyc/emitwrapper.py
+++ b/mypyc/emitwrapper.py
@@ -21,7 +21,6 @@ def generate_wrapper_function(fn: FuncIR, emitter: Emitter) -> None:
     emitter.emit_line('{} {{'.format(wrapper_function_header(fn, emitter.names)))
 
     # If fn is a method, then the first argument is a self param
-    print('>>>', fn.cname(emitter.names), fn.args)
     real_args = fn.args[:]
     if fn.class_name:
         arg = real_args.pop(0)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -183,6 +183,8 @@ class IRBuilder(NodeVisitor[Value]):
             # built-in primitives.
             return INVALID_VALUE
 
+        self.module_name = mypyfile.fullname()
+
         classes = [node for node in mypyfile.defs if isinstance(node, ClassDef)]
 
         # Build ClassIRs and TypeInfo-to-ClassIR mapping.
@@ -207,7 +209,7 @@ class IRBuilder(NodeVisitor[Value]):
     def create_class_def(self, cdef: ClassDef) -> None:
         # We want to collect the attributes first so they are available
         # while generating the methods
-        ir = ClassIR(cdef.name)
+        ir = ClassIR(cdef.name, self.module_name)
         self.classes.append(ir)
         self.mapper.type_to_ir[cdef.info] = ir
 
@@ -287,7 +289,7 @@ class IRBuilder(NodeVisitor[Value]):
 
         blocks, env = self.leave()
         args = self.convert_args(fdef)
-        return FuncIR(fdef.name(), class_name, args, self.ret_type, blocks, env)
+        return FuncIR(fdef.name(), class_name, self.module_name, args, self.ret_type, blocks, env)
 
     def visit_func_def(self, fdef: FuncDef) -> Value:
         self.functions.append(self.gen_func_def(fdef))

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -57,19 +57,22 @@ from mypyc.subtype import is_subtype
 from mypyc.sametype import is_same_type
 
 
-def build_ir(module: MypyFile,
-             types: Dict[Expression, Type]) -> ModuleIR:
-    mapper = Mapper()
-    builder = IRBuilder(types, mapper)
-    module.accept(builder)
-
-    return ModuleIR(
-        builder.imports,
-        builder.from_imports,
-        builder.literals,
-        builder.functions,
-        builder.classes
-    )
+def build_ir(modules: List[MypyFile],
+             types: Dict[Expression, Type]) -> List[Tuple[str, ModuleIR]]:
+    result = []
+    for module in modules:
+        mapper = Mapper()
+        builder = IRBuilder(types, mapper)
+        module.accept(builder)
+        ir = ModuleIR(
+            builder.imports,
+            builder.from_imports,
+            builder.literals,
+            builder.functions,
+            builder.classes
+        )
+        result.append((module.fullname(), ir))
+    return result
 
 
 class Mapper:

--- a/mypyc/namegen.py
+++ b/mypyc/namegen.py
@@ -44,7 +44,7 @@ class NameGenerator:
         self.translations = {}  # type: Dict[Tuple[str, str], str]
         self.used_names = set()  # type: Set[str]
 
-    def private_name(self, module: str, partial_name: Optional[str]) -> str:
+    def private_name(self, module: str, partial_name: Optional[str] = None) -> str:
         """Return a C name usable for a static definition.
 
         Return a distinct result for each (module, partial_name) pair.

--- a/mypyc/namegen.py
+++ b/mypyc/namegen.py
@@ -1,0 +1,109 @@
+from typing import List, Dict, Tuple, Set
+
+
+class NameGenerator:
+    """Utility for generating distinct C names from Python names.
+
+    Since C names can't use '.' (or unicode), some care is required to
+    make C names generated from Python names unique. Also, we want to
+    avoid generating overly long C names since they make the generated
+    code harder to read.
+
+    Note that we don't restrict ourselves to a 32-character distinguishing
+    prefix guaranteed by the C standard since all the compilers we care
+    about at the moment support longer names without issues.
+
+    For names that are exported in a shared library (not static) use
+    exported_name() instead.
+
+    Summary of the approach:
+
+    * Generate a unique name prefix from suffix of fully-qualified
+      module name used for static names. If only compiling a single
+      module, this can be empty. For example, if the modules are
+      'foo.bar' and 'foo.baz', the prefixes can be 'bar_' and 'baz_',
+      respectively. If the modules are 'bar.foo' and 'baz.foo', the
+      prefixes will be 'bar_foo_' and 'baz_foo_'.
+
+    * Replace '.' in the Python name with '_' in the C name. This can
+      obviously generate conflicts at C name level. If multiple Python
+      names would map to the same C name using the basic algorithm,
+      add suffixes _2, _3, etc. to make the C names unique.
+
+    * Keep a dictionary of mappings so that we can translate each name
+      consistently within a build.
+
+    The generated should be internal to a build and thus the mapping is
+    arbitrary. Just generating names '1', '2', ... would be correct,
+    though not very usable.
+    """
+
+    def __init__(self, module_names: List[str]) -> None:
+        """Initialize with names of all modules in the compilation unit."""
+        self.module_map = make_module_translation_map(module_names)
+        self.translations = {}  # type: Dict[Tuple[str, str], str]
+        self.used_names = set()  # type: Set[str]
+
+    def private_name(self, module: str, partial_name: str) -> str:
+        """Return a C name usable for a static definition.
+
+        Return a distinct result for each (module, partial_name) pair.
+
+        The caller should add a suitable prefix to the name to avoid
+        conflicts. Only ensure that the results of this function are
+        unique, not that they aren't overlapping with arbitrary names.
+        """
+        # TODO: Support unicode
+        if (module, partial_name) in self.translations:
+            return self.translations[module, partial_name]
+        candidate = '{}{}'.format(self.module_map[module], partial_name.replace('.', '_'))
+        actual = self.make_unique(candidate)
+        self.translations[module, partial_name] = actual
+        self.used_names.add(actual)
+        return actual
+
+    def make_unique(self, name: str) -> str:
+        if name not in self.used_names:
+            return name
+        i = 2
+        while True:
+            candidate = '{}_{}'.format(name, i)
+            if candidate not in self.used_names:
+                return candidate
+            i += 1
+
+
+def exported_name(fullname: str) -> str:
+    """Return a C name usable for an exported definition.
+
+    This is like private_name(), but the output only depends on the
+    'fullname' argument, so the names are distinct across multiple
+    builds.
+    """
+    # TODO: Support unicode
+    # TODO: Ensure that there are no conflicts?
+    return fullname.replace('.', '___')
+
+
+def make_module_translation_map(names: List[str]) -> Dict[str, str]:
+    num_instances = {}
+    for name in names:
+        for suffix in candidate_suffixes(name):
+            num_instances[suffix] = num_instances.get(suffix, 0) + 1
+    result = {}
+    for name in names:
+        for suffix in candidate_suffixes(name):
+            if num_instances[suffix] == 1:
+                result[name] = suffix
+                break
+        else:
+            assert False, names
+    return result
+
+
+def candidate_suffixes(fullname: str) -> List[str]:
+    components = fullname.split('.')
+    result = ['']
+    for i in range(len(components)):
+        result.append('_'.join(components[-i - 1:]) + '_')
+    return result

--- a/mypyc/namegen.py
+++ b/mypyc/namegen.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Tuple, Set
+from typing import List, Dict, Tuple, Set, Optional
 
 
 class NameGenerator:
@@ -44,7 +44,7 @@ class NameGenerator:
         self.translations = {}  # type: Dict[Tuple[str, str], str]
         self.used_names = set()  # type: Set[str]
 
-    def private_name(self, module: str, partial_name: str) -> str:
+    def private_name(self, module: str, partial_name: Optional[str]) -> str:
         """Return a C name usable for a static definition.
 
         Return a distinct result for each (module, partial_name) pair.
@@ -54,6 +54,8 @@ class NameGenerator:
         unique, not that they aren't overlapping with arbitrary names.
         """
         # TODO: Support unicode
+        if partial_name is None:
+            return self.module_map[module].rstrip('_')
         if (module, partial_name) in self.translations:
             return self.translations[module, partial_name]
         candidate = '{}{}'.format(self.module_map[module], partial_name.replace('.', '_'))
@@ -86,7 +88,7 @@ def exported_name(fullname: str) -> str:
 
 
 def make_module_translation_map(names: List[str]) -> Dict[str, str]:
-    num_instances = {}
+    num_instances = {}  # type: Dict[str, int]
     for name in names:
         for suffix in candidate_suffixes(name):
             num_instances[suffix] = num_instances.get(suffix, 0) + 1

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1275,6 +1275,8 @@ class ClassIR:
 
     def get_method(self, name: str) -> Optional[FuncIR]:
         matches = [func for func in self.methods if func.name == name]
+        if not matches and self.base:
+            return self.base.get_method(name)
         return matches[0] if matches else None
 
     def type_struct_name(self, names: NameGenerator) -> str:

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -671,7 +671,9 @@ class Call(RegisterOp):
 
     def to_str(self, env: Environment) -> str:
         args = ', '.join(env.format('%r', arg) for arg in self.args)
-        s = '%s(%s)' % (self.fn, args)
+        # TODO: Display long name?
+        short_name = self.fn.rpartition('.')[2]
+        s = '%s(%s)' % (short_name, args)
         if not self.is_void:
             s = env.format('%r = ', self) + s
         return s

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -271,8 +271,8 @@ class RInstance(RType):
     def c_undefined_value(self) -> str:
         return 'NULL'
 
-    def struct_name(self) -> str:
-        return self.class_ir.struct_name()
+    def struct_name(self, names: NameGenerator) -> str:
+        return self.class_ir.struct_name(names)
 
     def getter_index(self, name: str) -> int:
         return self.class_ir.vtable_entry(name)
@@ -1265,16 +1265,18 @@ class ClassIR:
             if name in ir.attributes: return ir.attributes[name]
         assert False, '%r has no attribute %r' % (self.name, name)
 
-    def struct_name(self) -> str:
-        return '{}Object'.format(self.name)
+    def name_prefix(self, names: NameGenerator) -> str:
+        return names.private_name(self.module_name, self.name)
+
+    def struct_name(self, names: NameGenerator) -> str:
+        return '{}Object'.format(self.name_prefix(names))
 
     def get_method(self, name: str) -> Optional[FuncIR]:
         matches = [func for func in self.methods if func.name == name]
         return matches[0] if matches else None
 
-    @property
-    def type_struct(self) -> str:
-        return '{}Type'.format(self.name)
+    def type_struct_name(self, names: NameGenerator) -> str:
+        return '{}Type'.format(self.name_prefix(names))
 
 
 class ModuleIR:
@@ -1294,10 +1296,6 @@ class ModuleIR:
 
         if 'builtins' not in self.imports:
             self.imports.insert(0, 'builtins')
-
-
-def type_struct_name(class_name: str) -> str:
-    return '{}Type'.format(class_name)
 
 
 class OpVisitor(Generic[T]):

--- a/mypyc/test/test_analysis.py
+++ b/mypyc/test/test_analysis.py
@@ -53,7 +53,8 @@ class TestAnalysis(MypycDataSuite):
                 if result.errors:
                     actual = result.errors
                 else:
-                    module = genops.build_ir(result.files['__main__'], result.types)
+                    modules = genops.build_ir([result.files['__main__']], result.types)
+                    module = modules[0][1]
                     assert len(module.functions) == 1, (
                         "Only 1 function definition expected per test case")
                     fn = module.functions[0]

--- a/mypyc/test/test_emit.py
+++ b/mypyc/test/test_emit.py
@@ -10,7 +10,7 @@ class TestEmitter(unittest.TestCase):
     def setUp(self) -> None:
         self.env = Environment()
         self.n = self.env.add_local(Var('n'), int_rprimitive)
-        self.context = EmitterContext()
+        self.context = EmitterContext(['mod'])
         self.emitter = Emitter(self.context, self.env)
 
     def test_label(self) -> None:

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -39,13 +39,13 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.t = self.env.add_local(Var('t'), RTuple([int_rprimitive, bool_rprimitive]))
         self.tt = self.env.add_local(
             Var('tt'), RTuple([RTuple([int_rprimitive, bool_rprimitive]), bool_rprimitive]))
-        ir = ClassIR('A')
+        ir = ClassIR('A', 'mod')
         ir.attributes = OrderedDict([('x', bool_rprimitive), ('y', int_rprimitive)])
         ir.compute_vtable()
         ir.mro = [ir]
         self.r = self.env.add_local(Var('r'), RInstance(ir))
 
-        self.context = EmitterContext()
+        self.context = EmitterContext(['mod'])
         self.emitter = Emitter(self.context, self.env)
         self.declarations = Emitter(self.context, self.env)
         self.visitor = FunctionEmitterVisitor(self.emitter, self.declarations, 'func', 'prog.py')
@@ -268,8 +268,8 @@ class TestGenerateFunction(unittest.TestCase):
 
     def test_simple(self) -> None:
         self.block.ops.append(Return(self.reg))
-        fn = FuncIR('myfunc', None, [self.arg], int_rprimitive, [self.block], self.env)
-        emitter = Emitter(EmitterContext())
+        fn = FuncIR('myfunc', None, 'mod', [self.arg], int_rprimitive, [self.block], self.env)
+        emitter = Emitter(EmitterContext(['mod']))
         generate_native_function(fn, emitter, 'prog.py')
         result = emitter.fragments
         assert_string_arrays_equal(
@@ -286,8 +286,8 @@ class TestGenerateFunction(unittest.TestCase):
         op = LoadInt(5)
         self.block.ops.append(op)
         self.env.add_op(op)
-        fn = FuncIR('myfunc', None, [self.arg], list_rprimitive, [self.block], self.env)
-        emitter = Emitter(EmitterContext())
+        fn = FuncIR('myfunc', None, 'mod', [self.arg], list_rprimitive, [self.block], self.env)
+        emitter = Emitter(EmitterContext(['mod']))
         generate_native_function(fn, emitter, 'prog.py')
         result = emitter.fragments
         assert_string_arrays_equal(

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -129,11 +129,11 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """)
 
     def test_call(self) -> None:
-        self.assert_emit(Call(int_rprimitive, 'myfn', [self.m], 55),
+        self.assert_emit(Call(int_rprimitive, 'mod.myfn', [self.m], 55),
                          "cpy_r_r0 = CPyDef_myfn(cpy_r_m);")
 
     def test_call_two_args(self) -> None:
-        self.assert_emit(Call(int_rprimitive, 'myfn', [self.m, self.k], 55),
+        self.assert_emit(Call(int_rprimitive, 'mod.myfn', [self.m, self.k], 55),
                          "cpy_r_r0 = CPyDef_myfn(cpy_r_m, cpy_r_k);")
 
     def test_inc_ref(self) -> None:

--- a/mypyc/test/test_emitmodule.py
+++ b/mypyc/test/test_emitmodule.py
@@ -40,7 +40,7 @@ class TestCompiler(MypycDataSuite):
             source = build.BuildSource('prog.py', 'prog', text)
 
             try:
-                ctext = emitmodule.compile_module_to_c(
+                ctext = emitmodule.compile_modules_to_c(
                     sources=[source],
                     module_names=['prog'],
                     options=options,

--- a/mypyc/test/test_emitmodule.py
+++ b/mypyc/test/test_emitmodule.py
@@ -42,7 +42,7 @@ class TestCompiler(MypycDataSuite):
             try:
                 ctext = emitmodule.compile_module_to_c(
                     sources=[source],
-                    module_name='prog',
+                    module_names=['prog'],
                     options=options,
                     alt_lib_path=test_temp_dir)
                 out = ctext.splitlines()

--- a/mypyc/test/test_emitwrapper.py
+++ b/mypyc/test/test_emitwrapper.py
@@ -10,7 +10,7 @@ from mypyc.ops import list_rprimitive, int_rprimitive
 
 class TestArgCheck(unittest.TestCase):
     def setUp(self) -> None:
-        self.context = EmitterContext()
+        self.context = EmitterContext(['mod'])
 
     def test_check_list(self) -> None:
         emitter = Emitter(self.context)

--- a/mypyc/test/test_genops.py
+++ b/mypyc/test/test_genops.py
@@ -63,7 +63,8 @@ class TestGenOps(MypycDataSuite):
                 if result.errors:
                     actual = result.errors
                 else:
-                    module = genops.build_ir(result.files['__main__'], result.types)
+                    modules = genops.build_ir([result.files['__main__']], result.types)
+                    module = modules[0][1]
                     actual = []
                     for fn in module.functions:
                         actual.extend(format_func(fn))

--- a/mypyc/test/test_namegen.py
+++ b/mypyc/test/test_namegen.py
@@ -1,0 +1,39 @@
+import unittest
+
+from mypyc.namegen import (
+    NameGenerator, exported_name, candidate_suffixes, make_module_translation_map
+)
+
+
+class TestNameGen(unittest.TestCase):
+    def test_candidate_suffixes(self) -> None:
+        assert candidate_suffixes('foo') == ['', 'foo_']
+        assert candidate_suffixes('foo.bar') == ['', 'bar_', 'foo_bar_']
+
+    def test_exported_name(self) -> None:
+        assert exported_name('foo') == 'foo'
+        assert exported_name('foo.bar') == 'foo___bar'
+
+    def test_make_module_translation_map(self) -> None:
+        assert make_module_translation_map(
+            ['foo', 'bar']) == {'foo': 'foo_', 'bar': 'bar_'}
+        assert make_module_translation_map(
+            ['foo.bar', 'foo.baz']) == {'foo.bar': 'bar_', 'foo.baz': 'baz_'}
+        assert make_module_translation_map(
+            ['zar', 'foo.bar', 'foo.baz']) == {'foo.bar': 'bar_',
+                                               'foo.baz': 'baz_',
+                                               'zar': 'zar_'}
+        assert make_module_translation_map(
+            ['foo.bar', 'fu.bar', 'foo.baz']) == {'foo.bar': 'foo_bar_',
+                                                  'fu.bar': 'fu_bar_',
+                                                  'foo.baz': 'baz_'}
+
+    def test_name_generator(self) -> None:
+        g = NameGenerator(['foo', 'foo.zar'])
+        assert g.private_name('foo', 'f') == 'foo_f'
+        assert g.private_name('foo', 'C.x.y') == 'foo_C_x_y'
+        assert g.private_name('foo', 'C.x.y') == 'foo_C_x_y'
+        assert g.private_name('foo.zar', 'C.x.y') == 'zar_C_x_y'
+        assert g.private_name('foo', 'C.x_y') == 'foo_C_x_y_2'
+        assert g.private_name('foo', 'C_x_y') == 'foo_C_x_y_3'
+        assert g.private_name('foo', 'C_x_y') == 'foo_C_x_y_3'

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -115,6 +115,8 @@ class TestRun(MypycDataSuite):
             env = os.environ.copy()
             env['PYTHONPATH'] = os.path.dirname(native_lib_path)
             env['MYPYC_RUN_BENCH'] = '1' if bench else '0'
+            env['LD_LIBRARY_PATH'] = os.getcwd()
+
             proc = subprocess.Popen(['python', driver_path], stdout=subprocess.PIPE,
                                     stderr=subprocess.STDOUT, env=env)
             output, _ = proc.communicate()

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -82,7 +82,7 @@ class TestRun(MypycDataSuite):
             use_shared_lib = len(module_names) > 1
 
             if use_shared_lib:
-                common_path = os.path.join(test_temp_dir, 'stuff.c')
+                common_path = os.path.join(test_temp_dir, '__shared_stuff.c')
                 with open(common_path, 'w') as f:
                     f.write(ctext)
                 try:

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -52,11 +52,19 @@ class TestRun(MypycDataSuite):
                 f.write(text)
 
             source = build.BuildSource(source_path, 'native', text)
+            sources = [source]
+            module_names = ['native']
+
+            # Hard code another module name to compile in the same compilation unit.
+            for fn, text in testcase.files:
+                if os.path.basename(fn) == 'other.py':
+                    module_names.append('other')
+                    sources.append(build.BuildSource(fn, 'other', text))
 
             try:
                 ctext = emitmodule.compile_module_to_c(
-                    sources=[source],
-                    module_name='native',
+                    sources=sources,
+                    module_names=module_names,
                     options=options,
                     alt_lib_path=test_temp_dir)
             except CompileError as e:

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -15,6 +15,7 @@ from mypyc import emitmodule
 from mypyc import buildc
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, assert_test_output,
+    show_c_error, heading,
 )
 
 import pytest  # type: ignore  # no pytest in typeshed
@@ -87,13 +88,7 @@ class TestRun(MypycDataSuite):
                 try:
                     shared_lib = buildc.build_shared_lib_for_modules(common_path)
                 except buildc.BuildError as err:
-                    heading('Generated C')
-                    with open(common_path) as f:
-                        print_with_line_nums(f.read().rstrip())
-                    heading('End C')
-                    heading('Build output')
-                    print(err.output.decode('utf8').rstrip('\n'))
-                    heading('End output')
+                    show_c_error(common_path, err.output)
                     raise
 
             for mod in module_names:
@@ -107,13 +102,7 @@ class TestRun(MypycDataSuite):
                     else:
                         native_lib_path = buildc.build_c_extension(cpath, mod, preserve_setup=True)
                 except buildc.BuildError as err:
-                    heading('Generated C')
-                    with open(cpath) as f:
-                        print(f.read().rstrip())
-                    heading('End C')
-                    heading('Build output')
-                    print(err.output.decode('utf8').rstrip('\n'))
-                    heading('End output')
+                    show_c_error(cpath, err.output)
                     raise
 
             # # TODO: is the location of the shared lib good?
@@ -148,13 +137,3 @@ class TestRun(MypycDataSuite):
                 assert_test_output(testcase, outlines, 'Invalid output')
 
             assert proc.returncode == 0
-
-
-def heading(text: str) -> None:
-    print('=' * 20 + ' ' + text + ' ' + '=' * 20)
-
-
-def print_with_line_nums(s: str) -> None:
-    lines = s.splitlines()
-    for i, line in enumerate(lines):
-        print('%-4d %s' % (i, line))

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -89,7 +89,7 @@ class TestRun(MypycDataSuite):
                 except buildc.BuildError as err:
                     heading('Generated C')
                     with open(common_path) as f:
-                        print(f.read().rstrip())
+                        print_with_line_nums(f.read().rstrip())
                     heading('End C')
                     heading('Build output')
                     print(err.output.decode('utf8').rstrip('\n'))
@@ -152,3 +152,9 @@ class TestRun(MypycDataSuite):
 
 def heading(text: str) -> None:
     print('=' * 20 + ' ' + text + ' ' + '=' * 20)
+
+
+def print_with_line_nums(s: str) -> None:
+    lines = s.splitlines()
+    for i, line in enumerate(lines):
+        print('%-4d %s' % (i, line))

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -22,6 +22,7 @@ import pytest  # type: ignore  # no pytest in typeshed
 files = [
     'run.test',
     'run-classes.test',
+    'run-multimodule.test',
     'run-bench.test',
 ]
 
@@ -83,7 +84,17 @@ class TestRun(MypycDataSuite):
                 common_path = os.path.join(test_temp_dir, 'stuff.c')
                 with open(common_path, 'w') as f:
                     f.write(ctext)
-                shared_lib = buildc.build_shared_lib_for_modules(common_path)
+                try:
+                    shared_lib = buildc.build_shared_lib_for_modules(common_path)
+                except buildc.BuildError as err:
+                    heading('Generated C')
+                    with open(common_path) as f:
+                        print(f.read().rstrip())
+                    heading('End C')
+                    heading('Build output')
+                    print(err.output.decode('utf8').rstrip('\n'))
+                    heading('End output')
+                    raise
 
             for mod in module_names:
                 cpath = os.path.join(test_temp_dir, '%s.c' % mod)

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -133,3 +133,23 @@ def assert_test_output(testcase: DataDrivenTestCase, actual: List[str],
     assert_string_arrays_equal(
         expected_output, actual,
         '{} ({}, line {})'.format(message, testcase.file, testcase.line))
+
+
+def print_with_line_numbers(s: str) -> None:
+    lines = s.splitlines()
+    for i, line in enumerate(lines):
+        print('%-4d %s' % (i, line))
+
+
+def heading(text: str) -> None:
+    print('=' * 20 + ' ' + text + ' ' + '=' * 20)
+
+
+def show_c_error(cpath: str, output: bytes) -> None:
+    heading('Generated C')
+    with open(cpath) as f:
+        print_with_line_numbers(f.read().rstrip())
+    heading('End C')
+    heading('Build output')
+    print(output.decode('utf8').rstrip('\n'))
+    heading('End output')

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -92,7 +92,8 @@ def build_ir_for_single_file(input_lines: List[str]) -> List[FuncIR]:
                          alt_lib_path=test_temp_dir)
     if result.errors:
         raise CompileError(result.errors)
-    module = genops.build_ir(result.files['__main__'], result.types)
+    modules = genops.build_ir([result.files['__main__']], result.types)
+    module = modules[0][1]
     return module.functions
 
 

--- a/test-data/run-multimodule.test
+++ b/test-data/run-multimodule.test
@@ -93,7 +93,7 @@ class D(C):
 
 def f(c: C) -> int:
     d = D(3)
-    return c.x + c.f() + d.x + 1
+    return c.x + c.f() + d.x + d.f() + 1
 [file other.py]
 class C:
     x: int
@@ -107,7 +107,7 @@ class C:
 from native import f
 from other import C
 c = C(4)
-assert f(c) == 4 + 2 + 3 + 1
+assert f(c) == 4 + 2 + 3 + 2 + 1
 try:
     f(1)
 except TypeError:

--- a/test-data/run-multimodule.test
+++ b/test-data/run-multimodule.test
@@ -60,3 +60,46 @@ assert isinstance(native.D(), native.C)
 assert isinstance(other.D(), other.C)
 assert not isinstance(native.D(), other.C)
 assert not isinstance(other.D(), native.C)
+
+[case testMultiModuleInitializeImportedModules]
+from other import f
+
+def g() -> int:
+    return f(1)
+[file other.py]
+def f(x: int) -> int:
+    return x + 4
+[file driver.py]
+import sys
+assert 'other' not in sys.modules
+from native import g
+assert 'other' in sys.modules
+assert g() == 5
+f = sys.modules['other'].f
+assert f(1) == 5
+try:
+    f(1.1)
+except TypeError:
+    pass
+else:
+    assert False
+
+[case testMultiModuleImportClass]
+from other import C
+
+def f(c: C) -> int:
+    return 1
+[file other.py]
+class C:
+    pass
+[file driver.py]
+from native import f
+from other import C
+c = C()
+assert f(c) == 1
+try:
+    f(1)
+except TypeError:
+    pass
+else:
+    assert False

--- a/test-data/run-multimodule.test
+++ b/test-data/run-multimodule.test
@@ -1,0 +1,62 @@
+-- These test cases compile two modules at a time (native and other.py)
+
+[case testMultiModuleBasic]
+from other import g
+def f(x: int) -> int:
+    return g(x + 1)
+[file other.py]
+def g(x: int) -> int:
+    return x + 2
+[file driver.py]
+from native import f
+from other import g
+assert f(3) == 6
+assert g(2) == 4
+try:
+    f(1.1)
+except TypeError:
+    pass
+else:
+    assert False
+try:
+    g(1.1)
+except TypeError:
+    pass
+else:
+    assert False
+
+[case testMultiModuleSameNames]
+# Use same names in both modules
+def f() -> int:
+    return 0
+class C:
+    x: int
+    def __init__(self) -> None:
+        self.x = 1
+    def f(self, x: int) -> int:
+        return self.x + x
+class D(C): pass
+[file other.py]
+def f(x: int) -> int:
+    return x + 1
+class C:
+    x: int
+    def __init__(self) -> None:
+        self.x = 2
+    def f(self, x: int) -> int:
+        return self.x + x + 1
+class D(C): pass
+[file driver.py]
+import native, other
+assert native.f() == 0
+assert other.f(3) == 4
+c1 = native.C()
+c1.x += 3
+c2 = other.C()
+c2.x += 6
+assert c1.f(9) == 1 + 3 + 9
+assert c2.f(7) == 2 + 6 + 7 + 1
+assert isinstance(native.D(), native.C)
+assert isinstance(other.D(), other.C)
+assert not isinstance(native.D(), other.C)
+assert not isinstance(other.D(), native.C)

--- a/test-data/run-multimodule.test
+++ b/test-data/run-multimodule.test
@@ -88,15 +88,16 @@ else:
 from other import C
 
 def f(c: C) -> int:
-    return 1
+    return c.x + 1
 [file other.py]
 class C:
-    pass
+    x: int
 [file driver.py]
 from native import f
 from other import C
 c = C()
-assert f(c) == 1
+c.x = 4
+assert f(c) == 5
 try:
     f(1)
 except TypeError:

--- a/test-data/run-multimodule.test
+++ b/test-data/run-multimodule.test
@@ -87,17 +87,27 @@ else:
 [case testMultiModuleImportClass]
 from other import C
 
+class D(C):
+    def __init__(self, x: int) -> None:
+        self.x = x
+
 def f(c: C) -> int:
-    return c.x + 1
+    d = D(3)
+    return c.x + c.f() + d.x + 1
 [file other.py]
 class C:
     x: int
+
+    def __init__(self, x: int) -> None:
+        self.x = x
+
+    def f(self) -> int:
+        return 2
 [file driver.py]
 from native import f
 from other import C
-c = C()
-c.x = 4
-assert f(c) == 5
+c = C(4)
+assert f(c) == 4 + 2 + 3 + 1
 try:
     f(1)
 except TypeError:

--- a/test-data/run-multimodule.test
+++ b/test-data/run-multimodule.test
@@ -85,6 +85,7 @@ else:
     assert False
 
 [case testMultiModuleImportClass]
+from typing import cast
 from other import C
 
 class D(C):
@@ -93,6 +94,8 @@ class D(C):
 
 def f(c: C) -> int:
     d = D(3)
+    o: object = c
+    c = cast(C, o)
     return c.x + c.f() + d.x + d.f() + 1
 [file other.py]
 class C:

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -678,16 +678,23 @@ assert neg(9223372036854775808) == -9223372036854775808
 assert neg(-9223372036854775808) == 9223372036854775808
 
 [case testXXX]
+from other import g
 def f(x: int) -> int:
-    return x + 1
+    return g(x + 1)
 [file other.py]
 def g(x: int) -> int:
     return x + 2
 [file driver.py]
 from native import f
 from other import g
-assert f(3) == 4
-assert g(4) == 6
+assert f(3) == 6
+assert g(2) == 4
+try:
+    f(1.1)
+except TypeError:
+    pass
+else:
+    assert False
 try:
     g(1.1)
 except TypeError:

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -784,31 +784,6 @@ assert neg(-9223372036854775807) == 9223372036854775807
 assert neg(9223372036854775808) == -9223372036854775808
 assert neg(-9223372036854775808) == 9223372036854775808
 
-[case testXXX]
-from other import g
-def f(x: int) -> int:
-    return g(x + 1)
-[file other.py]
-def g(x: int) -> int:
-    return x + 2
-[file driver.py]
-from native import f
-from other import g
-assert f(3) == 6
-assert g(2) == 4
-try:
-    f(1.1)
-except TypeError:
-    pass
-else:
-    assert False
-try:
-    g(1.1)
-except TypeError:
-    pass
-else:
-    assert False
-
 [case testContinueFor]
 def f() -> None:
     for n in range(5):

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -676,3 +676,21 @@ assert neg(9223372036854775807) == -9223372036854775807
 assert neg(-9223372036854775807) == 9223372036854775807
 assert neg(9223372036854775808) == -9223372036854775808
 assert neg(-9223372036854775808) == 9223372036854775808
+
+[case testXXX]
+def f(x: int) -> int:
+    return x + 1
+[file other.py]
+def g(x: int) -> int:
+    return x + 2
+[file driver.py]
+from native import f
+from other import g
+assert f(3) == 4
+assert g(4) == 6
+try:
+    g(1.1)
+except TypeError:
+    pass
+else:
+    assert False


### PR DESCRIPTION
If compiling more than one module, generate a separate shared library
with code for all the modules, and simple C extension shims that just 
call into the shared library. This way we can easily have cross-module 
C-level calls.

I also had to revamp C name generation so that we add a module name
prefix to make names unique. We try to keep the prefix reasonably short
for readability, and the prefix is empty if compiling just one module.

I also had to modify genops to set up classes in all modules first before
generating IR, since modules can refer to classes defined in other 
modules.

A bunch of things are still missing, but I want to merge this soon to avoid
merge conflicts. I'll continue working on this in separate PRs.
