### PR TITLE
Eliminate PyGetAttr/PySetAttr and turn them into primitive ops 

### DIFF
--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -8,7 +8,7 @@ from mypyc.ops import (
     Value, Register,
     BasicBlock, OpVisitor, Assign, LoadInt, LoadErrorValue, RegisterOp, Goto, Branch, Return, Call,
     Environment, Box, Unbox, Cast, Op, Unreachable, TupleGet, TupleSet, GetAttr, SetAttr, PyCall,
-    LoadStatic, PyGetAttr, PySetAttr, Label, PyMethodCall, PrimitiveOp, MethodCall,
+    LoadStatic, Label, PyMethodCall, PrimitiveOp, MethodCall,
 )
 
 
@@ -124,12 +124,6 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill]):
         return self.visit_register_op(op)
 
     def visit_load_static(self, op: LoadStatic) -> GenAndKill:
-        return self.visit_register_op(op)
-
-    def visit_py_get_attr(self, op: PyGetAttr) -> GenAndKill:
-        return self.visit_register_op(op)
-
-    def visit_py_set_attr(self, op: PySetAttr) -> GenAndKill:
         return self.visit_register_op(op)
 
     def visit_tuple_get(self, op: TupleGet) -> GenAndKill:

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -6,9 +6,9 @@ from mypyc.common import REG_PREFIX, NATIVE_PREFIX
 from mypyc.emit import Emitter
 from mypyc.ops import (
     FuncIR, OpVisitor, Goto, Branch, Return, Assign, LoadInt, LoadErrorValue, GetAttr, SetAttr,
-    LoadStatic, TupleGet, TupleSet, Call, PyCall, PyGetAttr, IncRef, DecRef, Box, Cast, Unbox,
+    LoadStatic, TupleGet, TupleSet, Call, PyCall, IncRef, DecRef, Box, Cast, Unbox,
     Label, Value, Register, RType, RTuple, MethodCall, PyMethodCall, PrimitiveOp, EmitterInterface,
-    PySetAttr, Unreachable, is_int_rprimitive
+    Unreachable, is_int_rprimitive
 )
 from mypyc.namegen import NameGenerator
 
@@ -191,20 +191,6 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
             self.emit_line('%s = CPyTagged_FromObject(%s);' % (dest, op.identifier))
         else:
             self.emit_line('%s = %s;' % (dest, op.identifier))
-
-    def visit_py_get_attr(self, op: PyGetAttr) -> None:
-        dest = self.reg(op)
-        obj = self.reg(op.obj)
-        attr = self.reg(op.attr)
-        self.emit_line('{} = PyObject_GetAttr({}, {});'.format(dest, obj, attr))
-
-    def visit_py_set_attr(self, op: PySetAttr) -> None:
-        dest = self.reg(op)
-        obj = self.reg(op.obj)
-        attr = self.reg(op.attr)
-        value = self.reg(op.value)
-        self.emit_line('{} = PyObject_SetAttr({}, {}, {}) >= 0;'.format(
-            dest, obj, attr, value))
 
     def visit_tuple_get(self, op: TupleGet) -> None:
         dest = self.reg(op)

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -201,9 +201,10 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
     def visit_py_set_attr(self, op: PySetAttr) -> None:
         dest = self.reg(op)
         obj = self.reg(op.obj)
+        attr = self.reg(op.attr)
         value = self.reg(op.value)
-        self.emit_line('{} = PyObject_SetAttrString({}, "{}", {}) >= 0;'.format(
-            dest, obj, op.attr, value))
+        self.emit_line('{} = PyObject_SetAttr({}, {}, {}) >= 0;'.format(
+            dest, obj, attr, value))
 
     def visit_tuple_get(self, op: TupleGet) -> None:
         dest = self.reg(op)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -448,7 +448,8 @@ class IRBuilder(NodeVisitor[Value]):
                 rvalue_reg = self.coerce(rvalue_reg, target.type, line)
                 return self.add(SetAttr(target.obj, target.attr, rvalue_reg, line))
             else:
-                return self.add(PySetAttr(target.obj, target.attr, rvalue_reg, line))
+                key = self.load_static_unicode(target.attr)
+                return self.add(PySetAttr(target.obj, key, rvalue_reg, line))
         elif isinstance(target, AssignmentTargetIndex):
             target_reg2 = self.translate_special_method_call(
                 target.base,

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -42,17 +42,19 @@ from mypyc.common import MAX_SHORT_INT
 from mypyc.ops import (
     BasicBlock, Environment, Op, LoadInt, RType, Value, Register, Label, Return, FuncIR, Assign,
     Branch, Goto, RuntimeArg, Call, Box, Unbox, Cast, RTuple, Unreachable, TupleGet, TupleSet,
-    ClassIR, RInstance, ModuleIR, GetAttr, SetAttr, LoadStatic, PyGetAttr, PyCall, ROptional,
+    ClassIR, RInstance, ModuleIR, GetAttr, SetAttr, LoadStatic, PyCall, ROptional,
     c_module_name, PyMethodCall, MethodCall, INVALID_VALUE, INVALID_LABEL, int_rprimitive,
     is_int_rprimitive, float_rprimitive, is_float_rprimitive, bool_rprimitive, list_rprimitive,
     is_list_rprimitive, dict_rprimitive, is_dict_rprimitive, str_rprimitive, is_tuple_rprimitive,
     tuple_rprimitive, none_rprimitive, is_none_rprimitive, object_rprimitive, PrimitiveOp,
-    ERR_FALSE, OpDescription, RegisterOp, is_object_rprimitive, PySetAttr,
+    ERR_FALSE, OpDescription, RegisterOp, is_object_rprimitive,
 )
 from mypyc.ops_primitive import binary_ops, unary_ops, func_ops, method_ops, name_ref_ops
 from mypyc.ops_list import list_len_op, list_get_item_op, list_set_item_op, new_list_op
 from mypyc.ops_dict import new_dict_op, dict_get_item_op
-from mypyc.ops_misc import none_op, iter_op, next_op, no_err_occurred_op
+from mypyc.ops_misc import (
+    none_op, iter_op, next_op, no_err_occurred_op, py_getattr_op, py_setattr_op,
+)
 from mypyc.subtype import is_subtype
 from mypyc.sametype import is_same_type
 
@@ -449,7 +451,7 @@ class IRBuilder(NodeVisitor[Value]):
                 return self.add(SetAttr(target.obj, target.attr, rvalue_reg, line))
             else:
                 key = self.load_static_unicode(target.attr)
-                return self.add(PySetAttr(target.obj, key, rvalue_reg, line))
+                return self.add(PrimitiveOp([target.obj, key, rvalue_reg], py_setattr_op, line))
         elif isinstance(target, AssignmentTargetIndex):
             target_reg2 = self.translate_special_method_call(
                 target.base,
@@ -826,7 +828,7 @@ class IRBuilder(NodeVisitor[Value]):
 
     def py_get_attr(self, obj: Value, attr: str, line: int) -> Value:
         key = self.load_static_unicode(attr)
-        return self.add(PyGetAttr(obj, key, line))
+        return self.add(PrimitiveOp([obj, key], py_getattr_op, line))
 
     def py_call(self, function: Value, args: List[Value],
                 target_type: RType, line: int) -> Value:

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -786,56 +786,6 @@ class PyMethodCall(RegisterOp):
         return visitor.visit_py_method_call(self)
 
 
-class PyGetAttr(RegisterOp):
-    """dest = obj.attr :: object (using C API)"""
-
-    error_kind = ERR_MAGIC
-
-    def __init__(self, obj: Value, attr: Value, line: int) -> None:
-        super().__init__(line)
-        self.obj = obj
-        self.attr = attr
-        self.type = object_rprimitive
-
-    def sources(self) -> List[Value]:
-        return [self.obj, self.attr]
-
-    def to_str(self, env: Environment) -> str:
-        return env.format('%r = %r.%r :: object', self, self.obj, self.attr)
-
-    def can_raise(self) -> bool:
-        return True
-
-    def accept(self, visitor: 'OpVisitor[T]') -> T:
-        return visitor.visit_py_get_attr(self)
-
-
-class PySetAttr(RegisterOp):
-    """dest = setattr(obj, 'attr', value) (using C API)"""
-
-    error_kind = ERR_FALSE
-
-    def __init__(self, obj: Value, attr: Value, value: Value, line: int) -> None:
-        super().__init__(line)
-        self.obj = obj
-        self.attr = attr
-        self.value = value
-        self.type = bool_rprimitive
-
-    def sources(self) -> List[Value]:
-        return [self.obj, self.attr, self.value]
-
-    def to_str(self, env: Environment) -> str:
-        return env.format('%r = setattr(%r, %r, %r)',
-                          self, self.obj, self.attr, self.value)
-
-    def can_raise(self) -> bool:
-        return True
-
-    def accept(self, visitor: 'OpVisitor[T]') -> T:
-        return visitor.visit_py_set_attr(self)
-
-
 class EmitterInterface:
     @abstractmethod
     def reg(self, name: Value) -> str:
@@ -1345,14 +1295,6 @@ class OpVisitor(Generic[T]):
 
     @abstractmethod
     def visit_load_static(self, op: LoadStatic) -> T:
-        raise NotImplementedError
-
-    @abstractmethod
-    def visit_py_get_attr(self, op: PyGetAttr) -> T:
-        raise NotImplementedError
-
-    @abstractmethod
-    def visit_py_set_attr(self, op: PySetAttr) -> T:
         raise NotImplementedError
 
     @abstractmethod

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -815,7 +815,7 @@ class PySetAttr(RegisterOp):
 
     error_kind = ERR_FALSE
 
-    def __init__(self, obj: Value, attr: str, value: Value, line: int) -> None:
+    def __init__(self, obj: Value, attr: Value, value: Value, line: int) -> None:
         super().__init__(line)
         self.obj = obj
         self.attr = attr
@@ -823,11 +823,11 @@ class PySetAttr(RegisterOp):
         self.type = bool_rprimitive
 
     def sources(self) -> List[Value]:
-        return [self.obj, self.value]
+        return [self.obj, self.attr, self.value]
 
     def to_str(self, env: Environment) -> str:
-        return env.format('%r = setattr(%r, %s, %r)',
-                          self, self.obj, repr(self.attr), self.value)
+        return env.format('%r = setattr(%r, %r, %r)',
+                          self, self.obj, self.attr, self.value)
 
     def can_raise(self) -> bool:
         return True

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -132,3 +132,19 @@ method_op('__setitem__',
           error_kind=ERR_FALSE,
           emit=simple_emit('{dest} = PyObject_SetItem({args[0]}, {args[1]}, {args[2]}) >= 0;'),
           priority=0)
+
+py_getattr_op = func_op(
+    name='getattr',
+    arg_types=[object_rprimitive, object_rprimitive],
+    result_type=object_rprimitive,
+    error_kind=ERR_MAGIC,
+    emit=simple_emit('{dest} = PyObject_GetAttr({args[0]}, {args[1]});')
+)
+
+py_setattr_op = func_op(
+    name='setattr',
+    arg_types=[object_rprimitive, object_rprimitive, object_rprimitive],
+    result_type=bool_rprimitive,
+    error_kind=ERR_FALSE,
+    emit=simple_emit('{dest} = PyObject_SetAttr({args[0]}, {args[1]}, {args[2]}) >= 0;')
+)

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -134,7 +134,7 @@ method_op('__setitem__',
           priority=0)
 
 py_getattr_op = func_op(
-    name='getattr',
+    name='builtins.getattr',
     arg_types=[object_rprimitive, object_rprimitive],
     result_type=object_rprimitive,
     error_kind=ERR_MAGIC,
@@ -142,7 +142,7 @@ py_getattr_op = func_op(
 )
 
 py_setattr_op = func_op(
-    name='setattr',
+    name='builtins.setattr',
     arg_types=[object_rprimitive, object_rprimitive, object_rprimitive],
     result_type=bool_rprimitive,
     error_kind=ERR_FALSE,

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -504,7 +504,7 @@ def f(x):
 L0:
     r0 = module_testmodule :: static
     r1 = __unicode_0 :: static
-    r2 = r0.r1 :: object
+    r2 = getattr r0, r1
     r3 = box(int, x)
     r4 = r2(r3) :: object
     r5 = unbox(int, r4)
@@ -550,7 +550,7 @@ def f(x):
 L0:
     r0 = module_builtins :: static
     r1 = __unicode_0 :: static
-    r2 = r0.r1 :: object
+    r2 = getattr r0, r1
     r3 = 5
     r4 = box(int, r3)
     r5 = r2(r4) :: object
@@ -573,7 +573,7 @@ L0:
     r0 = 5
     r1 = module_builtins :: static
     r2 = __unicode_0 :: static
-    r3 = r1.r2 :: object
+    r3 = getattr r1, r2
     r4 = box(int, r0)
     r5 = r3(r4) :: object
     r6 = cast(None, r5)
@@ -945,7 +945,7 @@ def call_python_function(x):
 L0:
     r0 = module_builtins :: static
     r1 = __unicode_0 :: static
-    r2 = r0.r1 :: object
+    r2 = getattr r0, r1
     r3 = box(int, x)
     r4 = r2(r3) :: object
     r5 = unbox(int, r4)


### PR DESCRIPTION
It turns out that using Python_GetAttr/Python_SetAttr with pre-created
static strings is a lot faster than using Python_GetAttrString and
Python_SetAttrString (since those need to convert the C string into a
Python string). I made this change for GetAttr in #146 (but somehow
forgot about SetAttr??).

But now that PyGetAttr and PySetAttr were just simple operations on a
list of Values, there is no reason they need to be their own Ops
anymore, so we can turn them into PrimitiveOps and delete a bunch of
code.