### PR TITLE
Avoid leaking a module reference when importing

### DIFF
--- a/test-data/module-output.test
+++ b/test-data/module-output.test
@@ -36,9 +36,11 @@ PyMODINIT_FUNC PyInit_prog(void)
     _globals = PyModule_GetDict(m);
     if (_globals == NULL)
         return NULL;
-    module_builtins = PyImport_ImportModule("builtins");
-    if (module_builtins == NULL)
-        return NULL;
+    if (module_builtins == NULL) {
+        module_builtins = PyImport_ImportModule("builtins");
+        if (module_builtins == NULL)
+            return NULL;
+    }
     return m;
 }
 


### PR DESCRIPTION
The leak only happened when compiling multiple modules
where multiple modules imported the same module.