### PR TITLE
Use namespacing for C static names

### DIFF
--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -25,6 +25,7 @@ class EmitterContext:
     def __init__(self, module_names: List[str]) -> None:
         self.temp_counter = 0
         self.names = NameGenerator(module_names)
+        self.static_names = NameGenerator(module_names)
 
         # A map of a C identifier to whatever the C identifier declares. Currently this is
         # used for declaring structs and the key corresponds to the name of the struct.
@@ -38,6 +39,7 @@ class Emitter:
     def __init__(self, context: EmitterContext, env: Optional[Environment] = None) -> None:
         self.context = context
         self.names = context.names
+        self.static_names = context.static_names
         self.env = env or Environment()
         self.fragments = []  # type: List[str]
         self._indent = 0
@@ -83,6 +85,19 @@ class Emitter:
     def temp_name(self) -> str:
         self.context.temp_counter += 1
         return '__tmp%d' % self.context.temp_counter
+
+    def static_name(self, id: str, module: Optional[str]) -> str:
+        """Create name of a C static variable.
+
+        These are used for literals and imported modules, among other
+        things.
+
+        The caller should ensure that the (id, module) pair cannot
+        overlap with other calls to this method within a compilation
+        unit.
+        """
+        suffix = self.static_names.private_name(module or '', id)
+        return 'CPyStatic_{}'.format(suffix)
 
     # Higher-level operations
 

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -43,11 +43,11 @@ from mypyc.ops import (
     BasicBlock, Environment, Op, LoadInt, RType, Value, Register, Label, Return, FuncIR, Assign,
     Branch, Goto, RuntimeArg, Call, Box, Unbox, Cast, RTuple, Unreachable, TupleGet, TupleSet,
     ClassIR, RInstance, ModuleIR, GetAttr, SetAttr, LoadStatic, PyCall, ROptional,
-    c_module_name, PyMethodCall, MethodCall, INVALID_VALUE, INVALID_LABEL, int_rprimitive,
+    PyMethodCall, MethodCall, INVALID_VALUE, INVALID_LABEL, int_rprimitive,
     is_int_rprimitive, float_rprimitive, is_float_rprimitive, bool_rprimitive, list_rprimitive,
     is_list_rprimitive, dict_rprimitive, is_dict_rprimitive, str_rprimitive, is_tuple_rprimitive,
     tuple_rprimitive, none_rprimitive, is_none_rprimitive, object_rprimitive, PrimitiveOp,
-    ERR_FALSE, OpDescription, RegisterOp, is_object_rprimitive, LiteralsMap,
+    ERR_FALSE, OpDescription, RegisterOp, is_object_rprimitive, LiteralsMap
 )
 from mypyc.ops_primitive import binary_ops, unary_ops, func_ops, method_ops, name_ref_ops
 from mypyc.ops_list import list_len_op, list_get_item_op, list_set_item_op, new_list_op
@@ -109,8 +109,7 @@ class Mapper:
 
     def __init__(self) -> None:
         self.type_to_ir = {}  # type: Dict[TypeInfo, ClassIR]
-        # Maps integer, float, and unicode literals to the static c name for that literal
-        # TODO: Maybe C names should generated only when emitting C?
+        # Maps integer, float, and unicode literals to a static name
         self.literals = {}  # type: LiteralsMap
 
     def type_to_rtype(self, typ: Type) -> RType:
@@ -155,17 +154,17 @@ class Mapper:
             return self.type_to_rtype(typ.upper_bound)
         assert False, '%s unsupported' % type(typ)
 
-    def c_name_for_literal(self, value: Union[int, float, str]) -> str:
+    def literal_static_name(self, value: Union[int, float, str]) -> str:
         # Include type to distinguish between 1 and 1.0, and so on.
         key = (type(value), value)
         if key not in self.literals:
             if isinstance(value, str):
-                prefix = '__unicode_'
+                prefix = 'unicode_'
             elif isinstance(value, float):
-                prefix = '__float_'
+                prefix = 'float_'
             else:
                 assert isinstance(value, int)
-                prefix = '__int_'
+                prefix = 'int_'
             self.literals[key] = prefix + str(len(self.literals))
         return self.literals[key]
 
@@ -1351,18 +1350,18 @@ class IRBuilder(NodeVisitor[Value]):
         This takes a NameExpr and uses its name as a key to retrieve the corresponding PyObject *
         from the _globals dictionary in the C-generated code.
         """
-        _globals = self.add(LoadStatic(object_rprimitive, '_globals'))
+        _globals = self.add(LoadStatic(object_rprimitive, 'globals', self.module_name))
         reg = self.load_static_unicode(expr.name)
         return self.add(PrimitiveOp([_globals, reg], dict_get_item_op, expr.line))
 
     def load_static_int(self, value: int) -> Value:
         """Loads a static integer Python 'int' object into a register."""
-        static_symbol = self.mapper.c_name_for_literal(value)
+        static_symbol = self.mapper.literal_static_name(value)
         return self.add(LoadStatic(int_rprimitive, static_symbol, ann=value))
 
     def load_static_float(self, value: float) -> Value:
         """Loads a static float value into a register."""
-        static_symbol = self.mapper.c_name_for_literal(value)
+        static_symbol = self.mapper.literal_static_name(value)
         return self.add(LoadStatic(float_rprimitive, static_symbol, ann=value))
 
     def load_static_unicode(self, value: str) -> Value:
@@ -1371,14 +1370,14 @@ class IRBuilder(NodeVisitor[Value]):
         This is useful for more than just unicode literals; for example, method calls
         also require a PyObject * form for the name of the method.
         """
-        static_symbol = self.mapper.c_name_for_literal(value)
+        static_symbol = self.mapper.literal_static_name(value)
         return self.add(LoadStatic(str_rprimitive, static_symbol, ann=value))
 
     def load_static_module_attr(self, expr: RefExpr) -> Value:
         assert expr.node, "RefExpr not resolved"
         module = '.'.join(expr.node.fullname().split('.')[:-1])
         name = expr.node.fullname().split('.')[-1]
-        left = self.add(LoadStatic(object_rprimitive, c_module_name(module)))
+        left = self.add(LoadStatic(object_rprimitive, 'module', module))
         return self.py_get_attr(left, name, expr.line)
 
     def coerce(self, src: Value, target_type: RType, line: int) -> Value:

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -33,10 +33,6 @@ Label = NewType('Label', int)
 INVALID_LABEL = Label(-88888)
 
 
-def c_module_name(module_name: str) -> str:
-    return 'module_{}'.format(module_name.replace('.', '__dot__'))
-
-
 def short_name(name: str) -> str:
     if name.startswith('builtins.'):
         return name[9:]
@@ -976,14 +972,27 @@ class SetAttr(RegisterOp):
 
 
 class LoadStatic(RegisterOp):
-    """dest = name :: static"""
+    """dest = name :: static
+
+    Load a C static variable. The namespace for statics is shared for the
+    entire compilation unit. You can optionally provide a module name for
+    additional namespacing. The static namespace does not overlap with
+    other C names, since the final C name will get a prefix, so conflicts
+    only must be avoided with other statics.
+    """
 
     error_kind = ERR_NEVER
     is_borrowed = True
 
-    def __init__(self, type: RType, identifier: str, line: int = -1, ann: object = None) -> None:
+    def __init__(self,
+                 type: RType,
+                 identifier: str,
+                 module_name: Optional[str] = None,
+                 line: int = -1,
+                 ann: object = None) -> None:
         super().__init__(line)
         self.identifier = identifier
+        self.module_name = module_name
         self.type = type
         self.ann = ann  # An object to pretty print with the load
 
@@ -992,7 +1001,10 @@ class LoadStatic(RegisterOp):
 
     def to_str(self, env: Environment) -> str:
         ann = '  ({})'.format(repr(self.ann)) if self.ann else ''
-        return env.format('%r = %s :: static%s', self, self.identifier, ann)
+        name = self.identifier
+        if self.module_name is not None:
+            name = '{}.{}'.format(self.module_name, name)
+        return env.format('%r = %s :: static%s', self, name, ann)
 
     def accept(self, visitor: 'OpVisitor[T]') -> T:
         return visitor.visit_load_static(self)

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -48,7 +48,8 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.context = EmitterContext(['mod'])
         self.emitter = Emitter(self.context, self.env)
         self.declarations = Emitter(self.context, self.env)
-        self.visitor = FunctionEmitterVisitor(self.emitter, self.declarations, 'func', 'prog.py')
+        self.visitor = FunctionEmitterVisitor(self.emitter, self.declarations, 'func', 'prog.py',
+                                              'prog')
 
     def test_goto(self) -> None:
         self.assert_emit(Goto(Label(2)),
@@ -270,7 +271,7 @@ class TestGenerateFunction(unittest.TestCase):
         self.block.ops.append(Return(self.reg))
         fn = FuncIR('myfunc', None, 'mod', [self.arg], int_rprimitive, [self.block], self.env)
         emitter = Emitter(EmitterContext(['mod']))
-        generate_native_function(fn, emitter, 'prog.py')
+        generate_native_function(fn, emitter, 'prog.py', 'prog')
         result = emitter.fragments
         assert_string_arrays_equal(
             [
@@ -288,7 +289,7 @@ class TestGenerateFunction(unittest.TestCase):
         self.env.add_op(op)
         fn = FuncIR('myfunc', None, 'mod', [self.arg], list_rprimitive, [self.block], self.env)
         emitter = Emitter(EmitterContext(['mod']))
-        generate_native_function(fn, emitter, 'prog.py')
+        generate_native_function(fn, emitter, 'prog.py', 'prog')
         result = emitter.fragments
         assert_string_arrays_equal(
             [

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -1014,7 +1014,7 @@ def inner_outer_obj.__call__(self):
     self :: object
     r0 :: str
 L0:
-    r0 = __unicode_0 :: static  ('inner: nested function')
+    r0 = unicode_0 :: static  ('inner: nested function')
     return r0
 def outer():
     r0 :: str
@@ -1027,7 +1027,7 @@ def third_first_second_obj.__call__(self):
     self :: object
     r0 :: str
 L0:
-    r0 = __unicode_1 :: static  ('third: nested function')
+    r0 = unicode_1 :: static  ('third: nested function')
     return r0
 def second_first_obj.__call__(self):
     self :: object
@@ -1047,7 +1047,7 @@ def dos_uno_obj.__call__(self, s):
     self :: object
     s, r0, r1 :: str
 L0:
-    r0 = __unicode_2 :: static  ('!')
+    r0 = unicode_2 :: static  ('!')
     r1 = s + r0
     return r1
 def uno(num):
@@ -1062,7 +1062,7 @@ def zwei_eins_obj.__call__(self, s):
     self :: object
     s, r0, r1 :: str
 L0:
-    r0 = __unicode_3 :: static  ('?')
+    r0 = unicode_3 :: static  ('?')
     r1 = s + r0
     return r1
 def eins(num):
@@ -1077,11 +1077,11 @@ def eins(num):
 L0:
     r0 = zwei_eins_obj()
     zwei = r0
-    r1 = __unicode_4 :: static  ('eins')
+    r1 = unicode_4 :: static  ('eins')
     r2 = zwei(r1) :: object
     r3 = cast(str, r2)
     a = r3
-    r4 = __unicode_5 :: static  ('zwei')
+    r4 = unicode_5 :: static  ('zwei')
     r5 = zwei(r4) :: object
     r6 = cast(str, r5)
     b = r6
@@ -1089,15 +1089,15 @@ L0:
 def inner():
     r0 :: str
 L0:
-    r0 = __unicode_6 :: static  ('inner: normal function')
+    r0 = unicode_6 :: static  ('inner: normal function')
     return r0
 def second():
     r0 :: str
 L0:
-    r0 = __unicode_7 :: static  ('second: normal function')
+    r0 = unicode_7 :: static  ('second: normal function')
     return r0
 def third():
     r0 :: str
 L0:
-    r0 = __unicode_8 :: static  ('third: normal function')
+    r0 = unicode_8 :: static  ('third: normal function')
     return r0

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -502,8 +502,8 @@ def f(x):
     r2, r3, r4 :: object
     r5 :: int
 L0:
-    r0 = module_testmodule :: static
-    r1 = __unicode_0 :: static  ('factorial')
+    r0 = testmodule.module :: static
+    r1 = unicode_0 :: static  ('factorial')
     r2 = getattr r0, r1
     r3 = box(int, x)
     r4 = r2(r3) :: object
@@ -526,8 +526,8 @@ def f(x):
     r2, r3, r4 :: object
     r5 :: int
 L0:
-    r0 = _globals :: static
-    r1 = __unicode_0 :: static  ('g')
+    r0 = __main__.globals :: static
+    r1 = unicode_0 :: static  ('g')
     r2 = r0[r1] :: dict
     r3 = box(int, x)
     r4 = r2(r3) :: object
@@ -548,8 +548,8 @@ def f(x):
     r4, r5 :: object
     r6, r7 :: None
 L0:
-    r0 = module_builtins :: static
-    r1 = __unicode_0 :: static  ('print')
+    r0 = builtins.module :: static
+    r1 = unicode_0 :: static  ('print')
     r2 = getattr r0, r1
     r3 = 5
     r4 = box(int, r3)
@@ -571,8 +571,8 @@ def f(x):
     r6, r7 :: None
 L0:
     r0 = 5
-    r1 = module_builtins :: static
-    r2 = __unicode_0 :: static  ('print')
+    r1 = builtins.module :: static
+    r2 = unicode_0 :: static  ('print')
     r3 = getattr r1, r2
     r4 = box(int, r0)
     r5 = r3(r4) :: object
@@ -588,9 +588,9 @@ def f() -> str:
 def f():
     x, r0, r1 :: str
 L0:
-    r0 = __unicode_0 :: static  ('some string')
+    r0 = unicode_0 :: static  ('some string')
     x = r0
-    r1 = __unicode_1 :: static  ('some other string')
+    r1 = unicode_1 :: static  ('some other string')
     return r1
 
 [case testPyMethodCall1]
@@ -609,11 +609,11 @@ def f(x):
     r4 :: object
     r5 :: int
 L0:
-    r0 = __unicode_0 :: static  ('pop')
+    r0 = unicode_0 :: static  ('pop')
     r1 = x.r0() :: object
     r2 = unbox(int, r1)
     y = r2
-    r3 = __unicode_0 :: static  ('pop')
+    r3 = unicode_0 :: static  ('pop')
     r4 = x.r3() :: object
     r5 = unbox(int, r4)
     return r5
@@ -851,11 +851,11 @@ def assign_and_return_float_sum():
     r5 :: object
     r6 :: float
 L0:
-    r0 = __float_0 :: static  (1.0)
+    r0 = float_0 :: static  (1.0)
     f1 = r0
-    r1 = __float_1 :: static  (2.0)
+    r1 = float_1 :: static  (2.0)
     f2 = r1
-    r2 = __float_2 :: static  (3.0)
+    r2 = float_2 :: static  (3.0)
     f3 = r2
     r3 = f1 * f2
     r4 = cast(float, r3)
@@ -881,13 +881,13 @@ L0:
     a_62_bit = r0
     r1 = 4611686018427387903
     max_62_bit = r1
-    r2 = __int_0 :: static  (4611686018427387904)
+    r2 = int_0 :: static  (4611686018427387904)
     b_63_bit = r2
-    r3 = __int_1 :: static  (9223372036854775806)
+    r3 = int_1 :: static  (9223372036854775806)
     c_63_bit = r3
-    r4 = __int_2 :: static  (9223372036854775807)
+    r4 = int_2 :: static  (9223372036854775807)
     max_63_bit = r4
-    r5 = __int_3 :: static  (9223372036854775808)
+    r5 = int_3 :: static  (9223372036854775808)
     d_64_bit = r5
     r6 = 2147483647
     max_32_bit = r6
@@ -943,8 +943,8 @@ def call_python_function(x):
     r2, r3, r4 :: object
     r5 :: int
 L0:
-    r0 = module_builtins :: static
-    r1 = __unicode_0 :: static  ('int')
+    r0 = builtins.module :: static
+    r1 = unicode_0 :: static  ('int')
     r2 = getattr r0, r1
     r3 = box(int, x)
     r4 = r2(r3) :: object
@@ -953,15 +953,15 @@ L0:
 def return_float():
     r0 :: float
 L0:
-    r0 = __float_1 :: static  (5.0)
+    r0 = float_1 :: static  (5.0)
     return r0
 def return_callable_type():
     r0 :: object
     r1 :: str
     r2 :: object
 L0:
-    r0 = _globals :: static
-    r1 = __unicode_2 :: static  ('return_float')
+    r0 = __main__.globals :: static
+    r1 = unicode_2 :: static  ('return_float')
     r2 = r0[r1] :: dict
     return r2
 def call_callable_type():

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -255,8 +255,8 @@ def C.foo(self, x):
     r2, r3 :: object
     r4 :: int
 L0:
-    r0 = module_builtins :: static
-    r1 = __unicode_0 :: static  ('id')
+    r0 = builtins.module :: static
+    r1 = unicode_0 :: static  ('id')
     r2 = getattr r0, r1
     r3 = r2(x) :: object
     r4 = unbox(int, r3)

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -92,7 +92,7 @@ def g(a):
     r3 :: None
 L0:
     r0 = 1
-    r1 = __unicode_0 :: static  ('hi')
+    r1 = unicode_0 :: static  ('hi')
     r2 = a.f(r0, r1)
     r3 = None
     return r3

--- a/test-data/module-output.test
+++ b/test-data/module-output.test
@@ -8,8 +8,8 @@ def f(x: int) -> int:
 #include <Python.h>
 #include <CPy.h>
 
-static PyObject *_globals;
-static CPyModule *module_builtins;
+static PyObject *CPyStatic_globals;
+static CPyModule *CPyStatic_builtins_module;
 static CPyTagged CPyDef_f(CPyTagged cpy_r_x);
 static PyObject *CPyPy_f(PyObject *self, PyObject *args, PyObject *kw);
 
@@ -33,12 +33,12 @@ PyMODINIT_FUNC PyInit_prog(void)
     m = PyModule_Create(&module);
     if (m == NULL)
         return NULL;
-    _globals = PyModule_GetDict(m);
-    if (_globals == NULL)
+    CPyStatic_globals = PyModule_GetDict(m);
+    if (CPyStatic_globals == NULL)
         return NULL;
-    if (module_builtins == NULL) {
-        module_builtins = PyImport_ImportModule("builtins");
-        if (module_builtins == NULL)
+    if (CPyStatic_builtins_module == NULL) {
+        CPyStatic_builtins_module = PyImport_ImportModule("builtins");
+        if (CPyStatic_builtins_module == NULL)
             return NULL;
     }
     return m;

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -602,7 +602,7 @@ def f() -> str:
     return "some string"
 [out]
 L0:
-    r0 = __unicode_0 :: static  ('some string')
+    r0 = unicode_0 :: static  ('some string')
     inc_ref r0
     return r0
 
@@ -612,7 +612,7 @@ def g(x: List[int], y: List[int]) -> None:
     x.extend(y)
 [out]
 L0:
-    r0 = __unicode_0 :: static  ('extend')
+    r0 = unicode_0 :: static  ('extend')
     r1 = x.r0(y) :: object
     r2 = cast(None, r1)
     dec_ref r2
@@ -658,7 +658,7 @@ L2:
     dec_ref r5 :: int
     goto L1
 L3:
-    r6 = no_err_occurred 
+    r6 = no_err_occurred
     r7 = None
     return r7
 L4:
@@ -698,7 +698,7 @@ L4:
 L5:
     goto L1
 L6:
-    r8 = no_err_occurred 
+    r8 = no_err_occurred
     r9 = None
     return r9
 L7:
@@ -745,7 +745,7 @@ L4:
 L5:
     goto L1
 L6:
-    r8 = no_err_occurred 
+    r8 = no_err_occurred
     r9 = None
     return r9
 L7:

--- a/test-data/run-multimodule.test
+++ b/test-data/run-multimodule.test
@@ -139,3 +139,43 @@ from native import fs, fi, ff
 assert fs() == 'fg'
 assert fi() == 30002000200020002000
 assert ff() == 5.0
+
+[case testMultiModuleTraceback]
+from other import fail2
+
+def fail() -> None:
+    fail2()
+[file other.py]
+def fail2() -> None:
+    x = [1]
+    x[2] = 2
+[file driver.py]
+import traceback
+import sys
+import native
+import other
+try:
+    other.fail2()
+except IndexError:
+    tb = sys.exc_info()[2]
+    assert tb.tb_next.tb_frame.f_globals is other.__dict__
+    traceback.print_exc()
+try:
+    native.fail()
+except IndexError:
+    tb = sys.exc_info()[2]
+    assert tb.tb_next.tb_frame.f_globals is native.__dict__
+    traceback.print_exc()
+[out]
+Traceback (most recent call last):
+  File "tmp/driver.py", line 6, in <module>
+    other.fail2()
+  File "tmp/other.py", line 3, in fail2
+IndexError: list assignment index out of range
+Traceback (most recent call last):
+  File "tmp/driver.py", line 12, in <module>
+    native.fail()
+  File "tmp/py/native.py", line 4, in fail
+    fail2()
+  File "tmp/other.py", line 3, in fail2
+IndexError: list assignment index out of range


### PR DESCRIPTION
Use the unique name generator to generate static names. This helps
avoid name conflicts and also makes the IR-level names of statics
abstracted away from the C representation. All names in IR must be
explicitly translated to C names.

All generated C static names have a `CPyStatic_` prefix, followed by
an optional module name, followed by the static identifier.

Fixes issue where all modules in a multiple module compilation unit
used the name static for storing globals. This resulted in traceback
objects having the wrong globals.