### PR TITLE
Implement isinstance()

### DIFF
--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -1,5 +1,7 @@
-PREFIX = 'CPyPy_'
-NATIVE_PREFIX = 'CPyDef_'
-REG_PREFIX = 'cpy_r_'
+PREFIX = 'CPyPy_'  # Python wrappers
+NATIVE_PREFIX = 'CPyDef_'  # Native functions etc.
+REG_PREFIX = 'cpy_r_'  # Registers
+STATIC_PREFIX = 'CPyStatic_'  # Static variables (for literals etc.)
+TYPE_PREFIX = 'CPyType_'  # Type object struct
 
 MAX_SHORT_INT = (1 << 62) - 1

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -3,12 +3,12 @@
 from collections import OrderedDict
 from typing import List, Set, Dict, Optional
 
-from mypyc.common import REG_PREFIX
+from mypyc.common import REG_PREFIX, STATIC_PREFIX, TYPE_PREFIX
 from mypyc.ops import (
     Environment, Label, Value, Register, RType, RTuple, RInstance, ROptional,
     RPrimitive, is_int_rprimitive, is_float_rprimitive, is_bool_rprimitive,
     short_name, is_list_rprimitive, is_dict_rprimitive, is_tuple_rprimitive, is_none_rprimitive,
-    object_rprimitive, is_str_rprimitive
+    object_rprimitive, is_str_rprimitive, ClassIR
 )
 from mypyc.namegen import NameGenerator
 
@@ -25,7 +25,6 @@ class EmitterContext:
     def __init__(self, module_names: List[str]) -> None:
         self.temp_counter = 0
         self.names = NameGenerator(module_names)
-        self.static_names = NameGenerator(module_names)
 
         # A map of a C identifier to whatever the C identifier declares. Currently this is
         # used for declaring structs and the key corresponds to the name of the struct.
@@ -39,7 +38,6 @@ class Emitter:
     def __init__(self, context: EmitterContext, env: Optional[Environment] = None) -> None:
         self.context = context
         self.names = context.names
-        self.static_names = context.static_names
         self.env = env or Environment()
         self.fragments = []  # type: List[str]
         self._indent = 0
@@ -86,7 +84,7 @@ class Emitter:
         self.context.temp_counter += 1
         return '__tmp%d' % self.context.temp_counter
 
-    def static_name(self, id: str, module: Optional[str]) -> str:
+    def static_name(self, id: str, module: Optional[str], prefix: str = STATIC_PREFIX) -> str:
         """Create name of a C static variable.
 
         These are used for literals and imported modules, among other
@@ -96,8 +94,11 @@ class Emitter:
         overlap with other calls to this method within a compilation
         unit.
         """
-        suffix = self.static_names.private_name(module or '', id)
-        return 'CPyStatic_{}'.format(suffix)
+        suffix = self.names.private_name(module or '', id)
+        return '{}{}'.format(prefix, suffix)
+
+    def type_struct_name(self, cl: ClassIR) -> str:
+        return self.static_name(cl.name, cl.module_name, prefix=TYPE_PREFIX)
 
     # Higher-level operations
 
@@ -216,7 +217,7 @@ class Emitter:
             self.emit_lines(
                 'if (PyObject_TypeCheck({}, &{}))'.format(
                     src,
-                    typ.class_ir.type_struct_name(self.names)),
+                    self.type_struct_name(typ.class_ir)),
                 '    {} = {};'.format(dest, src),
                 'else {',
                 err,

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -31,7 +31,7 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
     getseters_name = '{}_getseters'.format(name_prefix)
     methods_name = '{}_methods'.format(name_prefix)
     vtable_name = '{}_vtable'.format(name_prefix)
-    base_arg = "&{}".format(cl.base.type_struct_name(emitter.names)) if cl.base else "0"
+    base_arg = "&{}".format(emitter.type_struct_name(cl.base)) if cl.base else "0"
 
     def emit_line() -> None:
         emitter.emit_line()
@@ -120,7 +120,7 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
             0,                         /* tp_alloc */
             {new_name},                /* tp_new */
         }};\
-        """).format(type_struct=cl.type_struct_name(emitter.names),
+        """).format(type_struct=emitter.type_struct_name(cl),
                     struct_name=cl.struct_name(emitter.names),
                     fullname=fullname,
                     traverse_name=traverse_name,
@@ -230,7 +230,7 @@ def generate_setup_for_class(cl: ClassIR,
     emitter.emit_line('{} *self;'.format(cl.struct_name(emitter.names)))
     emitter.emit_line('self = ({struct} *){type_struct}.tp_alloc(&{type_struct}, 0);'.format(
         struct=cl.struct_name(emitter.names),
-        type_struct=cl.type_struct_name(emitter.names)))
+        type_struct=emitter.type_struct_name(cl)))
     emitter.emit_line('if (self == NULL)')
     emitter.emit_line('    return NULL;')
     emitter.emit_line('self->vtable = {};'.format(vtable_name))

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -165,7 +165,7 @@ class ModuleGenerator:
                            '{',
                            'PyObject *m;')
         for cl in module.classes:
-            type_struct = cl.type_struct_name(emitter.names)
+            type_struct = emitter.type_struct_name(cl)
             emitter.emit_lines('if (PyType_Ready(&{}) < 0)'.format(type_struct),
                                '    return NULL;')
         emitter.emit_lines('m = PyModule_Create(&{}module);'.format(module_prefix),
@@ -206,7 +206,7 @@ class ModuleGenerator:
 
         for cl in module.classes:
             name = cl.name
-            type_struct = cl.type_struct_name(emitter.names)
+            type_struct = emitter.type_struct_name(cl)
             emitter.emit_lines(
                 'Py_INCREF(&{});'.format(type_struct),
                 'PyModule_AddObject(m, "{}", (PyObject *)&{});'.format(name, type_struct))

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -148,3 +148,19 @@ py_setattr_op = func_op(
     error_kind=ERR_FALSE,
     emit=simple_emit('{dest} = PyObject_SetAttr({args[0]}, {args[1]}, {args[2]}) >= 0;')
 )
+
+
+def emit_isinstance(emitter: EmitterInterface, args: List[str], dest: str) -> None:
+    temp = emitter.temp_name()
+    emitter.emit_lines('int %s = PyObject_IsInstance(%s, %s);' % (temp, args[0], args[1]),
+                       'if (%s < 0)' % temp,
+                       '    %s = %s;' % (dest, bool_rprimitive.c_error_value()),
+                       'else',
+                       '    %s = %s;' % (dest, temp))
+
+
+func_op('builtins.isinstance',
+        arg_types=[object_rprimitive, object_rprimitive],
+        result_type=bool_rprimitive,
+        error_kind=ERR_MAGIC,
+        emit=emit_isinstance)

--- a/test-data/fixtures/ir.py
+++ b/test-data/fixtures/ir.py
@@ -76,3 +76,4 @@ def id(o: object) -> int: pass
 def len(o: Sized) -> int: pass
 def print(*object) -> None: pass
 def range(x: int) -> Iterator[int]: pass
+def isinstance(x: object, t: object) -> bool: pass

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -301,3 +301,28 @@ def use_c(x, y):
 L0:
     r0 = x.foo(y)
     return r0
+
+[case testIsInstance]
+class A: pass
+class B(A): pass
+
+def f(x: A) -> B:
+    if isinstance(x, B):
+        return x
+    return B()
+[out]
+def f(x):
+    x :: A
+    r0 :: object
+    r1 :: bool
+    r2, r3 :: B
+L0:
+    r0 = __main__.B :: type
+    r1 = isinstance x, r0
+    if r1 goto L1 else goto L2 :: bool
+L1:
+    r2 = cast(B, x)
+    return r2
+L2:
+    r3 = B()
+    return r3

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -350,3 +350,33 @@ C
 B
 C
 C
+
+[case testIsInstance]
+class X: pass
+class A(X): pass
+class B(A): pass
+
+def isa(x: object) -> bool:
+    return isinstance(x, A)
+def isint(x: object) -> bool:
+    return isinstance(x, int)
+def isstr(x: object) -> bool:
+    return isinstance(x, str)
+def islist(x: object) -> bool:
+    return isinstance(x, list)
+[file driver.py]
+from native import X, A, B, isa, isint, isstr, islist
+assert isa(1) == False
+assert isa(A()) == True
+assert isa(B()) == True
+assert isa(X()) == False
+
+assert isint(1) == True
+assert isint('') == False
+assert isint(A()) == False
+
+assert isstr(1) == False
+assert isstr('') == True
+
+assert islist(1) == False
+assert islist([]) == True


### PR DESCRIPTION
To speed things up, modify LoadStatic() to allow looking up a type
object of a native class without going through the Python namespace
dict.

This still pretty slow. Using PyObject_TypeCheck would be faster,
but using it will take a bit of additional work.

Also unify C name generation and namespacing somewhat.