### PR TITLE
Make sure rhs of py_setattr uses is boxed

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -585,7 +585,8 @@ class IRBuilder(NodeVisitor[Value]):
                 return self.add(SetAttr(target.obj, target.attr, rvalue_reg, line))
             else:
                 key = self.load_static_unicode(target.attr)
-                return self.add(PrimitiveOp([target.obj, key, rvalue_reg], py_setattr_op, line))
+                boxed_reg = self.box(rvalue_reg)
+                return self.add(PrimitiveOp([target.obj, key, boxed_reg], py_setattr_op, line))
         elif isinstance(target, AssignmentTargetIndex):
             target_reg2 = self.translate_special_method_call(
                 target.base,

--- a/test-data/genops-any.test
+++ b/test-data/genops-any.test
@@ -37,6 +37,7 @@ def f(a: Any, n: int, c: C) -> None:
     c.n = a
     a = n
     n = a
+    a.a = n
 [out]
 def f(a, n, c):
     a :: object
@@ -48,7 +49,10 @@ def f(a, n, c):
     r3 :: bool
     r4 :: object
     r5 :: int
-    r6 :: None
+    r6 :: str
+    r7 :: object
+    r8 :: bool
+    r9 :: None
 L0:
     r0 = box(int, n)
     c.a = r0; r1 = is_error
@@ -58,8 +62,11 @@ L0:
     a = r4
     r5 = unbox(int, a)
     n = r5
-    r6 = None
-    return r6
+    r6 = unicode_0 :: static  ('a')
+    r7 = box(int, n)
+    r8 = setattr a, r6, r7
+    r9 = None
+    return r9
 
 [case testCoerceAnyInOps]
 from typing import Any, List

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -558,10 +558,12 @@ def get_a(x: Any) -> Any:
     return x.a
 def set_a(x: Any, y: Any) -> None:
     x.a = y
+def set_a_unboxed(x: Any, y: int) -> None:
+    x.a = y
 def call_m(x: Any) -> Any:
     return x.m(1, [3])
 [file driver.py]
-from native import C, get_a, set_a, call_m
+from native import C, get_a, set_a, set_a_unboxed, call_m
 class D:
     def m(self, x, a):
         return self.a + x + a[0]
@@ -578,6 +580,8 @@ set_a(c, 5)
 assert c.a == 5
 set_a(d, 4)
 assert d.a == 4
+set_a_unboxed(d, 12)
+assert d.a == 12
 try:
     get_a(object())
 except AttributeError:


### PR DESCRIPTION
Otherwise we fail to compile code that assigns unboxed types