### PR TITLE
Support multiple assignment from tuple or iterable

### DIFF
--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -8,7 +8,7 @@ from mypyc.ops import (
     Value, Register,
     BasicBlock, OpVisitor, Assign, LoadInt, LoadErrorValue, RegisterOp, Goto, Branch, Return, Call,
     Environment, Box, Unbox, Cast, Op, Unreachable, TupleGet, TupleSet, GetAttr, SetAttr, PyCall,
-    LoadStatic, PyMethodCall, PrimitiveOp, MethodCall,
+    LoadStatic, PyMethodCall, PrimitiveOp, MethodCall, RaiseStandardError,
 )
 
 
@@ -140,6 +140,9 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill]):
         return self.visit_register_op(op)
 
     def visit_cast(self, op: Cast) -> GenAndKill:
+        return self.visit_register_op(op)
+
+    def visit_raise_standard_error(self, op: RaiseStandardError) -> GenAndKill:
         return self.visit_register_op(op)
 
 

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -288,7 +288,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         if op.message is not None:
             message = op.message.replace('"', '\\"')
             self.emitter.emit_line(
-                'PyErr_SetString(PyExc_{}, "{}");'.format(op.class_name, op.message))
+                'PyErr_SetString(PyExc_{}, "{}");'.format(op.class_name, message))
         else:
             self.emitter.emit_line('PyErr_SetNone(PyExc_{});'.format(op.class_name))
         self.emitter.emit_line('{} = 0;'.format(self.reg(op)))

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -9,6 +9,7 @@ from mypyc.ops import (
     LoadStatic, TupleGet, TupleSet, Call, PyCall, IncRef, DecRef, Box, Cast, Unbox,
     BasicBlock, Value, Register, RType, RTuple, MethodCall, PyMethodCall, PrimitiveOp,
     EmitterInterface, Unreachable, is_int_rprimitive, NAMESPACE_STATIC, NAMESPACE_TYPE,
+    RaiseStandardError,
 )
 from mypyc.namegen import NameGenerator
 
@@ -281,6 +282,16 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
 
     def visit_unreachable(self, op: Unreachable) -> None:
         pass  # Nothing to do
+
+    def visit_raise_standard_error(self, op: RaiseStandardError) -> None:
+        # TODO: Better escaping of backspaces and such
+        if op.message is not None:
+            message = op.message.replace('"', '\\"')
+            self.emitter.emit_line(
+                'PyErr_SetString(PyExc_{}, "{}");'.format(op.class_name, op.message))
+        else:
+            self.emitter.emit_line('PyErr_SetNone(PyExc_{});'.format(op.class_name))
+        self.emitter.emit_line('{} = 0;'.format(self.reg(op)))
 
     # Helpers
 

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -308,6 +308,8 @@ class AssignmentTargetTuple(AssignmentTarget):
 
     def __init__(self, items: List[AssignmentTarget]) -> None:
         self.items = items
+        # The shouldn't be relevant, but provide it just in case.
+        self.type = object_rprimitive
 
 
 class IRBuilder(NodeVisitor[Value]):

--- a/test-data/genops-statements.test
+++ b/test-data/genops-statements.test
@@ -339,3 +339,23 @@ L5:
 L6:
     r16 = no_err_occurred
     return s
+
+[case testMultipleAssignmentFromTuple]
+from typing import Tuple
+def f(t: Tuple[int, str]) -> None:
+    x, y = t
+[out]
+def f(t):
+    t :: tuple[int, str]
+    x :: int
+    y :: str
+    r0 :: int
+    r1 :: str
+    r2 :: None
+L0:
+    r0 = t[0]
+    x = r0
+    r1 = t[1]
+    y = r1
+    r2 = None
+    return r2

--- a/test-data/genops-statements.test
+++ b/test-data/genops-statements.test
@@ -340,12 +340,16 @@ L6:
     r16 = no_err_occurred
     return s
 
-[case testMultipleAssignmentFromTuple]
-from typing import Tuple
-def f(t: Tuple[int, str]) -> None:
+[case testMultipleAssignment]
+from typing import Tuple, Any
+
+def from_tuple(t: Tuple[int, str]) -> None:
     x, y = t
+
+def from_any(a: Any) -> None:
+    x, y = a
 [out]
-def f(t):
+def from_tuple(t):
     t :: tuple[int, str]
     x :: int
     y :: str
@@ -359,3 +363,35 @@ L0:
     y = r1
     r2 = None
     return r2
+def from_any(a):
+    a, x, y, r0, r1 :: object
+    r2 :: bool
+    r3 :: object
+    r4 :: bool
+    r5 :: object
+    r6 :: bool
+    r7 :: None
+L0:
+    r0 = iter a :: object
+    r1 = next r0 :: object
+    if is_error(r1) goto L1 else goto L2
+L1:
+    raise ValueError('not enough values to unpack')
+    unreachable
+L2:
+    x = r1
+    r3 = next r0 :: object
+    if is_error(r3) goto L3 else goto L4
+L3:
+    raise ValueError('not enough values to unpack')
+    unreachable
+L4:
+    y = r3
+    r5 = next r0 :: object
+    if is_error(r5) goto L6 else goto L5
+L5:
+    raise ValueError('too many values to unpack')
+    unreachable
+L6:
+    r7 = None
+    return r7

--- a/test-data/genops-statements.test
+++ b/test-data/genops-statements.test
@@ -395,3 +395,103 @@ L5:
 L6:
     r7 = None
     return r7
+
+[case testMultiAssignmentCoercions]
+from typing import Tuple, Any
+
+def from_tuple(t: Tuple[int, Any]) -> None:
+    x: object
+    y: int
+    x, y = t
+
+def from_any(a: Any) -> None:
+    x: int
+    x, y = a
+[out]
+def from_tuple(t):
+    t :: tuple[int, object]
+    x :: object
+    y, r0 :: int
+    r1, r2 :: object
+    r3 :: int
+    r4 :: None
+L0:
+    r0 = t[0]
+    r1 = box(int, r0)
+    x = r1
+    r2 = t[1]
+    r3 = unbox(int, r2)
+    y = r3
+    r4 = None
+    return r4
+def from_any(a):
+    a :: object
+    x :: int
+    y, r0, r1 :: object
+    r2 :: bool
+    r3 :: int
+    r4 :: object
+    r5 :: bool
+    r6 :: object
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = iter a :: object
+    r1 = next r0 :: object
+    if is_error(r1) goto L1 else goto L2
+L1:
+    raise ValueError('not enough values to unpack')
+    unreachable
+L2:
+    r3 = unbox(int, r1)
+    x = r3
+    r4 = next r0 :: object
+    if is_error(r4) goto L3 else goto L4
+L3:
+    raise ValueError('not enough values to unpack')
+    unreachable
+L4:
+    y = r4
+    r6 = next r0 :: object
+    if is_error(r6) goto L6 else goto L5
+L5:
+    raise ValueError('too many values to unpack')
+    unreachable
+L6:
+    r8 = None
+    return r8
+
+[case testMultiAssignmentNested]
+from typing import Tuple, Any, List
+
+class A:
+    x: int
+
+def multi_assign(t: Tuple[int, Tuple[str, Any]], a: A, l: List[str]) -> None:
+    z: int
+    a.x, (l[0], z) = t
+[out]
+def multi_assign(t, a, l):
+    t :: tuple[int, tuple[str, object]]
+    a :: A
+    l :: list
+    z, r0, r1 :: int
+    r2 :: bool
+    r3 :: tuple[str, object]
+    r4 :: str
+    r5 :: bool
+    r6 :: object
+    r7 :: int
+    r8 :: None
+L0:
+    r0 = 0
+    r1 = t[0]
+    a.x = r1; r2 = is_error
+    r3 = t[1]
+    r4 = r3[0]
+    r5 = l.__setitem__(r0, r4) :: list
+    r6 = r3[1]
+    r7 = unbox(int, r6)
+    z = r7
+    r8 = None
+    return r8

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -928,3 +928,24 @@ uno!
 eins?
 second: normal function
 third: normal function
+
+[case testMultipleAssignment]
+from typing import Tuple, List, Any
+
+def from_tuple(t: Tuple[int, str]) -> List[Any]:
+    x, y = t
+    return [y, x]
+
+def from_list(l: List[int]) -> List[int]:
+    x, y = l
+    return [y, x]
+
+def from_any(o: Any) -> List[Any]:
+    x, y = o
+    return [y, x]
+[file driver.py]
+from native import from_tuple, from_list, from_any
+
+assert from_tuple((1, 'x')) == ['x', 1]
+assert from_list([3, 4]) == [4, 3]
+assert from_any('xy') == ['y', 'x']


### PR DESCRIPTION
Support things like `x, y = iterable_or_tuple`. `x = y = z` is still not 
supported.

Also add a new op for raising a standard exception such as `ValueError`.

Fixes #96.
