### PR TITLE
Move more C-level things from mypyc.ops to mypyc.emit

### DIFF
--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -185,7 +185,7 @@ def generate_native_getters_and_setters(cl: ClassIR,
         emitter.emit_line('{')
         if rtype.is_refcounted:
             emitter.emit_lines(
-                'if (self->{} == {}) {{'.format(attr, rtype.c_undefined_value()),
+                'if (self->{} == {}) {{'.format(attr, emitter.c_undefined_value(rtype)),
                 'PyErr_SetString(PyExc_AttributeError, "attribute {} of {} undefined");'.format(
                     repr(attr), repr(cl.name)),
                 '} else {')
@@ -202,7 +202,8 @@ def generate_native_getters_and_setters(cl: ClassIR,
                                                 emitter.ctype_spaced(rtype)))
         emitter.emit_line('{')
         if rtype.is_refcounted:
-            emitter.emit_line('if (self->{} != {}) {{'.format(attr, rtype.c_undefined_value()))
+            emitter.emit_line('if (self->{} != {}) {{'.format(attr,
+                                                              emitter.c_undefined_value(rtype)))
             emitter.emit_dec_ref('self->{}'.format(attr), rtype)
             emitter.emit_line('}')
         emitter.emit_inc_ref('value'.format(attr), rtype)
@@ -244,7 +245,7 @@ def generate_setup_for_class(cl: ClassIR,
     emitter.emit_line('self->vtable = {};'.format(vtable_name))
     for base in reversed(cl.base_mro):
         for attr, rtype in base.attributes.items():
-            emitter.emit_line('self->{} = {};'.format(attr, rtype.c_undefined_value()))
+            emitter.emit_line('self->{} = {};'.format(attr, emitter.c_undefined_value(rtype)))
     emitter.emit_line('return (PyObject *)self;')
     emitter.emit_line('}')
 
@@ -398,7 +399,7 @@ def generate_getter(cl: ClassIR,
     emitter.emit_line('{}({} *self, void *closure)'.format(getter_name(cl, attr, emitter.names),
                                                            cl.struct_name(emitter.names)))
     emitter.emit_line('{')
-    emitter.emit_line('if (self->{} == {}) {{'.format(attr, rtype.c_undefined_value()))
+    emitter.emit_line('if (self->{} == {}) {{'.format(attr, emitter.c_undefined_value(rtype)))
     emitter.emit_line('PyErr_SetString(PyExc_AttributeError,')
     emitter.emit_line('    "attribute {} of {} undefined");'.format(repr(attr),
                                                                     repr(cl.name)))
@@ -420,7 +421,7 @@ def generate_setter(cl: ClassIR,
         cl.struct_name(emitter.names)))
     emitter.emit_line('{')
     if rtype.is_refcounted:
-        emitter.emit_line('if (self->{} != {}) {{'.format(attr, rtype.c_undefined_value()))
+        emitter.emit_line('if (self->{} != {}) {{'.format(attr, emitter.c_undefined_value(rtype)))
         emitter.emit_dec_ref('self->{}'.format(attr), rtype)
         emitter.emit_line('}')
     emitter.emit_line('if (value != NULL) {')
@@ -435,6 +436,6 @@ def generate_setter(cl: ClassIR,
         emitter.emit_inc_ref('tmp', rtype)
     emitter.emit_line('self->{} = tmp;'.format(attr))
     emitter.emit_line('} else')
-    emitter.emit_line('    self->{} = {};'.format(attr, rtype.c_undefined_value()))
+    emitter.emit_line('    self->{} = {};'.format(attr, emitter.c_undefined_value(rtype)))
     emitter.emit_line('return 0;')
     emitter.emit_line('}')

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -105,11 +105,11 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
                 item_type = typ.types[0]
                 cond = '{}.f0 {} {}'.format(self.reg(op.left),
                                             compare,
-                                            item_type.c_error_value())
+                                            self.c_error_value(item_type))
             else:
                 cond = '{} {} {}'.format(self.reg(op.left),
                                          compare,
-                                         typ.c_error_value())
+                                         self.c_error_value(typ))
         else:
             assert False, "Invalid branch"
 
@@ -165,13 +165,13 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
 
     def visit_load_error_value(self, op: LoadErrorValue) -> None:
         if isinstance(op.type, RTuple):
-            values = [item.c_undefined_value() for item in op.type.types]
+            values = [self.c_undefined_value(item) for item in op.type.types]
             tmp = self.temp_name()
             self.emit_line('%s %s = { %s };' % (self.ctype(op.type), tmp, ', '.join(values)))
             self.emit_line('%s = %s;' % (self.reg(op), tmp))
         else:
             self.emit_line('%s = %s;' % (self.reg(op),
-                                         op.type.c_error_value()))
+                                         self.c_error_value(op.type)))
 
     def visit_get_attr(self, op: GetAttr) -> None:
         dest = self.reg(op)
@@ -303,6 +303,12 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
 
     def ctype(self, rtype: RType) -> str:
         return self.emitter.ctype(rtype)
+
+    def c_error_value(self, rtype: RType) -> str:
+        return self.emitter.c_error_value(rtype)
+
+    def c_undefined_value(self, rtype: RType) -> str:
+        return self.emitter.c_undefined_value(rtype)
 
     def emit_line(self, line: str) -> None:
         self.emitter.emit_line(line)

--- a/mypyc/ops_primitive.py
+++ b/mypyc/ops_primitive.py
@@ -46,7 +46,7 @@ def negative_int_emit(template: str) -> EmitCallback:
         temp = emitter.temp_name()
         emitter.emit_line(template.format(args=args, dest='int %s' % temp))
         emitter.emit_lines('if (%s < 0)' % temp,
-                           '    %s = %s;' % (dest, bool_rprimitive.c_error_value()),
+                           '    %s = %s;' % (dest, emitter.c_error_value(bool_rprimitive)),
                            'else',
                            '    %s = %s;' % (dest, temp))
 


### PR DESCRIPTION
This moves most C undefined/error value logic to `mypyc.emit`.
Some related state in RPrimitive is still initialized in `mypyc.ops`,
but it seems okay since it's kind of trivial and moving it away would
unnecessarily spread out definitions of primitive types across
multiple modules.