### PR TITLE
Make trait method dispatch efficient

### DIFF
--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -2,14 +2,14 @@
 
 import textwrap
 
-from typing import Optional
+from typing import Optional, List, Tuple
 
 from mypyc.common import PREFIX, NATIVE_PREFIX, REG_PREFIX
 from mypyc.emit import Emitter
 from mypyc.emitfunc import native_function_header
 from mypyc.ops import (
     ClassIR, FuncIR, RType, Environment, object_rprimitive, FuncSignature,
-    VTableMethod, VTableAttr,
+    VTableMethod, VTableAttr, VTableEntries,
 )
 from mypyc.sametype import is_same_type
 from mypyc.namegen import NameGenerator
@@ -36,7 +36,8 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
         vtable_name = '{}_vtable'.format(name_prefix)
 
     methods_name = '{}_methods'.format(name_prefix)
-    base_arg = "&{}".format(emitter.type_struct_name(cl.base)) if cl.base else "0"
+    base_arg = "&{}".format(
+        emitter.type_struct_name(cl.base)) if cl.base and not cl.traits else "0"
 
     def emit_line() -> None:
         emitter.emit_line()
@@ -76,7 +77,7 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
         generate_dealloc_for_class(cl, dealloc_name, clear_name, emitter)
         emit_line()
         generate_native_getters_and_setters(cl, emitter)
-        generate_vtable(cl, vtable_name, emitter)
+        vtable_name = generate_vtables(cl, vtable_name, emitter)
         emit_line()
         generate_getseter_declarations(cl, emitter)
         emit_line()
@@ -213,17 +214,40 @@ def generate_native_getters_and_setters(cl: ClassIR,
         emitter.emit_line()
 
 
-def generate_vtable(base: ClassIR,
+def generate_vtables(base: ClassIR,
+                     vtable_name: str,
+                     emitter: Emitter) -> str:
+    subtables = []
+    for trait, vtable in base.trait_vtables.items():
+        name = '{}_{}_trait_vtable'.format(
+            base.name_prefix(emitter.names), trait.name_prefix(emitter.names))
+        generate_vtable(vtable, name, emitter, [])
+        subtables.append((trait, name))
+
+    generate_vtable(base.vtable_entries, vtable_name, emitter, subtables)
+
+    return vtable_name if not subtables else "{} + {}".format(vtable_name, len(subtables) * 2)
+
+
+def generate_vtable(entries: VTableEntries,
                     vtable_name: str,
-                    emitter: Emitter) -> None:
+                    emitter: Emitter,
+                    subtables: List[Tuple[ClassIR, str]]) -> None:
     emitter.emit_line('static CPyVTableItem {}[] = {{'.format(vtable_name))
-    for entry in base.vtable_entries:
+    if subtables:
+        emitter.emit_line('/* Array of trait vtables */')
+        for trait, table in subtables:
+            emitter.emit_line('(CPyVTableItem)&{}, (CPyVTableItem){},'.format(
+                emitter.type_struct_name(trait), table))
+        emitter.emit_line('/* Start of real vtable */')
+
+    for entry in entries:
         if isinstance(entry, VTableMethod):
             emitter.emit_line('(CPyVTableItem){}{},'.format(NATIVE_PREFIX,
                                                             entry.method.cname(emitter.names)))
         else:
-            cl, attr, is_getter = entry
-            namer = native_getter_name if is_getter else native_setter_name
+            cl, attr, is_setter = entry
+            namer = native_setter_name if is_setter else native_getter_name
             emitter.emit_line('(CPyVTableItem){},'.format(namer(cl, attr, emitter.names)))
     emitter.emit_line('};')
 

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -217,6 +217,13 @@ def generate_native_getters_and_setters(cl: ClassIR,
 def generate_vtables(base: ClassIR,
                      vtable_name: str,
                      emitter: Emitter) -> str:
+    """Emit the vtables for a class.
+
+    This includes both the primary vtable and any trait implementation vtables.
+
+    Returns the expression to use to refer to the vtable, which might be
+    different than the name, if there are trait vtables."""
+
     subtables = []
     for trait, vtable in base.trait_vtables.items():
         name = '{}_{}_trait_vtable'.format(

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -188,8 +188,9 @@ class ModuleGenerator:
         for cl in module.classes:
             type_struct = emitter.type_struct_name(cl)
             # FIXME: This ought to be driven by emitclass, maybe?
-            bases = ([cl.base] if cl.base else []) + cl.traits
-            if len(bases) > 1:
+            if cl.traits:
+                real_base = cl.real_base()
+                bases = ([real_base] if real_base else []) + cl.traits
                 emitter.emit_lines('{}.tp_bases = PyTuple_Pack({}, {});'.format(
                     type_struct,
                     len(bases),
@@ -352,6 +353,7 @@ def sort_classes(classes: List[Tuple[str, ClassIR]]) -> List[Tuple[str, ClassIR]
             deps[ir] = set()
         if ir.base:
             deps[ir].add(ir.base)
+        deps[ir].update(ir.traits)
     sorted_irs = toposort(deps)
     return [(mod_name[ir], ir) for ir in sorted_irs]
 

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -48,7 +48,8 @@ from mypyc.ops import (
     is_list_rprimitive, dict_rprimitive, is_dict_rprimitive, str_rprimitive, is_tuple_rprimitive,
     tuple_rprimitive, none_rprimitive, is_none_rprimitive, object_rprimitive, PrimitiveOp,
     ERR_FALSE, OpDescription, RegisterOp, is_object_rprimitive, LiteralsMap, FuncSignature,
-    VTableAttr, VTableMethod, NAMESPACE_TYPE, RaiseStandardError,
+    VTableAttr, VTableMethod, VTableEntries,
+    NAMESPACE_TYPE, RaiseStandardError,
 )
 from mypyc.ops_primitive import binary_ops, unary_ops, func_ops, method_ops, name_ref_ops
 from mypyc.ops_list import list_len_op, list_get_item_op, list_set_item_op, new_list_op
@@ -109,6 +110,33 @@ def is_trait(cdef: ClassDef) -> bool:
                if isinstance(d, NameExpr))
 
 
+def update_parent_vtable(entries: VTableEntries, cls: ClassIR, is_trait: bool) -> VTableEntries:
+    updated = []
+    for entry in entries:
+        if isinstance(entry, VTableMethod):
+            method = entry.method
+            if method.name in cls.methods:
+                # TODO: emit a wrapper for __init__ that raises or something
+                if (is_same_method_signature(method.sig, cls.methods[method.name].sig)
+                        or method.name == '__init__'):
+                    entry = VTableMethod(cls, entry.name, cls.methods[method.name])
+                else:
+                    entry = VTableMethod(cls, entry.name,
+                                         cls.glue_methods[(entry.cls, method.name)])
+            elif is_trait:
+                assert cls.vtable is not None
+                entry = cls.vtable_entries[cls.vtable[entry.name]]
+        else:
+            # If it is an attribute from a trait, we need to find out real class it got
+            # mixed in at and point to that.
+            if is_trait:
+                assert cls.vtable is not None
+                entry = cls.vtable_entries[cls.vtable[entry.name] + int(entry.is_setter)]
+
+        updated.append(entry)
+    return updated
+
+
 def compute_vtable(cls: ClassIR) -> None:
     """Compute the vtable structure for a class."""
     if cls.vtable is not None: return
@@ -122,7 +150,6 @@ def compute_vtable(cls: ClassIR) -> None:
                 cls.attributes[name] = typ
 
     cls.vtable = {}
-    entries = cls.vtable_entries
     if cls.base:
         compute_vtable(cls.base)
         assert cls.base.vtable is not None
@@ -132,28 +159,28 @@ def compute_vtable(cls: ClassIR) -> None:
         prefix = []
 
     # Include the vtable from the parent classes, but handle method overrides.
-    for entry in prefix:
-        if isinstance(entry, VTableMethod):
-            method = entry.method
-            if method.name in cls.methods:
-                # TODO: emit a wrapper for __init__ that raises or something
-                if (is_same_method_signature(method.sig, cls.methods[method.name].sig)
-                        or method.name == '__init__'):
-                    entry = VTableMethod(cls, cls.methods[method.name])
-                else:
-                    entry = VTableMethod(cls, cls.glue_methods[(entry.cls, method.name)])
-        entries.append(entry)
+    cls.vtable_entries = update_parent_vtable(prefix, cls, is_trait=False)
+    entries = cls.vtable_entries
 
     for attr in cls.attributes:
         cls.vtable[attr] = len(entries)
-        entries.append(VTableAttr(cls, attr, is_getter=True))
-        entries.append(VTableAttr(cls, attr, is_getter=False))
+        entries.append(VTableAttr(cls, attr, is_setter=False))
+        entries.append(VTableAttr(cls, attr, is_setter=True))
 
     for t in [cls] + cls.traits:
         for fn in t.methods.values():
+            # TODO: don't generate a new entry when we overload without changing the type
             if fn == cls.get_method(fn.name):
                 cls.vtable[fn.name] = len(entries)
-                entries.append(VTableMethod(t, fn))
+                entries.append(VTableMethod(t, fn.name, fn))
+
+    # Compute vtables for all of the traits that the class implements
+    all_traits = [t for t in cls.mro if t.is_trait]
+    if not cls.is_trait:
+        for trait in all_traits:
+            compute_vtable(trait)
+            cls.trait_vtables[trait] = update_parent_vtable(
+                trait.vtable_entries, cls, is_trait=True)
 
 
 class Mapper:
@@ -183,8 +210,7 @@ class Mapper:
                 return dict_rprimitive
             elif typ.type.fullname() == 'builtins.tuple':
                 return tuple_rprimitive  # Varying-length tuple
-            # TODO: don't erase traits
-            elif typ.type in self.type_to_ir and not self.type_to_ir[typ.type].is_trait:
+            elif typ.type in self.type_to_ir:
                 return RInstance(self.type_to_ir[typ.type])
             else:
                 return object_rprimitive
@@ -258,11 +284,11 @@ def prepare_class_def(cdef: ClassDef, mapper: Mapper) -> None:
             base_mro.append(base_ir)
         mro.append(base_ir)
 
-    if len(base_mro) > 1:
-        ir.base = base_mro[1]
+    base_idx = 1 if not ir.is_trait else 0
+    if len(base_mro) > base_idx:
+        ir.base = base_mro[base_idx]
     assert all(base_mro[i].base == base_mro[i + 1] for i in range(len(base_mro) - 1)), (
         "non-trait MRO must be linear")
-
     ir.mro = mro
     ir.base_mro = base_mro
 

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1126,18 +1126,70 @@ class FuncIR:
         return '\n'.join(format_func(self))
 
 
+# Some notes on the vtable layout:
+# Each concrete class has a vtable that contains function pointers for its
+# methods and for getters/setters of its attributes. So that subclasses
+# may be efficiently used when their parent class is expected, the layout
+# of child vtables must be an extension of their base class's vtable.
+#
+# This makes multiple inheritance tricky, since obviously we cannot be
+# an extension of multiple parent classes. We solve this by requriing
+# all but one parent to be "traits", which we can operate on in a
+# somewhat less efficient way. For each trait implemented by a class,
+# we generate a separate vtable for the methods in that trait.
+# We then store an array of (trait type, trait vtable) pointers alongside
+# a class's main vtable. When we want to call a trait method, we
+# (at runtime!) search the array of trait vtables to find the correct one,
+# then call through it.
+#
+# To keep down the number of indirections necessary, we store the
+# array of trait vtables in the memory *before* the class vtable, and
+# search it backwards.  (This is a trick we can only do once---there
+# are only two directions to store data in---but I don't think we'll
+# need it again.)
+# There are some tricks we could try in the future to store the trait
+# vtables inline in the trait table (which would cut down one indirection),
+# but this seems good enough for now.#
+#
+# As an example:
+# Imagine that we have a class B that inherits from a concrete class A
+# and traits T1 and T2, and that A has attribute x and methods foo() and
+# bar() and B overrides bar() with a more specific type.
+# Then B's vtable will look something like:
+#
+#
+#      T1 type object
+#      ptr to B's T1 trait vtable
+#      T2 type object
+#      ptr to B's T2 trait vtable
+# -> | Getter for x
+#    | Setter for x
+#    | A.foo
+#    | Glue function that converts between A.bar's type and B.bar
+#      B.bar
+#      B.baz
+#
+# The arrow points to the "start" of the vtable (what vtable pointers
+# point to) and the bars indicate which parts correspond to the parent
+# class A's vtable layout.
+
 # Descriptions of method and attribute entries in class vtables.
 # The 'cls' field is the class that the method/attr was defined in,
 # which might be a parent class.
+
 VTableMethod = NamedTuple(
     'VTableMethod', [('cls', 'ClassIR'),
+                     ('name', str),
                      ('method', FuncIR)])
 
 
 VTableAttr = NamedTuple(
     'VTableAttr', [('cls', 'ClassIR'),
                    ('name', str),
-                   ('is_getter', bool)])
+                   ('is_setter', bool)])
+
+
+VTableEntries = List[Union[VTableMethod, VTableAttr]]
 
 
 class ClassIR:
@@ -1160,7 +1212,10 @@ class ClassIR:
         # to IR of glue method.
         self.glue_methods = {}  # type: Dict[Tuple[ClassIR, str], FuncIR]
         self.vtable = None  # type: Optional[Dict[str, int]]
-        self.vtable_entries = []  # type: List[Union[VTableMethod, VTableAttr]]
+        self.vtable_entries = []  # type: VTableEntries
+        self.trait_vtables = OrderedDict()  # type: OrderedDict[ClassIR, VTableEntries]
+        # N.B: base might not actually quite be the direct base.
+        # It is the nearest concrete base, but we allow a trait in between.
         self.base = None  # type: Optional[ClassIR]
         self.traits = []  # type: List[ClassIR]
         # Supply a working mro for most generated classes. Real classes will need to
@@ -1168,6 +1223,11 @@ class ClassIR:
         self.mro = [self]  # type: List[ClassIR]
         # base_mro is the chain of concrete (non-trait) ancestors
         self.base_mro = [self]  # type: List[ClassIR]
+
+    def real_base(self) -> Optional['ClassIR']:
+        if len(self.mro) > 1 and not self.mro[1].is_trait:
+            return self.mro[1]
+        return None
 
     def vtable_entry(self, name: str) -> int:
         assert self.vtable is not None, "vtable not computed yet"

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1157,7 +1157,6 @@ class FuncIR:
 # bar() and B overrides bar() with a more specific type.
 # Then B's vtable will look something like:
 #
-#
 #      T1 type object
 #      ptr to B's T1 trait vtable
 #      T2 type object
@@ -1225,6 +1224,7 @@ class ClassIR:
         self.base_mro = [self]  # type: List[ClassIR]
 
     def real_base(self) -> Optional['ClassIR']:
+        """Return the actual concrete base class, if there is one."""
         if len(self.mro) > 1 and not self.mro[1].is_trait:
             return self.mro[1]
         return None

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -190,12 +190,14 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """cpy_r_r0 = PyList_Append(cpy_r_l, cpy_r_o) != -1;""")
 
     def test_get_attr(self) -> None:
-        self.assert_emit(GetAttr(self.r, 'y', 1),
-                         """cpy_r_r0 = CPY_GET_ATTR(cpy_r_r, 2, AObject, CPyTagged);""")
+        self.assert_emit(
+            GetAttr(self.r, 'y', 1),
+            """cpy_r_r0 = CPY_GET_ATTR(cpy_r_r, &CPyType_A, 2, AObject, CPyTagged);""")
 
     def test_set_attr(self) -> None:
-        self.assert_emit(SetAttr(self.r, 'y', self.m, 1),
-                         """cpy_r_r0 = CPY_SET_ATTR(cpy_r_r, 3, cpy_r_m, AObject, CPyTagged);""")
+        self.assert_emit(
+            SetAttr(self.r, 'y', self.m, 1),
+            """cpy_r_r0 = CPY_SET_ATTR(cpy_r_r, &CPyType_A, 3, cpy_r_m, AObject, CPyTagged);""")
 
     def test_dict_get_item(self) -> None:
         self.assert_emit(PrimitiveOp([self.d, self.o2], dict_get_item_op, 1),

--- a/test-data/run-bench.test
+++ b/test-data/run-bench.test
@@ -78,6 +78,7 @@ if os.environ.get('MYPYC_RUN_BENCH') == '1':
     print("Build speedup:", ibuild/nbuild)
 
 [case testBenchmarkVisitorTree]
+from mypy_extensions import trait
 from typing import cast, Generic, TypeVar
 
 T = TypeVar('T')
@@ -95,6 +96,7 @@ class Node(Tree):
     def accept(self, v: 'TreeVisitor[T]') -> T:
         return v.visit_node(self)
 
+@trait
 class TreeVisitor(Generic[T]):
     def visit_leaf(self, x: Leaf) -> T: return cast(T, None)
     def visit_node(self, x: Node) -> T: return cast(T, None)

--- a/test-data/run-traits.test
+++ b/test-data/run-traits.test
@@ -10,25 +10,31 @@ class A:
 class T:
     def bar(self) -> None:
         print("bar")
+    def baz(self) -> object:
+        return None
 
 class C(A, T):
-    pass
+    def baz(self) -> int:
+        return 10
 
-def use_t(t: T) -> None:
+def use_t(t: T) -> object:
     t.bar()
+    return t.baz()
 
-def use_c(c: C) -> None:
+def use_c(c: C) -> int:
     use_t(c)
     c.foo()
     c.bar()
+    return c.baz()
 
 [file driver.py]
 from native import A, T, C, use_c, use_t
 c = C()
 c.foo()
 c.bar()
-use_c(c)
-use_t(c)
+assert c.baz() == 10
+assert use_c(c) == 10
+assert use_t(c) == 10
 [out]
 foo
 bar
@@ -74,6 +80,7 @@ class D(C, T2):
 def use_t(t: T) -> None:
     t.bar()
 def use_t2(t: T2) -> int:
+    t.line = t.line
     return t.line
 
 def use_c(c: C) -> int:


### PR DESCRIPTION
Emit side vtables for each trait that a class implements and store
them in an array placed before the regular vtable. To call the
methods, then, we (at runtime) search the array for the the trait
vtable and dispatch through it.
(This may not seem all that efficient, but the alternative is a Python
method dispatch, so.)

Changing the visitor to be a trait in the TreeVisitor benchmark shows
minimal perf degradation. (And a 5x perf degredation without this PR!)