### PR TITLE
Implement slicing such as a[:-1]

### DIFF
--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -183,3 +183,10 @@ bool_op = func_op(
     result_type=bool_rprimitive,
     error_kind=ERR_MAGIC,
     emit=negative_int_emit('{dest} = PyObject_IsTrue({args[0]});'))
+
+new_slice_op = func_op(
+    'builtins.slice',
+    arg_types=[object_rprimitive, object_rprimitive, object_rprimitive],
+    result_type=object_rprimitive,
+    error_kind=ERR_MAGIC,
+    emit=simple_emit('{dest} = PySlice_New({args[0]}, {args[1]}, {args[2]});'))

--- a/test-data/fixtures/ir.py
+++ b/test-data/fixtures/ir.py
@@ -75,6 +75,8 @@ class dict(Generic[T, S]):
     def update(self, x: Dict[T, S]) -> None: pass
     def pop(self, x: int) -> T: pass
 
+class slice: pass
+
 def id(o: object) -> int: pass
 def len(o: Sized) -> int: pass
 def print(*object) -> None: pass

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -493,6 +493,16 @@ def contains(x: Any, y: Any) -> Any:
         return True
     else:
         return False
+def slice1(x: Any) -> Any:
+    return x[:]
+def slice2(x: Any, y: Any) -> Any:
+    return x[y:]
+def slice3(x: Any, y: Any) -> Any:
+    return x[:y]
+def slice4(x: Any, y: Any, z: Any) -> Any:
+    return x[y:z]
+def slice5(x: Any, y: Any, z: Any, zz: Any) -> Any:
+    return x[y:z:zz]
 [file driver.py]
 from native import *
 assert add(5, 6) == 11
@@ -525,6 +535,13 @@ assert ge('b', 'a')
 assert contains('x', 'axb')
 assert not contains('X', 'axb')
 assert contains('x', {'x', 'y'})
+a = [1, 3, 5]
+assert slice1(a) == a
+assert slice1(a) is not a
+assert slice2(a, 1) == [3, 5]
+assert slice3(a, -1) == [1, 3]
+assert slice4(a, 1, -1) == [3]
+assert slice5(a, 2, 0, -1) == [5, 3]
 
 [case testGenericMiscOps]
 from typing import Any


### PR DESCRIPTION
Only a simple generic op is available at the moment. Specializing for
`list` and/or `str` might improve performance, but optimizing at this
time seems premature as we don't know if these are performance
critical.

Fixes #126.