### PR TITLE
Allow primops to produce borrowed results

### DIFF
--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -428,9 +428,8 @@ static PyObject *CPyList_GetItem(PyObject *list, CPyTagged index) {
                 return NULL;
             }
         }
-        PyObject *result = PyList_GET_ITEM(list, n);
-        Py_INCREF(result);
-        return result;
+        /* N.B Returns borrowed value */
+        return PyList_GET_ITEM(list, n);
     } else {
         PyErr_SetString(PyExc_IndexError, "list index out of range");
         return NULL;
@@ -478,9 +477,8 @@ static PyObject *CPySequenceTuple_GetItem(PyObject *tuple, CPyTagged index) {
                 return NULL;
             }
         }
-        PyObject *result = PyTuple_GET_ITEM(tuple, n);
-        Py_INCREF(result);
-        return result;
+        /* N.B Returns borrowed value */
+        return PyTuple_GET_ITEM(tuple, n);
     } else {
         PyErr_SetString(PyExc_IndexError, "tuple index out of range");
         return NULL;

--- a/mypyc/ops_dict.py
+++ b/mypyc/ops_dict.py
@@ -12,9 +12,7 @@ from mypyc.ops_primitive import method_op, binary_op, func_op, simple_emit, nega
 def emit_get_item(emitter: EmitterInterface, args: List[str], dest: str) -> None:
     emitter.emit_lines('%s = PyDict_GetItemWithError(%s, %s);' % (dest, args[0], args[1]),
                        'if (!%s)' % dest,
-                       '    PyErr_SetObject(PyExc_KeyError, %s);' % args[1],
-                       'else',
-                       '    Py_INCREF(%s);' % dest)
+                       '    PyErr_SetObject(PyExc_KeyError, %s);' % args[1])
 
 
 dict_get_item_op = method_op(

--- a/mypyc/ops_list.py
+++ b/mypyc/ops_list.py
@@ -33,6 +33,7 @@ list_get_item_op = method_op(
     arg_types=[list_rprimitive, int_rprimitive],
     result_type=object_rprimitive,
     error_kind=ERR_MAGIC,
+    is_borrowed=True,
     emit=simple_emit('{dest} = CPyList_GetItem({args[0]}, {args[1]});'))
 
 

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -12,15 +12,11 @@ from mypyc.ops_primitive import (
 )
 
 
-def emit_none(emitter: EmitterInterface, args: List[str], dest: str) -> None:
-    emitter.emit_lines('{} = Py_None;'.format(dest),
-                       'Py_INCREF({});'.format(dest))
-
-
 none_op = name_ref_op('builtins.None',
                       result_type=none_rprimitive,
                       error_kind=ERR_NEVER,
-                      emit=emit_none)
+                      is_borrowed=True,
+                      emit=simple_emit('{dest} = Py_None;'))
 
 true_op = name_ref_op('builtins.True',
                       result_type=bool_rprimitive,

--- a/mypyc/ops_tuple.py
+++ b/mypyc/ops_tuple.py
@@ -18,6 +18,7 @@ tuple_get_item_op = method_op(
     arg_types=[tuple_rprimitive, int_rprimitive],
     result_type=object_rprimitive,
     error_kind=ERR_MAGIC,
+    is_borrowed=True,
     emit=simple_emit('{dest} = CPySequenceTuple_GetItem({args[0]}, {args[1]});'))
 
 

--- a/mypyc/refcount.py
+++ b/mypyc/refcount.py
@@ -1,4 +1,4 @@
-"""Transformation for inserting refrecence count inc/dec opcodes.
+"""Transformation for inserting reference count inc/dec opcodes.
 
 This transformation happens towards the end of compilation. Before this
 transformation, reference count management is not explicitly handled at all.

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -69,9 +69,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
 
     def test_load_None(self) -> None:
         self.assert_emit(PrimitiveOp([], none_op, 0),
-                         """cpy_r_r0 = Py_None;
-                            Py_INCREF(cpy_r_r0);
-                         """)
+                         """cpy_r_r0 = Py_None;""")
 
     def test_load_True(self) -> None:
         self.assert_emit(PrimitiveOp([], true_op, 0), "cpy_r_r0 = 1;")
@@ -204,8 +202,6 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                          """cpy_r_r0 = PyDict_GetItemWithError(cpy_r_d, cpy_r_o2);
                             if (!cpy_r_r0)
                                 PyErr_SetObject(PyExc_KeyError, cpy_r_o2);
-                            else
-                                Py_INCREF(cpy_r_r0);
                          """)
 
     def test_dict_set_item(self) -> None:

--- a/test-data/exceptions.test
+++ b/test-data/exceptions.test
@@ -14,7 +14,6 @@ L0:
     if is_error(r1) goto L3 (error at f:3) else goto L1
 L1:
     r2 = unbox(int, r1)
-    dec_ref r1
     if is_error(r2) goto L3 (error at f:3) else goto L2
 L2:
     return r2
@@ -44,6 +43,7 @@ L1:
     if not r4 goto L3 (error at f:4) else goto L2 :: bool
 L2:
     r5 = None
+    inc_ref r5
     return r5
 L3:
     r6 = <error> :: None
@@ -111,7 +111,6 @@ L2:
     if is_error(r3) goto L8 (error at sum:6) else goto L3
 L3:
     r4 = unbox(int, r3)
-    dec_ref r3
     if is_error(r4) goto L9 (error at sum:6) else goto L4
 L4:
     r5 = sum + r4 :: int

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -309,6 +309,7 @@ L0:
     x = r2
     dec_ref x :: int
     r3 = None
+    inc_ref r3
     return r3
 
 [case testAdd1]
@@ -326,6 +327,7 @@ L0:
     x = r2
     dec_ref x :: int
     r3 = None
+    inc_ref r3
     return r3
 
 [case testAdd2]
@@ -375,6 +377,7 @@ L0:
     z = r2
     dec_ref z :: int
     r3 = None
+    inc_ref r3
     return r3
 
 [case testAdd5]
@@ -394,6 +397,7 @@ L0:
     x = r2
     dec_ref x :: int
     r3 = None
+    inc_ref r3
     return r3
 
 [case testReturnInMiddleOfFunction]
@@ -524,12 +528,12 @@ L0:
     r2 = b[r1] :: list
     dec_ref r1 :: int
     r3 = unbox(int, r2)
-    dec_ref r2
     r4 = box(int, r3)
     r5 = a.__setitem__(r0, r4) :: list
     dec_ref r0 :: int
     dec_ref r4
     r6 = None
+    inc_ref r6
     return r6
 
 [case testTupleRefcount]
@@ -558,6 +562,7 @@ L0:
     dec_ref c
     dec_ref r1
     r3 = None
+    inc_ref r3
     return r3
 
 [case testCastRefCount]
@@ -576,10 +581,12 @@ L0:
     r3 = a[r2] :: list
     dec_ref a
     dec_ref r2 :: int
+    inc_ref r3
     r4 = cast(C, r3)
     d = r4
     dec_ref d
     r5 = None
+    inc_ref r5
     return r5
 
 [case testUnaryBranchSpecialCase]
@@ -617,6 +624,7 @@ L0:
     r2 = cast(None, r1)
     dec_ref r2
     r3 = None
+    inc_ref r3
     return r3
 
 [case testListAppend]
@@ -632,6 +640,7 @@ L0:
     r2 = None
     dec_ref r2
     r3 = None
+    inc_ref r3
     return r3
 
 [case testForDict]
@@ -660,7 +669,38 @@ L2:
 L3:
     r6 = no_err_occurred
     r7 = None
+    inc_ref r7
     return r7
 L4:
     dec_ref r0
     goto L3
+
+[case testPrimBorrows]
+from typing import List
+def g(x: List[object], y: List[str]) -> None:
+    x.append(None)  # shouldn't need to incref
+    s1 = y[0] + y[1]
+[out]
+L0:
+    r0 = None
+    r1 = x.append(r0) :: list
+    r2 = None
+    dec_ref r2
+    r3 = 0
+    r4 = y[r3] :: list
+    dec_ref r3 :: int
+    inc_ref r4
+    r5 = cast(str, r4)
+    r6 = 1
+    r7 = y[r6] :: list
+    dec_ref r6 :: int
+    inc_ref r7
+    r8 = cast(str, r7)
+    r9 = r5 + r8
+    dec_ref r5
+    dec_ref r8
+    s1 = r9
+    dec_ref s1
+    r10 = None
+    inc_ref r10
+    return r10


### PR DESCRIPTION
This allows reducing refcount traffic in some cases (with the cost
(benefit?) being substantial additional explicit refcount traffic in
the generated IR).

I think some tweaks to refcount's treatment of casts and borrowing
could unlock substantial additional wins.