### PR TITLE
Support is and is not in general, remove IS_NONE branch type

### DIFF
--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -94,9 +94,6 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         if op.op == Branch.BOOL_EXPR:
             expr_result = self.reg(op.left)  # right isn't used
             cond = '{}{}'.format(neg, expr_result)
-        elif op.op == Branch.IS_NONE:
-            compare = '!=' if op.negated else '=='
-            cond = '{} {} Py_None'.format(self.reg(op.left), compare)
         elif op.op == Branch.IS_ERROR:
             typ = op.left.type
             compare = '!=' if op.negated else '=='

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -457,12 +457,10 @@ class Branch(Op):
     error_kind = ERR_NEVER
 
     BOOL_EXPR = 100
-    IS_NONE = 101
-    IS_ERROR = 102  # Check for magic c_error_value (works for arbitary types)
+    IS_ERROR = 101  # Check for magic c_error_value (works for arbitary types)
 
     op_names = {
         BOOL_EXPR: ('%r', 'bool'),
-        IS_NONE: ('%r is None', 'object'),
         IS_ERROR: ('is_error(%r)', ''),
     }
 

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -102,6 +102,28 @@ binary_op('in',
           emit=negative_int_emit('{dest} = PySequence_Contains({args[1]}, {args[0]});'),
           priority=0)
 
+binary_op('is',
+          arg_types=[object_rprimitive, object_rprimitive],
+          result_type=bool_rprimitive,
+          error_kind=ERR_NEVER,
+          emit=negative_int_emit('{dest} = {args[0]} == {args[1]};'),
+          priority=0)
+
+binary_op('is not',
+          arg_types=[object_rprimitive, object_rprimitive],
+          result_type=bool_rprimitive,
+          error_kind=ERR_NEVER,
+          emit=negative_int_emit('{dest} = {args[0]} != {args[1]};'),
+          priority=0)
+
+is_none_op = custom_op(
+    arg_types=[object_rprimitive],
+    result_type=bool_rprimitive,
+    error_kind=ERR_NEVER,
+    format_str = '{dest} = {args[0]} is None',
+    emit=simple_emit('{dest} = {args[0]} == Py_None;'))
+
+
 for op, funcname in [('-', 'PyNumber_Negative'),
                      ('+', 'PyNumber_Positive'),
                      ('~', 'PyNumber_Invert')]:

--- a/test-data/exceptions.test
+++ b/test-data/exceptions.test
@@ -62,31 +62,28 @@ def f(x: Optional[A]) -> int:
     return 3
 [out]
 L0:
-    if x is None goto L1 else goto L2 :: object
+    r0 = x is None
+    if r0 goto L1 else goto L2 :: bool
 L1:
-    r0 = 1
-    return r0
+    r1 = 1
+    return r1
 L2:
     inc_ref x
-    r1 = cast(A, x)
-    if is_error(r1) goto L6 (error at f:8) else goto L3
+    r2 = cast(A, x)
+    if is_error(r2) goto L6 (error at f:8) else goto L3
 L3:
-    if not r1 is None goto L7 else goto L8 :: object
+    r3 = r2 is None
+    dec_ref r2
+    if not r3 goto L4 else goto L5 :: bool
 L4:
-    r2 = 2
-    return r2
-L5:
-    r3 = 3
-    return r3
-L6:
-    r4 = <error> :: int
+    r4 = 2
     return r4
-L7:
-    dec_ref r1
-    goto L4
-L8:
-    dec_ref r1
-    goto L5
+L5:
+    r5 = 3
+    return r5
+L6:
+    r6 = <error> :: int
+    return r6
 
 [case testListSum]
 from typing import List

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -1192,34 +1192,42 @@ def opt_a(x: Optional[A]) -> int:
 [out]
 def opt_int(x):
     x :: optional[int]
-    r0, r1 :: int
-    r2 :: bool
-    r3, r4 :: int
+    r0 :: None
+    r1 :: bool
+    r2, r3 :: int
+    r4 :: bool
+    r5, r6 :: int
 L0:
-    if not x is None goto L1 else goto L3 :: object
+    r0 = None
+    r1 = x is not r0
+    if r1 goto L1 else goto L3 :: bool
 L1:
-    r0 = unbox(int, x)
-    r1 = 0
-    r2 = r0 != r1 :: int
-    if r2 goto L2 else goto L3 :: bool
+    r2 = unbox(int, x)
+    r3 = 0
+    r4 = r2 != r3 :: int
+    if r4 goto L2 else goto L3 :: bool
 L2:
-    r3 = 1
-    return r3
+    r5 = 1
+    return r5
 L3:
-    r4 = 0
-    return r4
+    r6 = 0
+    return r6
 L4:
     unreachable
 def opt_a(x):
     x :: optional[A]
-    r0, r1 :: int
+    r0 :: None
+    r1 :: bool
+    r2, r3 :: int
 L0:
-    if not x is None goto L1 else goto L2 :: object
+    r0 = None
+    r1 = x is not r0
+    if r1 goto L1 else goto L2 :: bool
 L1:
-    r0 = 1
-    return r0
+    r2 = 1
+    return r2
 L2:
-    r1 = 0
-    return r1
+    r3 = 0
+    return r3
 L3:
     unreachable

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -124,23 +124,25 @@ class Node:
 def Node.length(self):
     self :: Node
     r0 :: optional[Node]
-    r1 :: int
-    r2 :: optional[Node]
-    r3 :: Node
-    r4, r5, r6 :: int
+    r1 :: bool
+    r2 :: int
+    r3 :: optional[Node]
+    r4 :: Node
+    r5, r6, r7 :: int
 L0:
     r0 = self.next
-    if not r0 is None goto L1 else goto L2 :: object
+    r1 = r0 is None
+    if not r1 goto L1 else goto L2 :: bool
 L1:
-    r1 = 1
-    r2 = self.next
-    r3 = cast(Node, r2)
-    r4 = r3.length()
-    r5 = r1 + r4 :: int
-    return r5
-L2:
-    r6 = 1
+    r2 = 1
+    r3 = self.next
+    r4 = cast(Node, r3)
+    r5 = r4.length()
+    r6 = r2 + r5 :: int
     return r6
+L2:
+    r7 = 1
+    return r7
 
 [case testSubclass]
 class A:

--- a/test-data/genops-optional.test
+++ b/test-data/genops-optional.test
@@ -10,15 +10,17 @@ def f(x: Optional[A]) -> int:
 [out]
 def f(x):
     x :: optional[A]
-    r0, r1 :: int
+    r0 :: bool
+    r1, r2 :: int
 L0:
-    if x is None goto L1 else goto L2 :: object
+    r0 = x is None
+    if r0 goto L1 else goto L2 :: bool
 L1:
-    r0 = 1
-    return r0
-L2:
-    r1 = 2
+    r1 = 1
     return r1
+L2:
+    r2 = 2
+    return r2
 
 [case testIsNotNone]
 from typing import Optional
@@ -32,15 +34,17 @@ def f(x: Optional[A]) -> int:
 [out]
 def f(x):
     x :: optional[A]
-    r0, r1 :: int
+    r0 :: bool
+    r1, r2 :: int
 L0:
-    if not x is None goto L1 else goto L2 :: object
+    r0 = x is None
+    if not r0 goto L1 else goto L2 :: bool
 L1:
-    r0 = 1
-    return r0
-L2:
-    r1 = 2
+    r1 = 1
     return r1
+L2:
+    r2 = 2
+    return r2
 
 [case testAssignToOptional]
 from typing import Optional
@@ -131,15 +135,18 @@ def f(x: Optional[A]) -> A:
 [out]
 def f(x):
     x :: optional[A]
-    y, r0, r1, r2 :: A
+    y, r0 :: A
+    r1 :: bool
+    r2, r3 :: A
 L0:
     r0 = A()
     y = r0
-    if not x is None goto L1 else goto L2 :: object
+    r1 = x is None
+    if not r1 goto L1 else goto L2 :: bool
 L1:
-    r1 = cast(A, x)
-    y = r1
     r2 = cast(A, x)
-    return r2
+    y = r2
+    r3 = cast(A, x)
+    return r3
 L2:
     return y

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -493,6 +493,16 @@ def contains(x: Any, y: Any) -> Any:
         return True
     else:
         return False
+def identity(x: Any, y: Any) -> Any:
+    if x is y:
+        return True
+    else:
+        return False
+def disidentity(x: Any, y: Any) -> Any:
+    if x is not y:
+        return True
+    else:
+        return False
 def slice1(x: Any) -> Any:
     return x[:]
 def slice2(x: Any, y: Any) -> Any:
@@ -542,6 +552,11 @@ assert slice2(a, 1) == [3, 5]
 assert slice3(a, -1) == [1, 3]
 assert slice4(a, 1, -1) == [3]
 assert slice5(a, 2, 0, -1) == [5, 3]
+o1, o2 = object(), object()
+assert identity(o1, o1)
+assert not identity(o1, o2)
+assert not disidentity(o1, o1)
+assert disidentity(o1, o2)
 
 [case testGenericMiscOps]
 from typing import Any


### PR DESCRIPTION
Add a special case is_none primop in addition to the generic is and is
not ones, to avoid generating a lot of spurious refcount traffic for
'is None'