### PR TITLE
Support conditional exprs in non-conditional contexts

### DIFF
--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -134,6 +134,22 @@ for op, funcname in [('-', 'PyNumber_Negative'),
              emit=simple_emit('{dest} = %s({args[0]});' % funcname),
              priority=0)
 
+unary_op(op='not',
+         arg_type=object_rprimitive,
+         result_type=bool_rprimitive,
+         error_kind=ERR_MAGIC,
+         format_str='{dest} = not {args[0]}',
+         emit=negative_int_emit('{dest} = PyObject_Not({args[0]});'),
+         priority=0)
+
+unary_op(op='not',
+         arg_type=bool_rprimitive,
+         result_type=bool_rprimitive,
+         error_kind=ERR_NEVER,
+         format_str='{dest} = !{args[0]}',
+         emit=negative_int_emit('{dest} = !{args[0]};'),
+         priority=1)
+
 method_op('__getitem__',
           arg_types=[object_rprimitive, object_rprimitive],
           result_type=object_rprimitive,

--- a/test-data/exceptions.test
+++ b/test-data/exceptions.test
@@ -74,16 +74,17 @@ L2:
 L3:
     r3 = r2 is None
     dec_ref r2
-    if not r3 goto L4 else goto L5 :: bool
+    r4 = !r3
+    if r4 goto L4 else goto L5 :: bool
 L4:
-    r4 = 2
-    return r4
-L5:
-    r5 = 3
+    r5 = 2
     return r5
-L6:
-    r6 = <error> :: int
+L5:
+    r6 = 3
     return r6
+L6:
+    r7 = <error> :: int
+    return r7
 
 [case testListSum]
 from typing import List

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -124,25 +124,26 @@ class Node:
 def Node.length(self):
     self :: Node
     r0 :: optional[Node]
-    r1 :: bool
-    r2 :: int
-    r3 :: optional[Node]
-    r4 :: Node
-    r5, r6, r7 :: int
+    r1, r2 :: bool
+    r3 :: int
+    r4 :: optional[Node]
+    r5 :: Node
+    r6, r7, r8 :: int
 L0:
     r0 = self.next
     r1 = r0 is None
-    if not r1 goto L1 else goto L2 :: bool
+    r2 = !r1
+    if r2 goto L1 else goto L2 :: bool
 L1:
-    r2 = 1
-    r3 = self.next
-    r4 = cast(Node, r3)
-    r5 = r4.length()
-    r6 = r2 + r5 :: int
-    return r6
-L2:
-    r7 = 1
+    r3 = 1
+    r4 = self.next
+    r5 = cast(Node, r4)
+    r6 = r5.length()
+    r7 = r3 + r6 :: int
     return r7
+L2:
+    r8 = 1
+    return r8
 
 [case testSubclass]
 class A:

--- a/test-data/genops-dict.test
+++ b/test-data/genops-dict.test
@@ -115,18 +115,19 @@ def f(d):
     d :: dict
     r0 :: int
     r1 :: object
-    r2, r3, r4 :: bool
+    r2, r3, r4, r5 :: bool
 L0:
     r0 = 4
     r1 = box(int, r0)
     r2 = r1 in d :: dict
-    if not r2 goto L1 else goto L2 :: bool
+    r3 = !r2
+    if r3 goto L1 else goto L2 :: bool
 L1:
-    r3 = True
-    return r3
-L2:
-    r4 = False
+    r4 = True
     return r4
+L2:
+    r5 = False
+    return r5
 L3:
     unreachable
 

--- a/test-data/genops-optional.test
+++ b/test-data/genops-optional.test
@@ -34,17 +34,18 @@ def f(x: Optional[A]) -> int:
 [out]
 def f(x):
     x :: optional[A]
-    r0 :: bool
-    r1, r2 :: int
+    r0, r1 :: bool
+    r2, r3 :: int
 L0:
     r0 = x is None
-    if not r0 goto L1 else goto L2 :: bool
+    r1 = !r0
+    if r1 goto L1 else goto L2 :: bool
 L1:
-    r1 = 1
-    return r1
-L2:
-    r2 = 2
+    r2 = 1
     return r2
+L2:
+    r3 = 2
+    return r3
 
 [case testAssignToOptional]
 from typing import Optional
@@ -136,17 +137,18 @@ def f(x: Optional[A]) -> A:
 def f(x):
     x :: optional[A]
     y, r0 :: A
-    r1 :: bool
-    r2, r3 :: A
+    r1, r2 :: bool
+    r3, r4 :: A
 L0:
     r0 = A()
     y = r0
     r1 = x is None
-    if not r1 goto L1 else goto L2 :: bool
+    r2 = !r1
+    if r2 goto L1 else goto L2 :: bool
 L1:
-    r2 = cast(A, x)
-    y = r2
     r3 = cast(A, x)
-    return r3
+    y = r3
+    r4 = cast(A, x)
+    return r4
 L2:
     return y

--- a/test-data/run-bench.test
+++ b/test-data/run-bench.test
@@ -122,9 +122,9 @@ class EqualVisitor(TreeVisitor[bool]):
     def visit_node(self, right: Node) -> bool:
         if isinstance(self.left, Node):
             # our boolean stuff is crap
-            if self.left.value == right.value:
-                if equal(self.left.left, right.left):
-                    return equal(self.left.right, right.right)
+            if (self.left.value == right.value and equal(self.left.left, right.left)
+                    and equal(self.left.right, right.right)):
+                return True
         return False
 
 def sum_tree(x: Tree) -> int:

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -503,6 +503,8 @@ def disidentity(x: Any, y: Any) -> Any:
         return True
     else:
         return False
+def eq2(a: Any, b: Any) -> bool:
+    return a == b
 def slice1(x: Any) -> Any:
     return x[:]
 def slice2(x: Any, y: Any) -> Any:
@@ -557,6 +559,8 @@ assert identity(o1, o1)
 assert not identity(o1, o2)
 assert not disidentity(o1, o1)
 assert disidentity(o1, o2)
+assert eq2('xz', 'x' + 'z')
+assert not eq2('x', 'y')
 
 [case testGenericMiscOps]
 from typing import Any


### PR DESCRIPTION
Implemented by just making conditional exprs be compiled in a totally
straightforward way without any special branch related treatment. This
will generate slightly noisier code for 'is not' and 'not in' but it
shouldn't be any *slower* of code.

Work on #25.