### PR TITLE
Overhaul control flow genops to eliminate backpatching

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1403,6 +1403,7 @@ class IRBuilder(NodeVisitor[Value]):
                 branch.true = self.new_block()
                 remaining = self.coerce(value, value.type.value_type, value.line)
                 self.add_bool_branch(remaining, true, false)
+            return
         elif not is_same_type(value.type, bool_rprimitive):
             value = self.primitive_op(bool_op, [value], value.line)
         self.add(Branch(value, true, false, Branch.BOOL_EXPR))

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -361,11 +361,6 @@ class BasicBlock:
         self.ops = []  # type: List[Op]
 
 
-# This is used for placeholder labels which aren't assigned yet (but will
-# be eventually. It's kind of a hack.
-INVALID_LABEL = BasicBlock(-88888)
-
-
 ERR_NEVER = 0  # Never generates an exception
 ERR_MAGIC = 1  # Generates magic value (c_error_value) based on target RType on exception
 ERR_FALSE = 2  # Generates false (bool) on exception

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -235,7 +235,7 @@ def f(x, y):
     r1 :: int
 L0:
     r0 = x < y :: int
-    if not r0 goto L1 else goto L2 :: bool
+    if r0 goto L2 else goto L1 :: bool
 L1:
     r1 = 1
     x = r1
@@ -254,10 +254,10 @@ def f(x, y):
     r2 :: int
 L0:
     r0 = x < y :: int
-    if not r0 goto L1 else goto L3 :: bool
+    if r0 goto L1 else goto L2 :: bool
 L1:
     r1 = x > y :: int
-    if not r1 goto L2 else goto L3 :: bool
+    if r1 goto L3 else goto L2 :: bool
 L2:
     r2 = 1
     x = r2
@@ -1250,6 +1250,7 @@ L1:
     r3 = 0
     r4 = r2 != r3 :: int
     if r4 goto L2 else goto L3 :: bool
+    if x goto L2 else goto L3 :: bool
 L2:
     r5 = 1
     return r5
@@ -1267,6 +1268,7 @@ L0:
     r0 = None
     r1 = x is not r0
     if r1 goto L1 else goto L2 :: bool
+    if x goto L1 else goto L2 :: bool
 L1:
     r2 = 1
     return r2

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -1534,7 +1534,6 @@ L1:
     r3 = 0
     r4 = r2 != r3 :: int
     if r4 goto L2 else goto L3 :: bool
-    if x goto L2 else goto L3 :: bool
 L2:
     r5 = 1
     return r5
@@ -1552,7 +1551,6 @@ L0:
     r0 = None
     r1 = x is not r0
     if r1 goto L1 else goto L2 :: bool
-    if x goto L1 else goto L2 :: bool
 L1:
     r2 = 1
     return r2

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -989,13 +989,22 @@ def f(b: bool) -> Tuple[object, object, object]:
 def g() -> Tuple[object, object]:
     return (foo() or bar(), foo() and bar())
 
+def nand(p: bool, q: bool) -> bool:
+    if not (p and q):
+        return True
+    return False
 [file driver.py]
-from native import f, g
+from native import f, g, nand
 assert f(True) == ('foo', True, 'foo')
 print()
 assert f(False) == ('bar', 'foo', False)
 print()
 assert g() == ('foo', 'bar')
+
+assert nand(True, True) == False
+assert nand(True, False) == True
+assert nand(False, True) == True
+assert nand(False, False) == True
 [out]
 foo
 foo


### PR DESCRIPTION
Use preallocated `BasicBlock`s everywhere and get rid of `INVALID_LABEL`.

Fixes a bug in the negation of `and`/`or` in conditional positions as a side-effect.

I find the non-backpatching version a bunch cleaner, though it might be a matter of taste? Thoughts?