### PR TITLE
 Evaluate statements at module top levels

### DIFF
--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -7,3 +7,5 @@ TYPE_PREFIX = 'CPyType_'  # Type object struct
 ENV_ATTR_NAME = '__mypyc_env__'
 
 MAX_SHORT_INT = (1 << 62) - 1
+
+TOP_LEVEL_NAME = '__top_level__'  # Special function representing module top level

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -3,12 +3,12 @@
 from collections import OrderedDict
 from typing import List, Set, Dict, Optional
 
-from mypyc.common import REG_PREFIX, STATIC_PREFIX, TYPE_PREFIX
+from mypyc.common import REG_PREFIX, STATIC_PREFIX, TYPE_PREFIX, NATIVE_PREFIX
 from mypyc.ops import (
     Any, AssignmentTarget, Environment, BasicBlock, Value, Register, RType, RTuple, RInstance,
     ROptional, RPrimitive, is_int_rprimitive, is_float_rprimitive, is_bool_rprimitive,
     short_name, is_list_rprimitive, is_dict_rprimitive, is_tuple_rprimitive, is_none_rprimitive,
-    is_object_rprimitive, object_rprimitive, is_str_rprimitive, ClassIR
+    is_object_rprimitive, object_rprimitive, is_str_rprimitive, ClassIR, FuncIR
 )
 from mypyc.namegen import NameGenerator
 
@@ -133,6 +133,9 @@ class Emitter:
 
     def c_error_value(self, rtype: RType) -> str:
         return self.c_undefined_value(rtype)
+
+    def native_function_name(self, fn: FuncIR) -> str:
+        return '{}{}'.format(NATIVE_PREFIX, fn.cname(self.names))
 
     def tuple_ctype(self, rtuple: RTuple) -> str:
         return 'struct {}'.format(self.tuple_struct_name(rtuple))

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -25,10 +25,9 @@ def native_function_header(fn: FuncIR, emitter: Emitter) -> str:
     for arg in fn.args:
         args.append('{}{}{}'.format(emitter.ctype_spaced(arg.type), REG_PREFIX, arg.name))
 
-    return 'static {ret_type}{prefix}{name}({args})'.format(
+    return 'static {ret_type}{name}({args})'.format(
         ret_type=emitter.ctype_spaced(fn.ret_type),
-        prefix=NATIVE_PREFIX,
-        name=fn.cname(emitter.names),
+        name=emitter.native_function_name(fn),
         args=', '.join(args) or 'void')
 
 
@@ -118,8 +117,11 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
 
         if op.traceback_entry is not None:
             globals_static = self.emitter.static_name('globals', self.module_name)
+            func_name = self.func_name
+            if func_name == '__top_level__':
+                func_name = '<module>'
             self.emit_line('CPy_AddTraceback("%s", "%s", %d, %s);' % (self.source_path,
-                                                                      self.func_name,
+                                                                      func_name,
                                                                       op.line,
                                                                       globals_static))
         self.emit_lines(

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -2,7 +2,7 @@
 
 from typing import Optional, List
 
-from mypyc.common import REG_PREFIX, NATIVE_PREFIX, STATIC_PREFIX, TYPE_PREFIX
+from mypyc.common import REG_PREFIX, NATIVE_PREFIX, STATIC_PREFIX, TYPE_PREFIX, TOP_LEVEL_NAME
 from mypyc.emit import Emitter
 from mypyc.ops import (
     FuncIR, OpVisitor, Goto, Branch, Return, Assign, LoadInt, LoadErrorValue, GetAttr, SetAttr,
@@ -118,8 +118,8 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         if op.traceback_entry is not None:
             globals_static = self.emitter.static_name('globals', self.module_name)
             func_name = self.func_name
-            if func_name == '__top_level__':
-                func_name = '<module>'
+            if func_name == TOP_LEVEL_NAME:
+                func_name = '<module>'  # Like normal Python tracebacks
             self.emit_line('CPy_AddTraceback("%s", "%s", %d, %s);' % (self.source_path,
                                                                       func_name,
                                                                       op.line,

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -8,7 +8,7 @@ from mypy.errors import CompileError
 from mypy.options import Options
 
 from mypyc import genops
-from mypyc.common import PREFIX
+from mypyc.common import PREFIX, TOP_LEVEL_NAME
 from mypyc.emit import EmitterContext, Emitter, HeaderDeclaration
 from mypyc.emitfunc import generate_native_function, native_function_header
 from mypyc.emitclass import generate_class
@@ -139,7 +139,7 @@ class ModuleGenerator:
         module_prefix = emitter.names.private_name(module_name)
         emitter.emit_line('static PyMethodDef {}module_methods[] = {{'.format(module_prefix))
         for fn in module.functions:
-            if fn.class_name is not None or fn.name == '__top_level__':
+            if fn.class_name is not None or fn.name == TOP_LEVEL_NAME:
                 continue
             emitter.emit_line(
                 ('{{"{name}", (PyCFunction){prefix}{cname}, METH_VARARGS | METH_KEYWORDS, '
@@ -245,7 +245,7 @@ class ModuleGenerator:
 
     def generate_top_level_call(self, module: ModuleIR, emitter: Emitter) -> None:
         for fn in module.functions:
-            if fn.name == '__top_level__' and not is_empty_module_top_level(fn):
+            if fn.name == TOP_LEVEL_NAME and not is_empty_module_top_level(fn):
                 emitter.emit_lines(
                     'PyObject *result = {}();'.format(emitter.native_function_name(fn)),
                     'if (result == NULL)',

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -635,16 +635,18 @@ class IRBuilder(NodeVisitor[Value]):
                             return target
 
                     if fn_info.contains_nested:
-                        # First, define a new variable in the current function's environment class.
-                        # Next, define a target that refers to the newly defined variable in that
-                        # environment class. Add the target to the table containing class environment
-                        # variables, as well as the current environment.
+                        # First, define a new variable in the current
+                        # function's environment class.  Next, define a target
+                        # that refers to the newly defined variable in that
+                        # environment class. Add the target to the table
+                        # containing class environment variables, as well as
+                        # the current environment.
                         fn_info.env_class.attributes[lvalue.node.name()] = self.node_type(lvalue)
                         target = AssignmentTargetAttr(fn_info.env_class_val, lvalue.node.name())
                         return self.environment.add_target(lvalue.node, target)
 
-                    # If the function neither is nested nor contains a nested function, then define a
-                    # new local variable.
+                    # If the function neither is nested nor contains a nested
+                    # function, then define a new local variable.
                     return self.environment.add_local_reg(lvalue.node, self.node_type(lvalue))
                 else:
                     # Assignt to a previously defined variable.

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -37,7 +37,7 @@ from mypy.visitor import NodeVisitor
 from mypy.subtypes import is_named_instance
 from mypy.checkmember import bind_self
 
-from mypyc.common import ENV_ATTR_NAME, MAX_SHORT_INT
+from mypyc.common import ENV_ATTR_NAME, MAX_SHORT_INT, TOP_LEVEL_NAME
 from mypyc.ops import (
     BasicBlock, AssignmentTarget, AssignmentTargetRegister, AssignmentTargetIndex,
     AssignmentTargetAttr, AssignmentTargetTuple, Environment, Op, LoadInt, RType, Value, Register,
@@ -378,7 +378,7 @@ class IRBuilder(NodeVisitor[Value]):
         self.add_func_end()
         blocks, env, ret_type = self.leave()
         sig = FuncSignature([], none_rprimitive)
-        func_ir = FuncIR('__top_level__', None, self.module_name, sig, blocks, env)
+        func_ir = FuncIR(TOP_LEVEL_NAME, None, self.module_name, sig, blocks, env)
         self.functions.append(func_ir)
 
         return INVALID_VALUE

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -21,6 +21,7 @@ from collections import OrderedDict
 from mypy.nodes import SymbolNode, Var, FuncDef
 
 from mypyc.namegen import NameGenerator
+from mypyc.common import TOP_LEVEL_NAME
 
 
 T = TypeVar('T')
@@ -1474,7 +1475,7 @@ def format_func(fn: FuncIR) -> List[str]:
 
 
 def is_empty_module_top_level(fn: FuncIR) -> bool:
-    return fn.name == '__top_level__' and len(fn.blocks) == 1 and len(fn.blocks[0].ops) == 2
+    return fn.name == TOP_LEVEL_NAME and len(fn.blocks) == 1 and len(fn.blocks[0].ops) == 2
 
 
 class RTypeVisitor(Generic[T]):

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1473,6 +1473,10 @@ def format_func(fn: FuncIR) -> List[str]:
     return lines
 
 
+def is_empty_module_top_level(fn: FuncIR) -> bool:
+    return fn.name == '__top_level__' and len(fn.blocks) == 1 and len(fn.blocks[0].ops) == 2
+
+
 class RTypeVisitor(Generic[T]):
     @abstractmethod
     def visit_rprimitive(self, typ: RPrimitive) -> T:

--- a/mypyc/test/test_analysis.py
+++ b/mypyc/test/test_analysis.py
@@ -55,7 +55,7 @@ class TestAnalysis(MypycDataSuite):
                 else:
                     modules = genops.build_ir([result.files['__main__']], result.types)
                     module = modules[0][1]
-                    assert len(module.functions) == 1, (
+                    assert len(module.functions) == 2, (
                         "Only 1 function definition expected per test case")
                     fn = module.functions[0]
                     actual = format_func(fn)

--- a/mypyc/test/test_exceptions.py
+++ b/mypyc/test/test_exceptions.py
@@ -40,6 +40,7 @@ class TestExceptionTransform(MypycDataSuite):
             except CompileError as e:
                 actual = e.messages
             else:
+                # Expect one function + module top level function.
                 assert len(ir) == 2, "Only 1 function definition expected per test case"
                 fn = ir[0]
                 insert_exception_handling(fn)

--- a/mypyc/test/test_exceptions.py
+++ b/mypyc/test/test_exceptions.py
@@ -40,7 +40,7 @@ class TestExceptionTransform(MypycDataSuite):
             except CompileError as e:
                 actual = e.messages
             else:
-                assert len(ir) == 1, "Only 1 function definition expected per test case"
+                assert len(ir) == 2, "Only 1 function definition expected per test case"
                 fn = ir[0]
                 insert_exception_handling(fn)
                 insert_ref_count_opcodes(fn)

--- a/mypyc/test/test_genops.py
+++ b/mypyc/test/test_genops.py
@@ -13,7 +13,7 @@ from mypy.options import Options
 from mypy import experiments
 
 from mypyc import genops
-from mypyc.ops import format_func
+from mypyc.ops import format_func, FuncIR, is_empty_module_top_level
 
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, assert_test_output
@@ -67,6 +67,9 @@ class TestGenOps(MypycDataSuite):
                     module = modules[0][1]
                     actual = []
                     for fn in module.functions:
+                        if is_empty_module_top_level(fn):
+                            # Skip trivial module top levels that only return.
+                            continue
                         actual.extend(format_func(fn))
 
             assert_test_output(testcase, actual, 'Invalid source code output',

--- a/mypyc/test/test_refcount.py
+++ b/mypyc/test/test_refcount.py
@@ -40,7 +40,7 @@ class TestRefCountTransform(MypycDataSuite):
             except CompileError as e:
                 actual = e.messages
             else:
-                assert len(ir) == 1, "Only 1 function definition expected per test case"
+                assert len(ir) == 2, "Only 1 function definition expected per test case"
                 fn = ir[0]
                 insert_ref_count_opcodes(fn)
                 actual = format_func(fn)

--- a/mypyc/test/test_refcount.py
+++ b/mypyc/test/test_refcount.py
@@ -40,6 +40,7 @@ class TestRefCountTransform(MypycDataSuite):
             except CompileError as e:
                 actual = e.messages
             else:
+                # Expect one function + module top level function.
                 assert len(ir) == 2, "Only 1 function definition expected per test case"
                 fn = ir[0]
                 insert_ref_count_opcodes(fn)

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -1559,3 +1559,65 @@ L2:
     return r3
 L3:
     unreachable
+
+[case testModuleTopLevel]
+x = 1
+print(x)
+
+def f() -> None:
+    print(x)
+[out]
+def f():
+    r0 :: object
+    r1 :: str
+    r2 :: object
+    r3 :: int
+    r4 :: object
+    r5 :: str
+    r6, r7, r8 :: object
+    r9, r10 :: None
+L0:
+    r0 = __main__.globals :: static
+    r1 = unicode_0 :: static  ('x')
+    r2 = r0[r1] :: dict
+    r3 = unbox(int, r2)
+    r4 = builtins.module :: static
+    r5 = unicode_1 :: static  ('print')
+    r6 = getattr r4, r5
+    r7 = box(int, r3)
+    r8 = py_call(r6, r7)
+    r9 = cast(None, r8)
+    r10 = None
+    return r10
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2 :: int
+    r3 :: object
+    r4 :: bool
+    r5 :: object
+    r6 :: str
+    r7 :: object
+    r8 :: int
+    r9 :: object
+    r10 :: str
+    r11, r12, r13 :: object
+    r14, r15 :: None
+L0:
+    r0 = __main__.globals :: static
+    r1 = unicode_0 :: static  ('x')
+    r2 = 1
+    r3 = box(int, r2)
+    r4 = r0.__setitem__(r1, r3) :: object
+    r5 = __main__.globals :: static
+    r6 = unicode_0 :: static  ('x')
+    r7 = r5[r6] :: dict
+    r8 = unbox(int, r7)
+    r9 = builtins.module :: static
+    r10 = unicode_1 :: static  ('print')
+    r11 = getattr r9, r10
+    r12 = box(int, r8)
+    r13 = py_call(r11, r12)
+    r14 = cast(None, r13)
+    r15 = None
+    return r15

--- a/test-data/module-output.test
+++ b/test-data/module-output.test
@@ -13,6 +13,7 @@ static PyObject *CPyStatic_globals;
 static CPyModule *CPyStatic_builtins_module;
 static CPyTagged CPyDef_f(CPyTagged cpy_r_x);
 static PyObject *CPyPy_f(PyObject *self, PyObject *args, PyObject *kw);
+static PyObject *CPyDef___top_level__(void);
 
 static PyMethodDef module_methods[] = {
     {"f", (PyCFunction)CPyPy_f, METH_VARARGS | METH_KEYWORDS, NULL /* docstring */},
@@ -45,6 +46,10 @@ PyMODINIT_FUNC PyInit_prog(void)
         if (CPyStatic_builtins_module == NULL)
             return NULL;
     }
+    PyObject *result = CPyDef___top_level__();
+    if (result == NULL)
+        return NULL;
+    Py_DECREF(result);
     return CPyStatic_module;
 }
 
@@ -75,6 +80,13 @@ static PyObject *CPyPy_f(PyObject *self, PyObject *args, PyObject *kw) {
     return retbox;
 }
 
+static PyObject *CPyDef___top_level__(void) {
+    PyObject *cpy_r_r0;
+CPyL0: ;
+    cpy_r_r0 = Py_None;
+    Py_INCREF(cpy_r_r0);
+    return cpy_r_r0;
+}
 [case testError]
 def f(x: List[int]) -> None: pass
 [out]

--- a/test-data/run-multimodule.test
+++ b/test-data/run-multimodule.test
@@ -352,3 +352,27 @@ def f2() -> int:
 from native import f1
 
 assert f1() == 2
+
+[case testImportCycleWithTopLevelStatements]
+import other
+x = 1
+print(x)
+
+[file other.py]
+import native
+x = 2
+print(x)
+
+[file driver.py]
+import other
+print('-')
+import native
+print('>', native.x)
+print('>', other.x)
+
+[out]
+1
+2
+-
+> 1
+> 2

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -944,3 +944,53 @@ def f(x: List[Tuple[int, int]]) -> int:
 [file driver.py]
 from native import f
 assert f([(5, 6)]) == 11
+
+[case testModuleTopLevel]
+x = 1
+print(x)
+
+def f() -> None:
+    print(x + 1)
+
+def g() -> None:
+    global x
+    x = 77
+
+[file driver.py]
+import native
+native.f()
+native.x = 5
+native.f()
+native.g()
+print(native.x)
+
+[out]
+1
+2
+6
+77
+
+[case testExceptionAtModuleTopLevel]
+from typing import Any
+
+def f(x: int) -> None: pass
+
+y: Any = ''
+f(y)
+
+[file driver.py]
+import traceback
+try:
+    import native
+except TypeError:
+    traceback.print_exc()
+else:
+    assert False
+
+[out]
+Traceback (most recent call last):
+  File "tmp/driver.py", line 3, in <module>
+    import native
+  File "tmp/py/native.py", line 6, in <module>
+    f(y)
+TypeError: int object expected


### PR DESCRIPTION
Create a hidden function that corresponds to the module top level.
Also add support for `global` declarations.

Module-level attributes are accessed through the globals dictionary,
which makes them pretty slow.

Imports are still treated as declarations and they are evaluated
before evaluating non-import statements at the module top level. We
can fix this later but the current approach is probably fine for a
while.

Closes #169.