### PR TITLE
Preload Environment Registers

### DIFF
--- a/mypyc/free_vars.py
+++ b/mypyc/free_vars.py
@@ -1,6 +1,0 @@
-from mypy.traverser import TraverserVisitor
-
-class FreeVarsVisitor(TraverserVisitor):
-
-	def visit_var(self, o: 'mypy.nodes.Var'):
-		pass

--- a/mypyc/free_vars.py
+++ b/mypyc/free_vars.py
@@ -1,0 +1,6 @@
+from mypy.traverser import TraverserVisitor
+
+class FreeVarsVisitor(TraverserVisitor):
+
+	def visit_var(self, o: 'mypy.nodes.Var'):
+		pass

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1692,21 +1692,21 @@ class IRBuilder(NodeVisitor[Value]):
     def load_outer_env(self, base: Value, index: int, line: int) -> Value:
         """Loads the environment class for a given base into a register.
 
-        Additionally, iterates through all of the SymbolNodes in the symtable of the environment at
-        the given index, and maps those SymbolNodes to the register where the environment class was
-        loaded in a separate dictionary. This is done so that the register containing the
-        environment where any particular SymbolNode lives can be looked up easily.
+        Additionally, iterates through all of the SymbolNode and AssignmentTarget instances of the
+        environment at the given index's symtable, and adds those instances to the environment of
+        the current environment. This is done so that the current environment can access outer
+        environment variables without having to reload all of the environment registers.
 
         Returns the register where the environment class was loaded.
         """
         env = self.add(GetAttr(base, ENV_ATTR_NAME, line))
         assert isinstance(env.type, RInstance), '{} must be of type RInstance'.format(env)
 
-        # Iterate through all of the SymbolNode and AssignmentTarget instances in the symtable
         for symbol, target in self.environments[index].symtable.items():
             env.type.class_ir.attributes[symbol.name()] = target.type
             symbol_target = AssignmentTargetAttr(env, symbol.name())
             self.environment.add_target(symbol, symbol_target)
+
         return env
 
     def load_env_registers(self, fdef: FuncDef) -> None:

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -58,6 +58,7 @@ from mypyc.ops_misc import (
     py_call_op, py_method_call_op, fast_isinstance_op, bool_op, new_slice_op,
     is_none_op,
 )
+from mypyc.free_vars import FreeVarsVisitor
 from mypyc.subtype import is_subtype
 from mypyc.sametype import is_same_type, is_same_method_signature
 

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -1056,10 +1056,12 @@ def second() -> str:
 [out]
 def inner_a_obj.__call__(self):
     self :: inner_a_obj
-    r0 :: None
+    r0 :: a__env
+    r1 :: None
 L0:
-    r0 = None
-    return r0
+    r0 = self.__mypyc_env__
+    r1 = None
+    return r1
 def a():
     r0 :: a__env
     r1 :: inner_a_obj
@@ -1073,25 +1075,31 @@ L0:
     return inner
 def second_b_first_obj.__call__(self):
     self :: second_b_first_obj
-    r0 :: str
-L0:
-    r0 = unicode_0 :: static  ('b.first.second: nested function')
-    return r0
-def first_b_obj.__call__(self):
-    self :: first_b_obj
     r0 :: first_b_env
     r1 :: b__env
-    r2 :: bool
-    r3 :: second_b_first_obj
-    r4 :: bool
+    r2 :: str
+L0:
+    r0 = self.__mypyc_env__
+    r1 = r0.__mypyc_env__
+    r2 = unicode_0 :: static  ('b.first.second: nested function')
+    return r2
+def first_b_obj.__call__(self):
+    self :: first_b_obj
+    r0 :: b__env
+    r1 :: first_b_env
+    r2 :: b__env
+    r3 :: bool
+    r4 :: second_b_first_obj
+    r5 :: bool
     second :: object
 L0:
-    r0 = first_b_env()
-    r1 = self.__mypyc_env__
-    r0.__mypyc_env__ = r1; r2 = is_error
-    r3 = second_b_first_obj()
-    r3.__mypyc_env__ = r0; r4 = is_error
-    second = r3
+    r0 = self.__mypyc_env__
+    r1 = first_b_env()
+    r2 = self.__mypyc_env__
+    r1.__mypyc_env__ = r2; r3 = is_error
+    r4 = second_b_first_obj()
+    r4.__mypyc_env__ = r1; r5 = is_error
+    second = r4
     return second
 def b():
     r0 :: b__env
@@ -1106,11 +1114,14 @@ L0:
     return first
 def inner_c_obj.__call__(self, s):
     self :: inner_c_obj
-    s, r0, r1 :: str
+    s :: str
+    r0 :: c__env
+    r1, r2 :: str
 L0:
-    r0 = unicode_1 :: static  ('!')
-    r1 = s + r0
-    return r1
+    r0 = self.__mypyc_env__
+    r1 = unicode_1 :: static  ('!')
+    r2 = s + r1
+    return r2
 def c(num):
     num :: float
     r0 :: c__env
@@ -1127,11 +1138,14 @@ L0:
     return inner
 def inner_d_obj.__call__(self, s):
     self :: inner_d_obj
-    s, r0, r1 :: str
+    s :: str
+    r0 :: d__env
+    r1, r2 :: str
 L0:
-    r0 = unicode_2 :: static  ('?')
-    r1 = s + r0
-    return r1
+    r0 = self.__mypyc_env__
+    r1 = unicode_2 :: static  ('?')
+    r2 = s + r1
+    return r2
 def d(num):
     num :: float
     r0 :: d__env
@@ -1237,18 +1251,15 @@ def inner_b_obj.__call__(self):
     r0 :: b__env
     r1 :: int
     r2 :: bool
-    foo, r3 :: int
-    r4 :: b__env
-    r5 :: int
+    foo, r3, r4 :: int
 L0:
     r0 = self.__mypyc_env__
     r1 = 4
     r0.num = r1; r2 = is_error
     r3 = 6
     foo = r3
-    r4 = self.__mypyc_env__
-    r5 = r4.num
-    return r5
+    r4 = r0.num
+    return r4
 def b():
     r0 :: b__env
     r1 :: int
@@ -1271,16 +1282,20 @@ L0:
     return r8
 def inner_c_obj.__call__(self):
     self :: inner_c_obj
-    r0 :: str
+    r0 :: c__env
+    r1 :: str
 L0:
-    r0 = unicode_0 :: static  ('f.inner: first definition')
-    return r0
+    r0 = self.__mypyc_env__
+    r1 = unicode_0 :: static  ('f.inner: first definition')
+    return r1
 def inner_c_obj_0.__call__(self):
     self :: inner_c_obj_0
-    r0 :: str
+    r0 :: c__env
+    r1 :: str
 L0:
-    r0 = unicode_1 :: static  ('f.inner: second definition')
-    return r0
+    r0 = self.__mypyc_env__
+    r1 = unicode_1 :: static  ('f.inner: second definition')
+    return r1
 def c(flag):
     flag :: bool
     r0 :: c__env
@@ -1334,10 +1349,10 @@ L0:
     return r2
 def b_a_obj.__call__(self):
     self :: b_a_obj
-    r0 :: b_a_env
-    r1 :: a__env
-    r2 :: bool
-    r3 :: a__env
+    r0 :: a__env
+    r1 :: b_a_env
+    r2 :: a__env
+    r3 :: bool
     r4, r5, r6 :: int
     r7 :: bool
     r8 :: c_a_b_obj
@@ -1345,16 +1360,16 @@ def b_a_obj.__call__(self):
     c, r10 :: object
     r11 :: int
 L0:
-    r0 = b_a_env()
-    r1 = self.__mypyc_env__
-    r0.__mypyc_env__ = r1; r2 = is_error
-    r3 = self.__mypyc_env__
+    r0 = self.__mypyc_env__
+    r1 = b_a_env()
+    r2 = self.__mypyc_env__
+    r1.__mypyc_env__ = r2; r3 = is_error
     r4 = 1
-    r5 = r3.x
+    r5 = r0.x
     r6 = r5 + r4 :: int
-    r3.x = r6; r7 = is_error
+    r0.x = r6; r7 = is_error
     r8 = c_a_b_obj()
-    r8.__mypyc_env__ = r0; r9 = is_error
+    r8.__mypyc_env__ = r1; r9 = is_error
     c = r8
     r10 = py_call(c)
     r11 = unbox(int, r10)
@@ -1390,16 +1405,20 @@ def f(flag: bool) -> str:
 [out]
 def inner_f_obj.__call__(self):
     self :: inner_f_obj
-    r0 :: str
+    r0 :: f__env
+    r1 :: str
 L0:
-    r0 = unicode_0 :: static  ('f.inner: first definition')
-    return r0
+    r0 = self.__mypyc_env__
+    r1 = unicode_0 :: static  ('f.inner: first definition')
+    return r1
 def inner_f_obj_0.__call__(self):
     self :: inner_f_obj_0
-    r0 :: str
+    r0 :: f__env
+    r1 :: str
 L0:
-    r0 = unicode_1 :: static  ('f.inner: second definition')
-    return r0
+    r0 = self.__mypyc_env__
+    r1 = unicode_1 :: static  ('f.inner: second definition')
+    return r1
 def f(flag):
     flag :: bool
     r0 :: f__env

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -1018,34 +1018,6 @@ L0:
     r2 = cast(float, r1)
     return r2
 
-[case testBasicNestedFunction]
-from typing import Callable
-def a() -> Callable[[], object]:
-    def inner() -> object:
-        return None
-    return inner
-
-[out]
-def inner_a_obj.__call__(self):
-    self :: inner_a_obj
-    r0 :: a__env
-    r1 :: None
-L0:
-    r0 = self.__mypyc_env__
-    r1 = None
-    return r1
-def a():
-    r0 :: a__env
-    r1 :: inner_a_obj
-    r2 :: bool
-    inner :: object
-L0:
-    r0 = a__env()
-    r1 = inner_a_obj()
-    r1.__mypyc_env__ = r0; r2 = is_error
-    inner = r1
-    return inner
-
 [case testNestedFunctions]
 from typing import Callable
 

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -1087,19 +1087,17 @@ def first_b_obj.__call__(self):
     self :: first_b_obj
     r0 :: b__env
     r1 :: first_b_env
-    r2 :: b__env
-    r3 :: bool
-    r4 :: second_b_first_obj
-    r5 :: bool
+    r2 :: bool
+    r3 :: second_b_first_obj
+    r4 :: bool
     second :: object
 L0:
     r0 = self.__mypyc_env__
     r1 = first_b_env()
-    r2 = self.__mypyc_env__
-    r1.__mypyc_env__ = r2; r3 = is_error
-    r4 = second_b_first_obj()
-    r4.__mypyc_env__ = r1; r5 = is_error
-    second = r4
+    r1.__mypyc_env__ = r0; r2 = is_error
+    r3 = second_b_first_obj()
+    r3.__mypyc_env__ = r1; r4 = is_error
+    second = r3
     return second
 def b():
     r0 :: b__env
@@ -1326,7 +1324,7 @@ L3:
     r8 = cast(str, r7)
     return r8
 
-[case testSpecialNestedd]
+[case testMultiplyNestedd]
 def a() -> int:
     x = 1
     def b() -> int:
@@ -1351,29 +1349,27 @@ def b_a_obj.__call__(self):
     self :: b_a_obj
     r0 :: a__env
     r1 :: b_a_env
-    r2 :: a__env
-    r3 :: bool
-    r4, r5, r6 :: int
-    r7 :: bool
-    r8 :: c_a_b_obj
-    r9 :: bool
-    c, r10 :: object
-    r11 :: int
+    r2 :: bool
+    r3, r4, r5 :: int
+    r6 :: bool
+    r7 :: c_a_b_obj
+    r8 :: bool
+    c, r9 :: object
+    r10 :: int
 L0:
     r0 = self.__mypyc_env__
     r1 = b_a_env()
-    r2 = self.__mypyc_env__
-    r1.__mypyc_env__ = r2; r3 = is_error
-    r4 = 1
-    r5 = r0.x
-    r6 = r5 + r4 :: int
-    r0.x = r6; r7 = is_error
-    r8 = c_a_b_obj()
-    r8.__mypyc_env__ = r1; r9 = is_error
-    c = r8
-    r10 = py_call(c)
-    r11 = unbox(int, r10)
-    return r11
+    r1.__mypyc_env__ = r0; r2 = is_error
+    r3 = 1
+    r4 = r0.x
+    r5 = r4 + r3 :: int
+    r0.x = r5; r6 = is_error
+    r7 = c_a_b_obj()
+    r7.__mypyc_env__ = r1; r8 = is_error
+    c = r7
+    r9 = py_call(c)
+    r10 = unbox(int, r9)
+    return r10
 def a():
     r0 :: a__env
     r1 :: int
@@ -1448,6 +1444,77 @@ L3:
     r7 = py_call(inner)
     r8 = cast(str, r7)
     return r8
+
+[case testNestedFunctionRangeLoop]
+def f() -> None:
+    for i in range(10):
+        print(i)
+    def g() -> None:
+        print('hello')
+[out]
+def g_f_obj.__call__(self):
+    self :: g_f_obj
+    r0 :: f__env
+    r1 :: str
+    r2 :: object
+    r3 :: str
+    r4, r5 :: object
+    r6, r7 :: None
+L0:
+    r0 = self.__mypyc_env__
+    r1 = unicode_1 :: static  ('hello')
+    r2 = builtins.module :: static
+    r3 = unicode_0 :: static  ('print')
+    r4 = getattr r2, r3
+    r5 = py_call(r4, r1)
+    r6 = cast(None, r5)
+    r7 = None
+    return r7
+def f():
+    r0 :: f__env
+    r1, r2 :: int
+    r3 :: bool
+    r4 :: int
+    r5 :: bool
+    r6 :: int
+    r7 :: object
+    r8 :: str
+    r9, r10, r11 :: object
+    r12 :: None
+    r13, r14 :: int
+    r15 :: bool
+    r16 :: g_f_obj
+    r17 :: bool
+    g :: object
+    r18 :: None
+L0:
+    r0 = f__env()
+    r1 = 10
+    r2 = 0
+    r0.i = r2; r3 = is_error
+L1:
+    r4 = r0.i
+    r5 = r4 < r1 :: int
+    if r5 goto L2 else goto L4 :: bool
+L2:
+    r6 = r0.i
+    r7 = builtins.module :: static
+    r8 = unicode_0 :: static  ('print')
+    r9 = getattr r7, r8
+    r10 = box(int, r6)
+    r11 = py_call(r9, r10)
+    r12 = cast(None, r11)
+L3:
+    r13 = 1
+    r14 = r4 + r13 :: int
+    r0.i = r14; r15 = is_error
+    goto L1
+L4:
+    r16 = g_f_obj()
+    r16.__mypyc_env__ = r0; r17 = is_error
+    g = r16
+    r18 = None
+    return r18
 
 [case testObjectAsBoolean]
 from typing import List

--- a/test-data/run-functions.test
+++ b/test-data/run-functions.test
@@ -105,6 +105,9 @@ def triple(a: int) -> Callable[[], Callable[[int], int]]:
     return outer
 
 def if_else(flag: int) -> str:
+    def dummy_funtion() -> str:
+        return 'if_else.dummy_function'
+
     if flag < 0:
         def inner() -> str:
             return 'if_else.inner: first definition'
@@ -117,6 +120,9 @@ def if_else(flag: int) -> str:
     return inner()
 
 def for_loop() -> int:
+    def dummy_funtion() -> str:
+        return 'for_loop.dummy_function'
+
     for i in range(5):
         def inner(i: int) -> int:
             return i
@@ -125,6 +131,9 @@ def for_loop() -> int:
     return 0
 
 def while_loop() -> int:
+    def dummy_funtion() -> str:
+        return 'while_loop.dummy_function'
+
     i = 0
     while i < 5:
         def inner(i: int) -> int:


### PR DESCRIPTION
Load the registers containing environment classes at the beginning of each nested function, so they do not have to be reloaded multiple times whenever they are used. To do this, we add a dictionary that maps from `SymbolNode` instances to `Value` instances representing registers where environment classes are stored locally. When we encounter `SymbolNode` instances, we look up the environment class in which they live, and then perform a `GetAttr` or `SetAttr` on the environment register.

Additionally, add test cases for nested functions at the same level as `range` for-loops.

This fixes #203.