### PR TITLE
Extremely basic try/finally support

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -57,7 +57,7 @@ from mypyc.ops_dict import new_dict_op, dict_get_item_op
 from mypyc.ops_misc import (
     none_op, iter_op, next_op, no_err_occurred_op, py_getattr_op, py_setattr_op,
     py_call_op, py_method_call_op, fast_isinstance_op, bool_op, new_slice_op,
-    is_none_op, type_op, raise_exception_op,
+    is_none_op, type_op, raise_exception_op, clear_exception_op,
 )
 from mypyc.subtype import is_subtype
 from mypyc.sametype import is_same_type, is_same_method_signature
@@ -349,6 +349,8 @@ class IRBuilder(NodeVisitor[Value]):
         # This list operate as stack frames for loops. Each loop adds a new
         # frame containing the continue and break targets for the loop.
         self.loop_exits = []  # type: List[Tuple[BasicBlock, BasicBlock]]
+        # Stack of except handler entry blocks
+        self.error_handlers = [None]  # type: List[Optional[BasicBlock]]
 
         self.mapper = mapper
         self.imports = []  # type: List[str]
@@ -1448,6 +1450,30 @@ class IRBuilder(NodeVisitor[Value]):
         self.add(Unreachable())
         return INVALID_VALUE
 
+    def visit_try_stmt(self, t: TryStmt) -> Value:
+        assert len(t.handlers) == 1 and t.types[0] is None and t.vars[0] is None, (
+            "Only bare except supported")
+        assert not t.else_body, "try/else not implemented"
+        assert not t.finally_body, "try/finally not implemented"
+
+        except_entry, exit_block = BasicBlock(), BasicBlock()
+
+        self.error_handlers.append(except_entry)
+        self.goto_and_activate(BasicBlock())
+        self.accept(t.body)
+        self.add(Goto(exit_block))
+        self.error_handlers.pop()
+
+        self.activate_block(except_entry)
+        except_body = t.handlers[0]
+        self.primitive_op(clear_exception_op, [], except_body.line)
+        self.accept(except_body)
+        self.add(Goto(exit_block))
+
+        self.activate_block(exit_block)
+
+        return INVALID_VALUE
+
     def visit_pass_stmt(self, o: PassStmt) -> Value:
         return INVALID_VALUE
 
@@ -1536,9 +1562,6 @@ class IRBuilder(NodeVisitor[Value]):
     def visit_temp_node(self, o: TempNode) -> Value:
         raise NotImplementedError
 
-    def visit_try_stmt(self, o: TryStmt) -> Value:
-        raise NotImplementedError
-
     def visit_type_alias_expr(self, o: TypeAliasExpr) -> Value:
         raise NotImplementedError
 
@@ -1572,10 +1595,12 @@ class IRBuilder(NodeVisitor[Value]):
         self.environment = Environment(name)
         self.environments.append(self.environment)
         self.ret_types.append(none_rprimitive)
+        self.error_handlers.append(None)
         self.blocks.append([])
         self.new_block()
 
     def activate_block(self, block: BasicBlock) -> None:
+        block.error_handler = self.error_handlers[-1]
         self.blocks[-1].append(block)
 
     def goto_and_activate(self, block: BasicBlock) -> None:
@@ -1596,6 +1621,7 @@ class IRBuilder(NodeVisitor[Value]):
         blocks = self.blocks.pop()
         env = self.environments.pop()
         ret_type = self.ret_types.pop()
+        self.error_handlers.pop()
         self.environment = self.environments[-1]
         return blocks, env, ret_type
 

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -423,15 +423,22 @@ class BasicBlock:
     as the final op in a block. Manually inserting error checking ops
     would be boring and error-prone.
 
+    BasicBlock's have an error_handler attribute that determines where
+    to jump if an error occurs. If none is specified, an error will
+    propagate up out of the function. This is compiled away by the
+    `exceptions` module.
+
     Block labels are used for pretty printing and emitting C code, and get
     filled in by those passes.
 
     Ops that may terminate the program aren't treated as exits.
+
     """
 
     def __init__(self, label: int = -1) -> None:
         self.label = label
         self.ops = []  # type: List[Op]
+        self.error_handler = None  # type: Optional[BasicBlock]
 
 
 ERR_NEVER = 0  # Never generates an exception
@@ -1437,11 +1444,21 @@ def format_blocks(blocks: List[BasicBlock], env: Environment) -> List[str]:
     for i, block in enumerate(blocks):
         block.label = i
 
+    handler_map = {}  # type: Dict[BasicBlock, List[BasicBlock]]
+    for b in blocks:
+        if b.error_handler:
+            handler_map.setdefault(b.error_handler, []).append(b)
+
     lines = []
     for i, block in enumerate(blocks):
         i == len(blocks) - 1
 
-        lines.append(env.format('%l:', block.label))
+        handler_msg = ''
+        if block in handler_map:
+            labels = sorted(env.format('%l', b.label) for b in handler_map[block])
+            handler_msg = ' (handler for {})'.format(', '.join(labels))
+
+        lines.append(env.format('%l:%s', block.label, handler_msg))
         ops = block.ops
         if (isinstance(ops[-1], Goto) and i + 1 < len(blocks) and
                 ops[-1].label == blocks[i + 1]):

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -423,7 +423,7 @@ class BasicBlock:
     as the final op in a block. Manually inserting error checking ops
     would be boring and error-prone.
 
-    BasicBlock's have an error_handler attribute that determines where
+    BasicBlocks have an error_handler attribute that determines where
     to jump if an error occurs. If none is specified, an error will
     propagate up out of the function. This is compiled away by the
     `exceptions` module.
@@ -432,7 +432,6 @@ class BasicBlock:
     filled in by those passes.
 
     Ops that may terminate the program aren't treated as exits.
-
     """
 
     def __init__(self, label: int = -1) -> None:

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -243,3 +243,11 @@ raise_exception_op = custom_op(
     error_kind=ERR_FALSE,
     format_str = 'raise_exception({args[0]}, {args[1]}); {dest} = 0',
     emit=simple_emit('PyErr_SetObject({args[0]}, {args[1]}); {dest} = 0;'))
+
+# This having a return value is pretty ugly
+clear_exception_op = custom_op(
+    arg_types=[],
+    result_type=bool_rprimitive,
+    error_kind=ERR_NEVER,
+    format_str = 'clear_exception(); {dest} = 0',
+    emit=simple_emit('PyErr_Clear(); {dest} = 0; (void){dest};'))

--- a/mypyc/test/test_genops.py
+++ b/mypyc/test/test_genops.py
@@ -29,6 +29,7 @@ files = [
     'genops-tuple.test',
     'genops-any.test',
     'genops-generics.test',
+    'genops-try.test',
 ]
 
 

--- a/test-data/exceptions.test
+++ b/test-data/exceptions.test
@@ -138,3 +138,50 @@ L9:
     dec_ref sum :: int
     dec_ref i :: int
     goto L6
+
+[case testTryExcept]
+def g() -> None:
+    try:
+        object()
+    except:
+        print("weeee")
+[out]
+L0:
+L1:
+    r0 = builtins.module :: static
+    r1 = unicode_0 :: static  ('object')
+    r2 = getattr r0, r1
+    if is_error(r2) goto L4 (error at g:3) else goto L2
+L2:
+    r3 = py_call(r2)
+    dec_ref r2
+    if is_error(r3) goto L4 (error at g:3) else goto L10
+L3:
+    goto L8
+L4:
+    clear_exception(); r4 = 0
+    r5 = unicode_1 :: static  ('weeee')
+    r6 = builtins.module :: static
+    r7 = unicode_2 :: static  ('print')
+    r8 = getattr r6, r7
+    if is_error(r8) goto L9 (error at g:5) else goto L5
+L5:
+    r9 = py_call(r8, r5)
+    dec_ref r8
+    if is_error(r9) goto L9 (error at g:5) else goto L6
+L6:
+    r10 = cast(None, r9)
+    if is_error(r10) goto L9 (error at g:5) else goto L11
+L7:
+L8:
+    r11 = None
+    return r11
+L9:
+    r12 = <error> :: None
+    return r12
+L10:
+    dec_ref r3
+    goto L3
+L11:
+    dec_ref r10
+    goto L7

--- a/test-data/genops-try.test
+++ b/test-data/genops-try.test
@@ -81,3 +81,71 @@ L5: (handler for L1, L2, L3, L4)
 L6:
     r13 = None
     return r13
+
+[case testTryExcept3]
+def g() -> None:
+    try:
+        print('a')
+        try:
+            object()
+        except:
+            print('b')
+    except:
+        print("weeee")
+[out]
+def g():
+    r0 :: str
+    r1 :: object
+    r2 :: str
+    r3, r4 :: object
+    r5 :: None
+    r6 :: object
+    r7 :: str
+    r8, r9 :: object
+    r10 :: bool
+    r11 :: str
+    r12 :: object
+    r13 :: str
+    r14, r15 :: object
+    r16 :: None
+    r17 :: bool
+    r18 :: str
+    r19 :: object
+    r20 :: str
+    r21, r22 :: object
+    r23, r24 :: None
+L0:
+L1:
+    r0 = unicode_0 :: static  ('a')
+    r1 = builtins.module :: static
+    r2 = unicode_1 :: static  ('print')
+    r3 = getattr r1, r2
+    r4 = py_call(r3, r0)
+    r5 = cast(None, r4)
+L2:
+    r6 = builtins.module :: static
+    r7 = unicode_2 :: static  ('object')
+    r8 = getattr r6, r7
+    r9 = py_call(r8)
+    goto L4
+L3: (handler for L2)
+    clear_exception(); r10 = 0
+    r11 = unicode_3 :: static  ('b')
+    r12 = builtins.module :: static
+    r13 = unicode_1 :: static  ('print')
+    r14 = getattr r12, r13
+    r15 = py_call(r14, r11)
+    r16 = cast(None, r15)
+L4:
+    goto L6
+L5: (handler for L1, L3, L4)
+    clear_exception(); r17 = 0
+    r18 = unicode_4 :: static  ('weeee')
+    r19 = builtins.module :: static
+    r20 = unicode_1 :: static  ('print')
+    r21 = getattr r19, r20
+    r22 = py_call(r21, r18)
+    r23 = cast(None, r22)
+L6:
+    r24 = None
+    return r24

--- a/test-data/genops-try.test
+++ b/test-data/genops-try.test
@@ -1,0 +1,83 @@
+[case testTryExcept1]
+def g() -> None:
+    try:
+        object()
+    except:
+        print("weeee")
+[out]
+def g():
+    r0 :: object
+    r1 :: str
+    r2, r3 :: object
+    r4 :: bool
+    r5 :: str
+    r6 :: object
+    r7 :: str
+    r8, r9 :: object
+    r10, r11 :: None
+L0:
+L1:
+    r0 = builtins.module :: static
+    r1 = unicode_0 :: static  ('object')
+    r2 = getattr r0, r1
+    r3 = py_call(r2)
+    goto L3
+L2: (handler for L1)
+    clear_exception(); r4 = 0
+    r5 = unicode_1 :: static  ('weeee')
+    r6 = builtins.module :: static
+    r7 = unicode_2 :: static  ('print')
+    r8 = getattr r6, r7
+    r9 = py_call(r8, r5)
+    r10 = cast(None, r9)
+L3:
+    r11 = None
+    return r11
+
+[case testTryExcept2]
+def g(b: bool) -> None:
+    try:
+        if b:
+            object()
+        else:
+            str('hi')
+    except:
+        print("weeee")
+[out]
+def g(b):
+    b :: bool
+    r0 :: object
+    r1 :: str
+    r2, r3 :: object
+    r4, r5 :: str
+    r6 :: bool
+    r7 :: str
+    r8 :: object
+    r9 :: str
+    r10, r11 :: object
+    r12, r13 :: None
+L0:
+L1:
+    if b goto L2 else goto L3 :: bool
+L2:
+    r0 = builtins.module :: static
+    r1 = unicode_0 :: static  ('object')
+    r2 = getattr r0, r1
+    r3 = py_call(r2)
+    goto L4
+L3:
+    r4 = unicode_1 :: static  ('hi')
+    r5 = str r4 :: object
+L4:
+    goto L6
+L5: (handler for L1, L2, L3, L4)
+    clear_exception(); r6 = 0
+    r7 = unicode_2 :: static  ('weeee')
+    r8 = builtins.module :: static
+    r9 = unicode_3 :: static  ('print')
+    r10 = getattr r8, r9
+    r11 = py_call(r10, r7)
+    r12 = cast(None, r11)
+L6:
+    r13 = None
+    return r13

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -149,6 +149,8 @@ print(primes(13))
 [out]
 [[0, 0, 1, 1]
 [[0, 0, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1]
+-- argh ]]
+
 
 [case testListAppend]
 from typing import List
@@ -451,6 +453,24 @@ Traceback (most recent call last):
   File "tmp/py/native.py", line 19, in q2
     raise Exception
 Exception
+
+[case testTryExcept]
+def g(b: bool) -> None:
+    try:
+        if b:
+            x = [0]
+            x[1]
+        else:
+            raise Exception('hi')
+    except:
+        print("caught!")
+[file driver.py]
+from native import g
+g(True)
+g(False)
+[out]
+caught!
+caught!
 
 [case testGenericEquality]
 def eq(a: object, b: object) -> bool:


### PR DESCRIPTION
Support just bare except: statements, but introduce the infrastructure
for exception handling.

BasicBlock is extended to have an optional error_handler, which is a
block to jump to if an error occurs. It is compiled away in the
obvious fashion by the exceptions module.

Work on #172.