### PR TITLE
Only Load Free Symbols into Environment Classes

### DIFF
--- a/mypyc/freesymbols.py
+++ b/mypyc/freesymbols.py
@@ -1,0 +1,49 @@
+from typing import Dict, List, Set
+
+from mypy.nodes import FuncDef, NameExpr, SymbolNode, Var
+from mypy.traverser import TraverserVisitor
+
+
+class FreeSymbolsVisitor(TraverserVisitor):
+    """Class used to visit nested functions and determine free symbols."""
+    def __init__(self) -> None:
+        super().__init__()
+        self.free_symbols = {}  # type: Dict[FuncDef, Set[SymbolNode]]
+        self.symbols_to_fdefs = {}  # type: Dict[SymbolNode, FuncDef]
+        self.fdefs = []  # type: List[FuncDef]
+
+    def visit_func_def(self, fdef: FuncDef) -> None:
+        self.fdefs.append(fdef)
+        self.visit_func(fdef)
+        self.fdefs.pop()
+
+    def visit_var(self, var: Var) -> None:
+        self.visit_symbol_node(var)
+
+    def visit_symbol_node(self, symbol: SymbolNode) -> None:
+        if not self.fdefs:
+            # If the list of FuncDefs is empty, then we are not inside of a function and hence do
+            # not need to do anything regarding free variables.
+            return
+
+        if symbol in self.symbols_to_fdefs and self.symbols_to_fdefs[symbol] != self.fdefs[-1]:
+            # If the SymbolNode instance has already been visited before, and it was declared in a
+            # FuncDef outside of the current FuncDef that is being visted, then it is a free symbol
+            # because it is being visited again.
+            self.add_free_symbol(symbol)
+        else:
+            # Otherwise, this is the first time the SymbolNode is being visited. We map the
+            # SymbolNode to the current FuncDef being visited to note where it was first visited.
+            self.symbols_to_fdefs[symbol] = self.fdefs[-1]
+
+    def visit_name_expr(self, expr: NameExpr) -> None:
+        if isinstance(expr.node, (Var, FuncDef)):
+            self.visit_symbol_node(expr.node)
+
+    def add_free_symbol(self, symbol: SymbolNode) -> None:
+        # Get the FuncDef instance where the free symbol was first declared, and map that FuncDef
+        # to the SymbolNode representing the free symbol.
+        fdef = self.symbols_to_fdefs[symbol]
+        if fdef not in self.free_symbols:
+            self.free_symbols[fdef] = set()
+        self.free_symbols[fdef].add(symbol)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -35,11 +35,11 @@ from mypy.types import (
     TypeType, FunctionLike, Overloaded
 )
 from mypy.visitor import NodeVisitor
-from mypy.traverser import TraverserVisitor
 from mypy.subtypes import is_named_instance
 from mypy.checkmember import bind_self
 
 from mypyc.common import ENV_ATTR_NAME, MAX_SHORT_INT, TOP_LEVEL_NAME
+from mypyc.freesymbols import FreeSymbolsVisitor
 from mypyc.ops import (
     BasicBlock, AssignmentTarget, AssignmentTargetRegister, AssignmentTargetIndex,
     AssignmentTargetAttr, AssignmentTargetTuple, Environment, Op, LoadInt, RType, Value, Register,
@@ -330,51 +330,6 @@ class FuncInfo(object):
         self.is_nested = False
         self.contains_nested = False
         # TODO: add field for ret_type: RType = none_rprimitive
-
-
-class FreeSymbolsVisitor(TraverserVisitor):
-    """Class used to visit nested functions and determine free symbols."""
-    def __init__(self) -> None:
-        super().__init__()
-        self.free_symbols = {}  # type: Dict[FuncDef, Set[SymbolNode]]
-        self.symbols_to_fdefs = {}  # type: Dict[SymbolNode, FuncDef]
-        self.fdefs = []  # type: List[FuncDef]
-
-    def visit_func_def(self, fdef: FuncDef) -> None:
-        self.fdefs.append(fdef)
-        self.visit_func(fdef)
-        self.fdefs.pop()
-
-    def visit_var(self, var: Var) -> None:
-        self.visit_symbol_node(var)
-
-    def visit_symbol_node(self, symbol: SymbolNode) -> None:
-        if not self.fdefs:
-            # If the list of FuncDefs is empty, then we are not inside of a function and hence do
-            # not need to do anything regarding free variables.
-            return
-
-        if symbol in self.symbols_to_fdefs and self.symbols_to_fdefs[symbol] != self.fdefs[-1]:
-            # If the SymbolNode instance has already been visited before, and it was declared in a
-            # FuncDef outside of the current FuncDef that is being visted, then it is a free symbol
-            # because it is being visited again.
-            self.add_free_symbol(symbol)
-        else:
-            # Otherwise, this is the first time the SymbolNode is being visited. We map the
-            # SymbolNode to the current FuncDef being visited to note where it was first visited.
-            self.symbols_to_fdefs[symbol] = self.fdefs[-1]
-
-    def visit_name_expr(self, expr: NameExpr) -> None:
-        if isinstance(expr.node, (Var, FuncDef)):
-            self.visit_symbol_node(expr.node)
-
-    def add_free_symbol(self, symbol: SymbolNode) -> None:
-        # Get the FuncDef instance where the free symbol was first declared, and map that FuncDef
-        # to the SymbolNode representing the free symbol.
-        fdef = self.symbols_to_fdefs[symbol]
-        if fdef not in self.free_symbols:
-            self.free_symbols[fdef] = set()
-        self.free_symbols[fdef].add(symbol)
 
 
 class IRBuilder(NodeVisitor[Value]):

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -1114,16 +1114,14 @@ L0:
 def c(num):
     num :: float
     r0 :: c__env
-    r1 :: bool
-    r2 :: inner_c_obj
-    r3 :: bool
+    r1 :: inner_c_obj
+    r2 :: bool
     inner :: object
 L0:
     r0 = c__env()
-    r0.num = num; r1 = is_error
-    r2 = inner_c_obj()
-    r2.__mypyc_env__ = r0; r3 = is_error
-    inner = r2
+    r1 = inner_c_obj()
+    r1.__mypyc_env__ = r0; r2 = is_error
+    inner = r1
     return inner
 def inner_d_obj.__call__(self, s):
     self :: inner_d_obj
@@ -1135,35 +1133,28 @@ L0:
 def d(num):
     num :: float
     r0 :: d__env
-    r1 :: bool
-    r2 :: inner_d_obj
-    r3 :: bool
+    r1 :: inner_d_obj
+    r2 :: bool
     inner :: object
-    r4 :: str
-    r5 :: object
-    r6 :: str
-    r7 :: bool
+    a, r3 :: str
+    r4 :: object
+    r5, b, r6 :: str
+    r7 :: object
     r8 :: str
-    r9 :: object
-    r10 :: str
-    r11 :: bool
-    r12 :: str
 L0:
     r0 = d__env()
-    r0.num = num; r1 = is_error
-    r2 = inner_d_obj()
-    r2.__mypyc_env__ = r0; r3 = is_error
-    inner = r2
-    r4 = unicode_3 :: static  ('one')
-    r5 = py_call(inner, r4)
-    r6 = cast(str, r5)
-    r0.a = r6; r7 = is_error
-    r8 = unicode_4 :: static  ('two')
-    r9 = py_call(inner, r8)
-    r10 = cast(str, r9)
-    r0.b = r10; r11 = is_error
-    r12 = r0.a
-    return r12
+    r1 = inner_d_obj()
+    r1.__mypyc_env__ = r0; r2 = is_error
+    inner = r1
+    r3 = unicode_3 :: static  ('one')
+    r4 = py_call(inner, r3)
+    r5 = cast(str, r4)
+    a = r5
+    r6 = unicode_4 :: static  ('two')
+    r7 = py_call(inner, r6)
+    r8 = cast(str, r7)
+    b = r8
+    return a
 def inner():
     r0 :: str
 L0:
@@ -1284,32 +1275,29 @@ L0:
 def c(flag):
     flag :: bool
     r0 :: c__env
-    r1, r2 :: bool
-    r3 :: inner_c_obj
-    r4 :: bool
+    r1 :: inner_c_obj
+    r2 :: bool
     inner :: object
-    r5 :: inner_c_obj_0
-    r6 :: bool
-    r7 :: object
-    r8 :: str
+    r3 :: inner_c_obj_0
+    r4 :: bool
+    r5 :: object
+    r6 :: str
 L0:
     r0 = c__env()
-    r0.flag = flag; r1 = is_error
-    r2 = r0.flag
-    if r2 goto L1 else goto L2 :: bool
+    if flag goto L1 else goto L2 :: bool
 L1:
-    r3 = inner_c_obj()
-    r3.__mypyc_env__ = r0; r4 = is_error
-    inner = r3
+    r1 = inner_c_obj()
+    r1.__mypyc_env__ = r0; r2 = is_error
+    inner = r1
     goto L3
 L2:
-    r5 = inner_c_obj_0()
-    r5.__mypyc_env__ = r0; r6 = is_error
-    inner = r5
+    r3 = inner_c_obj_0()
+    r3.__mypyc_env__ = r0; r4 = is_error
+    inner = r3
 L3:
-    r7 = py_call(inner)
-    r8 = cast(str, r7)
-    return r8
+    r5 = py_call(inner)
+    r6 = cast(str, r5)
+    return r6
 
 [case testSpecialNestedd]
 def a() -> int:
@@ -1403,40 +1391,39 @@ L0:
 def f(flag):
     flag :: bool
     r0 :: f__env
-    r1, r2 :: bool
-    r3 :: inner_f_obj
-    r4 :: bool
+    r1 :: inner_f_obj
+    r2 :: bool
     inner :: object
-    r5 :: inner_f_obj_0
-    r6 :: bool
-    r7 :: object
-    r8 :: str
+    r3 :: inner_f_obj_0
+    r4 :: bool
+    r5 :: object
+    r6 :: str
 L0:
     r0 = f__env()
-    r0.flag = flag; r1 = is_error
-    r2 = r0.flag
-    if r2 goto L1 else goto L2 :: bool
+    if flag goto L1 else goto L2 :: bool
 L1:
-    r3 = inner_f_obj()
-    r3.__mypyc_env__ = r0; r4 = is_error
-    inner = r3
+    r1 = inner_f_obj()
+    r1.__mypyc_env__ = r0; r2 = is_error
+    inner = r1
     goto L3
 L2:
-    r5 = inner_f_obj_0()
-    r5.__mypyc_env__ = r0; r6 = is_error
-    inner = r5
+    r3 = inner_f_obj_0()
+    r3.__mypyc_env__ = r0; r4 = is_error
+    inner = r3
 L3:
-    r7 = py_call(inner)
-    r8 = cast(str, r7)
-    return r8
+    r5 = py_call(inner)
+    r6 = cast(str, r5)
+    return r6
 
 [case testNestedFunctionUnusedFreeVars]
-def f(num: int) -> None:
+def f(foo: int, bar: int) -> None:
     x = 1
     y = 2
     def g() -> None:
         nonlocal y
         y = 3
+        nonlocal bar
+        bar += 2
     z = 3
     
 [out]
@@ -1445,36 +1432,46 @@ def g_f_obj.__call__(self):
     r0 :: f__env
     r1 :: int
     r2 :: bool
-    r3 :: None
+    r3 :: f__env
+    r4, r5, r6 :: int
+    r7 :: bool
+    r8 :: None
 L0:
     r0 = self.__mypyc_env__
     r1 = 3
     r0.y = r1; r2 = is_error
-    r3 = None
-    return r3
-def f(num):
-    num :: int
+    r3 = self.__mypyc_env__
+    r4 = 2
+    r5 = r3.bar
+    r6 = r5 + r4 :: int
+    r3.bar = r6; r7 = is_error
+    r8 = None
+    return r8
+def f(foo, bar):
+    foo, bar :: int
     r0 :: f__env
-    x, r1, r2 :: int
-    r3 :: bool
-    r4 :: g_f_obj
-    r5 :: bool
+    r1 :: bool
+    x, r2, r3 :: int
+    r4 :: bool
+    r5 :: g_f_obj
+    r6 :: bool
     g :: object
-    z, r6 :: int
-    r7 :: None
+    z, r7 :: int
+    r8 :: None
 L0:
     r0 = f__env()
-    r1 = 1
-    x = r1
-    r2 = 2
-    r0.y = r2; r3 = is_error
-    r4 = g_f_obj()
-    r4.__mypyc_env__ = r0; r5 = is_error
-    g = r4
-    r6 = 3
-    z = r6
-    r7 = None
-    return r7
+    r0.bar = bar; r1 = is_error
+    r2 = 1
+    x = r2
+    r3 = 2
+    r0.y = r3; r4 = is_error
+    r5 = g_f_obj()
+    r5.__mypyc_env__ = r0; r6 = is_error
+    g = r5
+    r7 = 3
+    z = r7
+    r8 = None
+    return r8
 
 [case testObjectAsBoolean]
 from typing import List

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -1430,6 +1430,52 @@ L3:
     r8 = cast(str, r7)
     return r8
 
+[case testNestedFunctionUnusedFreeVars]
+def f(num: int) -> None:
+    x = 1
+    y = 2
+    def g() -> None:
+        nonlocal y
+        y = 3
+    z = 3
+    
+[out]
+def g_f_obj.__call__(self):
+    self :: g_f_obj
+    r0 :: f__env
+    r1 :: int
+    r2 :: bool
+    r3 :: None
+L0:
+    r0 = self.__mypyc_env__
+    r1 = 3
+    r0.y = r1; r2 = is_error
+    r3 = None
+    return r3
+def f(num):
+    num :: int
+    r0 :: f__env
+    x, r1, r2 :: int
+    r3 :: bool
+    r4 :: g_f_obj
+    r5 :: bool
+    g :: object
+    z, r6 :: int
+    r7 :: None
+L0:
+    r0 = f__env()
+    r1 = 1
+    x = r1
+    r2 = 2
+    r0.y = r2; r3 = is_error
+    r4 = g_f_obj()
+    r4.__mypyc_env__ = r0; r5 = is_error
+    g = r4
+    r6 = 3
+    z = r6
+    r7 = None
+    return r7
+
 [case testObjectAsBoolean]
 from typing import List
 

--- a/test-data/run-functions.test
+++ b/test-data/run-functions.test
@@ -134,6 +134,18 @@ def while_loop() -> int:
         i += 1
     return 0
 
+def free_vars(foo: int, bar: int) -> int:
+    x = 1
+    y = 2
+    def g() -> None:
+        nonlocal y
+        y = 3
+        nonlocal bar
+        bar += y
+    z = 3
+    g()
+    return bar
+
 def outer() -> str:
     return 'outer: normal function'
 
@@ -151,7 +163,7 @@ class A:
         return inner()
 
 [file driver.py]
-from native import a, b, c, d, e, f, g, h, i, j, k, l, m, n, triple, if_else, for_loop, while_loop, outer, inner, A
+from native import a, b, c, d, e, f, g, h, i, j, k, l, m, n, triple, if_else, for_loop, while_loop, free_vars, outer, inner, A
 
 assert a()() == None
 assert b()()() == 'b.first.second: nested function'
@@ -181,6 +193,8 @@ assert if_else(0) == 'if_else.inner: third definition'
 
 assert for_loop() == 3
 assert while_loop() == 3
+
+assert free_vars(1, 2) == 5
 
 assert outer() == 'outer: normal function'
 assert inner() == 'inner: normal function'


### PR DESCRIPTION
Add `FreeSymbolsVisitor(TraverserVisitor)` class to do a first-pass
analysis to determine free variables of nested functions. On the
second-pass, the `IRBuilder` only stores free symbols into
environment classes, as opposed to all of the symbols.

This fixes #212 and #229.