### PR TITLE
Emit Unreachable as __builtin_unreachable()

### DIFF
--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -14,6 +14,7 @@ extern "C" {
 
 #define likely(x)       __builtin_expect((x),1)
 #define unlikely(x)     __builtin_expect((x),0)
+#define CPy_Unreachable() __builtin_unreachable()
 
 // Naming conventions:
 //

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -273,7 +273,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         self.emitter.emit_unbox(self.reg(op.src), self.reg(op), op.type)
 
     def visit_unreachable(self, op: Unreachable) -> None:
-        pass  # Nothing to do
+        self.emitter.emit_line('CPy_Unreachable();')
 
     def visit_raise_standard_error(self, op: RaiseStandardError) -> None:
         # TODO: Better escaping of backspaces and such


### PR DESCRIPTION
The main rationale for doing this is basically just so that
Unreachable is manifested in the generated C code in some visible way,
to aid reading the code. But we might as well give the compiler a hint
while we're at it.