### PR TITLE
Add command-line compiler tool

### DIFF
--- a/mypyc/buildc.py
+++ b/mypyc/buildc.py
@@ -116,6 +116,6 @@ def run_setup_py_build(setup_path: str, module_name: str) -> str:
         subprocess.check_output(['python', setup_path, 'build'], stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as err:
         raise BuildError(err.output)
-    so_path = glob.glob('build/*/%s*.so' % module_name)
-    assert len(so_path) == 1
+    so_path = glob.glob('build/*/%s.*.so' % module_name)
+    assert len(so_path) == 1, so_path
     return so_path[0]

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -1,7 +1,7 @@
 """Generate C code for a Python C extension module from Python source code."""
 
 from collections import OrderedDict
-from typing import List, Tuple, Dict, Iterable, Set, TypeVar
+from typing import List, Tuple, Dict, Iterable, Set, TypeVar, Optional
 
 from mypy.build import BuildSource, build
 from mypy.errors import CompileError
@@ -26,7 +26,7 @@ class MarkedDeclaration:
 
 
 def compile_modules_to_c(sources: List[BuildSource], module_names: List[str], options: Options,
-                         alt_lib_path: str) -> str:
+                         alt_lib_path: Optional[str] = None) -> str:
     """Compile Python module(s) to C that can be used from Python C extension modules."""
     assert options.strict_optional, 'strict_optional must be turned on'
     result = build(sources=sources,

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -91,7 +91,7 @@ class TestRun(MypycDataSuite):
                 with open(common_path, 'w') as f:
                     f.write(ctext)
                 try:
-                    shared_lib = buildc.build_shared_lib_for_modules(common_path)
+                    shared_lib = buildc.build_shared_lib_for_modules(common_path, module_names)
                 except buildc.BuildError as err:
                     show_c_error(common_path, err.output)
                     raise

--- a/scripts/mypyc
+++ b/scripts/mypyc
@@ -44,7 +44,7 @@ def build_using_shared_lib(fobj: IO[str], ctext: str, module_names: List[str]) -
     fobj.write(ctext)
     fobj.flush()
     try:
-        shared_lib = build_shared_lib_for_modules(common_path)
+        shared_lib = build_shared_lib_for_modules(common_path, module_names)
     except BuildError as err:
         handle_build_error(err, common_path)
 

--- a/scripts/mypyc
+++ b/scripts/mypyc
@@ -25,13 +25,13 @@ from mypyc import buildc
 
 def main() -> None:
     sources, options = process_options(sys.argv[1:])
-    options.show_traceback = True
     if options.python_version[0] == 2:
         sys.exit('Python 2 not supported')
     if not options.strict_optional:
         sys.exit('Disabling strict optional checking not supported')
+    options.show_traceback = True
     # Needed to get types for all AST nodes
-    options.dump_deps = True
+    options.export_types = True
     # TODO: Support incremental checking
     options.incremental = False
 

--- a/scripts/mypyc
+++ b/scripts/mypyc
@@ -3,8 +3,14 @@
 
 Usage:
 
-    $ mypyc foo.py
+    $ mypyc foo.py [...]
     $ python3 -c 'import foo'  # Uses compiled 'foo'
+
+Limitations:
+
+* Can only compile top-level modules
+* There's no easy way to look at the generated code as the C file gets
+  deleted at the end
 """
 
 import os

--- a/scripts/mypyc
+++ b/scripts/mypyc
@@ -12,7 +12,7 @@ import sys
 sys.path.extend(['external/mypy', '.'])
 
 import shutil
-from typing import List
+from typing import List, Optional
 
 from mypy.errors import CompileError
 from mypy.options import Options
@@ -20,7 +20,18 @@ from mypy.main import process_options
 from mypy import build
 
 from mypyc import emitmodule
-from mypyc import buildc
+from mypyc.buildc import (
+    BuildError, build_shared_lib_for_modules, build_c_extension_shim, build_c_extension
+)
+
+
+def handle_build_error(err: BuildError, c_path: Optional[str]) -> None:
+    print(err.output.decode('utf8'))
+    if c_path is not None:
+        extra = ' (%s)' % c_path
+    else:
+        extra = ''
+    sys.exit('Internal error: C compilation failed' + extra)
 
 
 def main() -> None:
@@ -35,8 +46,6 @@ def main() -> None:
     # TODO: Support incremental checking
     options.incremental = False
 
-    assert len(sources) == 1
-
     module_names = [source.module for source in sources]
 
     try:
@@ -49,16 +58,37 @@ def main() -> None:
             print(line)
         sys.exit(1)
 
-    for source in sources:
-        module = source.module
+    use_shared_lib = len(module_names) > 1
+    if use_shared_lib:
+        common_path = '__shared_stuff.c'
+        with open(common_path, 'w') as f:
+            f.write(ctext)
+        try:
+            shared_lib = build_shared_lib_for_modules(common_path)
+        except BuildError as err:
+            handle_build_error(err, common_path)
+
+        for module in module_names:
+            so_path = '%s.so' % module
+            try:
+                native_lib_path = build_c_extension_shim(module, shared_lib)
+            except BuildError as err:
+                handle_build_error(err, None)
+            shutil.copy(native_lib_path, so_path)
+    else:
+        module = module_names[0]
         c_path = '%s.c' % module
         so_path = '%s.so' % module
+
         with open(c_path, 'w') as f:
             f.write(ctext)
 
-        for mod in module_names:
-            native_lib_path = buildc.build_c_extension(c_path, mod, preserve_setup=True)
-            shutil.copy(native_lib_path, so_path)
+        try:
+            native_lib_path = build_c_extension(c_path, module, preserve_setup=True)
+        except BuildError as err:
+            handle_build_error(err, c_path)
+
+        shutil.copy(native_lib_path, so_path)
 
 
 if __name__ == '__main__':

--- a/scripts/mypyc
+++ b/scripts/mypyc
@@ -71,7 +71,7 @@ def build_single_module(fobj: IO[str], ctext: str, module: str) -> None:
         f.write(ctext)
 
     try:
-        native_lib_path = build_c_extension(c_path, module, preserve_setup=True)
+        native_lib_path = build_c_extension(c_path, module)
     except BuildError as err:
         handle_build_error(err, c_path)
 

--- a/scripts/mypyc
+++ b/scripts/mypyc
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Mypyc command-line tool.
+
+Usage:
+
+    $ mypyc foo.py
+    $ python3 -c 'import foo'  # Uses compiled 'foo'
+"""
+
+import sys
+
+sys.path.extend(['external/mypy', '.'])
+
+import shutil
+from typing import List
+
+from mypy.errors import CompileError
+from mypy.options import Options
+from mypy.main import process_options
+from mypy import build
+
+from mypyc import emitmodule
+from mypyc import buildc
+
+
+def main() -> None:
+    sources, options = process_options(sys.argv[1:])
+    options.show_traceback = True
+    if options.python_version[0] == 2:
+        sys.exit('Python 2 not supported')
+    if not options.strict_optional:
+        sys.exit('Disabling strict optional checking not supported')
+    # Needed to get types for all AST nodes
+    options.dump_deps = True
+    # TODO: Support incremental checking
+    options.incremental = False
+
+    assert len(sources) == 1
+
+    module_names = [source.module for source in sources]
+
+    try:
+        ctext = emitmodule.compile_modules_to_c(
+            sources=sources,
+            module_names=module_names,
+            options=options)
+    except CompileError as e:
+        for line in e.messages:
+            print(line)
+        sys.exit(1)
+
+    for source in sources:
+        module = source.module
+        c_path = '%s.c' % module
+        so_path = '%s.so' % module
+        with open(c_path, 'w') as f:
+            f.write(ctext)
+
+        for mod in module_names:
+            native_lib_path = buildc.build_c_extension(c_path, mod, preserve_setup=True)
+            shutil.copy(native_lib_path, so_path)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/mypyc
+++ b/scripts/mypyc
@@ -7,9 +7,12 @@ Usage:
     $ python3 -c 'import foo'  # Uses compiled 'foo'
 """
 
+import os.path
 import sys
 
-sys.path.extend(['external/mypy', '.'])
+base_path = os.path.join(os.path.dirname(__file__), '..')
+
+sys.path.extend([os.path.join(base_path, 'external/mypy'), base_path])
 
 import shutil
 from typing import List, Optional

--- a/scripts/mypyc
+++ b/scripts/mypyc
@@ -7,6 +7,7 @@ Usage:
     $ python3 -c 'import foo'  # Uses compiled 'foo'
 """
 
+import os
 import os.path
 import sys
 
@@ -78,6 +79,7 @@ def main() -> None:
             except BuildError as err:
                 handle_build_error(err, None)
             shutil.copy(native_lib_path, so_path)
+        os.remove(common_path)
     else:
         module = module_names[0]
         c_path = '%s.c' % module

--- a/scripts/mypyc
+++ b/scripts/mypyc
@@ -10,13 +10,14 @@ Usage:
 import os
 import os.path
 import sys
+import tempfile
 
 base_path = os.path.join(os.path.dirname(__file__), '..')
 
 sys.path.extend([os.path.join(base_path, 'external/mypy'), base_path])
 
 import shutil
-from typing import List, Optional
+from typing import List, Optional, IO
 
 from mypy.errors import CompileError
 from mypy.options import Options
@@ -36,6 +37,39 @@ def handle_build_error(err: BuildError, c_path: Optional[str]) -> None:
     else:
         extra = ''
     sys.exit('Internal error: C compilation failed' + extra)
+
+
+def build_using_shared_lib(fobj: IO[str], ctext: str, module_names: List[str]) -> None:
+    common_path = fobj.name
+    fobj.write(ctext)
+    fobj.flush()
+    try:
+        shared_lib = build_shared_lib_for_modules(common_path)
+    except BuildError as err:
+        handle_build_error(err, common_path)
+
+    for module in module_names:
+        so_path = '%s.so' % module
+        try:
+            native_lib_path = build_c_extension_shim(module, shared_lib)
+        except BuildError as err:
+            handle_build_error(err, None)
+        shutil.copy(native_lib_path, so_path)
+
+
+def build_single_module(fobj: IO[str], ctext: str, module: str) -> None:
+    c_path = fobj.name
+    so_path = '%s.so' % module
+
+    with open(c_path, 'w') as f:
+        f.write(ctext)
+
+    try:
+        native_lib_path = build_c_extension(c_path, module, preserve_setup=True)
+    except BuildError as err:
+        handle_build_error(err, c_path)
+
+    shutil.copy(native_lib_path, so_path)
 
 
 def main() -> None:
@@ -63,37 +97,14 @@ def main() -> None:
         sys.exit(1)
 
     use_shared_lib = len(module_names) > 1
-    if use_shared_lib:
-        common_path = '__shared_stuff.c'
-        with open(common_path, 'w') as f:
-            f.write(ctext)
-        try:
-            shared_lib = build_shared_lib_for_modules(common_path)
-        except BuildError as err:
-            handle_build_error(err, common_path)
-
-        for module in module_names:
-            so_path = '%s.so' % module
-            try:
-                native_lib_path = build_c_extension_shim(module, shared_lib)
-            except BuildError as err:
-                handle_build_error(err, None)
-            shutil.copy(native_lib_path, so_path)
-        os.remove(common_path)
-    else:
-        module = module_names[0]
-        c_path = '%s.c' % module
-        so_path = '%s.so' % module
-
-        with open(c_path, 'w') as f:
-            f.write(ctext)
-
-        try:
-            native_lib_path = build_c_extension(c_path, module, preserve_setup=True)
-        except BuildError as err:
-            handle_build_error(err, c_path)
-
-        shutil.copy(native_lib_path, so_path)
+    with tempfile.NamedTemporaryFile(mode='w+',
+                                     prefix='mypyc-tmp-',
+                                     suffix='.c',
+                                     dir='.') as fobj:
+        if use_shared_lib:
+            build_using_shared_lib(fobj, ctext, module_names)
+        else:
+            build_single_module(fobj, ctext, module_names[0])
 
 
 if __name__ == '__main__':

--- a/test-data/commandline.test
+++ b/test-data/commandline.test
@@ -1,0 +1,51 @@
+-- Test cases for invoking mypyc on the command line
+--
+-- These are slow -- do not add test cases unless you have a very good reason to do so.
+
+[case testCompileTwoModules]
+# cmd: a.py b.py
+import a
+import b
+print('<main>', b.g(a.A()))
+try:
+    a.f('')
+except TypeError:
+    pass
+else:
+    assert False
+
+[file a.py]
+import b
+
+print('<a>', ord('A') == 65)  # Test full builtins
+
+class A:
+    def __init__(self) -> None:
+        self.x = 4
+
+def f(x: int) -> b.B:
+    return b.B(x)
+
+class B:
+    def __init__(self, x: int, y: str) -> None:
+        self.x = x
+
+print('<a>', f(5).x)
+
+[file b.py]
+import a
+
+class B:
+    def __init__(self, x: int) -> None:
+        self.x = x
+
+def g(a: a.A) -> int:
+    return a.x
+
+print('<b>', 'here')
+
+[out]
+<b> here
+<a> True
+<a> 5
+<main> 4


### PR DESCRIPTION
This allows compiling one or more modules through `scripts/mypyc mod.py [...]`.
If multiple modules are being compiled, we create one `.so` file per module and
an extra shared `.so` file that contains most of the compiled code. The 
command-line compiler uses full stubs, unlike the test cases.

The compiled module cannot be run directly, since the main module must be a
Python file. It may be necessary to do something like `python3 -c 'import mod'`
to run compiled code.

Currently only top-level modules can be compiled.

Closes #14.