### PR TITLE
Support keyword arguments when calling native functions

### DIFF
--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -1330,3 +1330,37 @@ L0:
     r5 = f(r3, r4)
     r6 = None
     return r6
+
+[case testMethodCallWithKeywordArgs]
+class A:
+    def f(self, x: int, y: str) -> None: pass
+
+def g(a: A) -> None:
+    a.f(y='a', x=0)
+    a.f(1, y='b')
+[out]
+def A.f(self, x, y):
+    self :: A
+    x :: int
+    y :: str
+    r0 :: None
+L0:
+    r0 = None
+    return r0
+def g(a):
+    a :: A
+    r0 :: str
+    r1 :: int
+    r2 :: None
+    r3 :: int
+    r4 :: str
+    r5, r6 :: None
+L0:
+    r0 = unicode_0 :: static  ('a')
+    r1 = 0
+    r2 = a.f(r1, r0)
+    r3 = 1
+    r4 = unicode_1 :: static  ('b')
+    r5 = a.f(r3, r4)
+    r6 = None
+    return r6

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -1300,7 +1300,7 @@ L0:
     r6 = cast(str, r5)
     return r6
 
-[case testCallWithKeywordArgs]
+[case testFunctionCallWithKeywordArgs]
 def f(x: int, y: str) -> None: pass
 
 def g() -> None:
@@ -1315,16 +1315,16 @@ L0:
     r0 = None
     return r0
 def g():
-    r0 :: int
-    r1 :: str
+    r0 :: str
+    r1 :: int
     r2 :: None
     r3 :: int
     r4 :: str
     r5, r6 :: None
 L0:
-    r0 = 0
-    r1 = unicode_0 :: static  ('a')
-    r2 = f(r0, r1)
+    r0 = unicode_0 :: static  ('a')
+    r1 = 0
+    r2 = f(r1, r0)
     r3 = 1
     r4 = unicode_1 :: static  ('b')
     r5 = f(r3, r4)

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -1299,3 +1299,34 @@ L0:
     r5 = py_call(r2, r4)
     r6 = cast(str, r5)
     return r6
+
+[case testCallWithKeywordArgs]
+def f(x: int, y: str) -> None: pass
+
+def g() -> None:
+    f(y='a', x=0)
+    f(1, y='b')
+[out]
+def f(x, y):
+    x :: int
+    y :: str
+    r0 :: None
+L0:
+    r0 = None
+    return r0
+def g():
+    r0 :: int
+    r1 :: str
+    r2 :: None
+    r3 :: int
+    r4 :: str
+    r5, r6 :: None
+L0:
+    r0 = 0
+    r1 = unicode_0 :: static  ('a')
+    r2 = f(r0, r1)
+    r3 = 1
+    r4 = unicode_1 :: static  ('b')
+    r5 = f(r3, r4)
+    r6 = None
+    return r6


### PR DESCRIPTION
Keyword arguments are translated to positional arguments in native calls.

Calling Python functions with keyword arguments is not supported yet.

Work towards #39.