### PR TITLE
Use INCREF/DECREF wrapper macros that assert the pointer is non-NULL

### DIFF
--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <Python.h>
 #include <frameobject.h>
+#include <assert.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,6 +38,12 @@ static void CPyDebug_Print(const char *msg) {
     printf("%s\n", msg);
     fflush(stdout);
 }
+
+// INCREF and DECREF that assert the pointer is not NULL.
+// asserts are disabled in release builds so there shouldn't be a perf hit.
+// I'm honestly kind of surprised that this isn't done by default.
+#define CPy_INCREF(p) do { assert(p); Py_INCREF(p); } while (0)
+#define CPy_DECREF(p) do { assert(p); Py_DECREF(p); } while (0)
 
 // Search backwards through the trait part of a vtable (which sits *before*
 // the start of the vtable proper) looking for the subvtable describing a trait

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -205,7 +205,7 @@ class Emitter:
             for i, item_type in enumerate(rtype.types):
                 self.emit_inc_ref('{}.f{}'.format(dest, i), item_type)
         elif not rtype.is_unboxed:
-            self.emit_line('Py_INCREF(%s);' % dest)
+            self.emit_line('CPy_INCREF(%s);' % dest)
         # Otherwise assume it's an unboxed, pointerless value and do nothing.
 
     def emit_dec_ref(self, dest: str, rtype: RType) -> None:
@@ -220,7 +220,7 @@ class Emitter:
             for i, item_type in enumerate(rtype.types):
                 self.emit_dec_ref('{}.f{}'.format(dest, i), item_type)
         elif not rtype.is_unboxed:
-            self.emit_line('Py_DECREF(%s);' % dest)
+            self.emit_line('CPy_DECREF(%s);' % dest)
         # Otherwise assume it's an unboxed, pointerless value and do nothing.
 
     def pretty_name(self, typ: RType) -> str:


### PR DESCRIPTION
This should make debugging certain problems easier without any
performance impact in release mdoe.