### PR TITLE
Added set literals

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1445,7 +1445,7 @@ class IRBuilder(NodeVisitor[Value]):
         return dict_reg
 
     def visit_set_expr(self, expr: SetExpr) -> Value:
-        set_reg = self.add(PrimitiveOp([], new_set_op, expr.line))
+        set_reg = self.primitive_op(new_set_op, [], expr.line)
         for key_expr in expr.items:
             key_reg = self.accept(key_expr)
             self.primitive_op(set_add_op, [set_reg, key_reg], expr.line)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -59,6 +59,7 @@ from mypyc.ops import (
 )
 from mypyc.ops_primitive import binary_ops, unary_ops, func_ops, method_ops, name_ref_ops
 from mypyc.ops_list import list_len_op, list_get_item_op, list_set_item_op, new_list_op
+from mypyc.ops_set import new_set_op, set_add_op
 from mypyc.ops_dict import new_dict_op, dict_get_item_op
 from mypyc.ops_misc import (
     none_op, iter_op, next_op, py_getattr_op, py_setattr_op,
@@ -1443,6 +1444,13 @@ class IRBuilder(NodeVisitor[Value]):
                 line=expr.line)
         return dict_reg
 
+    def visit_set_expr(self, expr: SetExpr) -> Value:
+        set_reg = self.add(PrimitiveOp([], new_set_op, expr.line))
+        for key_expr in expr.items:
+            key_reg = self.accept(key_expr)
+            self.primitive_op(set_add_op, [set_reg, key_reg], expr.line)
+        return set_reg
+
     def visit_str_expr(self, expr: StrExpr) -> Value:
         return self.load_static_unicode(expr.value)
 
@@ -1733,9 +1741,6 @@ class IRBuilder(NodeVisitor[Value]):
         raise NotImplementedError
 
     def visit_reveal_expr(self, o: RevealExpr) -> Value:
-        raise NotImplementedError
-
-    def visit_set_expr(self, o: SetExpr) -> Value:
         raise NotImplementedError
 
     def visit_star_expr(self, o: StarExpr) -> Value:

--- a/mypyc/ops_set.py
+++ b/mypyc/ops_set.py
@@ -1,0 +1,22 @@
+"""Primitive set ops."""
+from mypyc.ops_primitive import func_op, custom_op, simple_emit
+from mypyc.ops import object_rprimitive, bool_rprimitive, ERR_MAGIC, ERR_FALSE
+
+new_set_op = func_op(
+    name='builtins.set',
+    arg_types=[],
+    result_type=object_rprimitive,
+    error_kind=ERR_MAGIC,
+    format_str='{dest} = set()',
+    emit=simple_emit('{dest} = PySet_New(NULL);')
+)
+
+# This operation is only used during set literal generation. The first argument must be a set.
+# If sets get added as special types, this will become a method_op on set rprimitives.
+set_add_op = custom_op(
+    arg_types=[object_rprimitive, object_rprimitive],
+    result_type=bool_rprimitive,
+    error_kind=ERR_FALSE,
+    format_str='{dest} = {args[0]}.add({args[1]})',
+    emit=simple_emit('{dest} = PySet_Add({args[0]}, {args[1]}) == 0;')
+)

--- a/mypyc/test/test_genops.py
+++ b/mypyc/test/test_genops.py
@@ -31,6 +31,7 @@ files = [
     'genops-any.test',
     'genops-generics.test',
     'genops-try.test',
+    'genops-set.test',
 ]
 
 

--- a/test-data/fixtures/ir.py
+++ b/test-data/fixtures/ir.py
@@ -79,6 +79,10 @@ class dict(Generic[T, S]):
     def update(self, x: Dict[T, S]) -> None: pass
     def pop(self, x: int) -> T: pass
 
+class set(Generic[T]):
+    def add(self, x: T) -> None: pass
+    def __iter__(self) -> Iterator[T]: pass
+
 class slice: pass
 
 class BaseException: pass

--- a/test-data/genops-set.test
+++ b/test-data/genops-set.test
@@ -1,0 +1,39 @@
+[case testNewSet]
+from typing import Set
+def f() -> Set[int]:
+    return {1, 2, 3}
+[out]
+def f():
+    r0 :: object
+    r1 :: int
+    r2 :: object
+    r3 :: bool
+    r4 :: int
+    r5 :: object
+    r6 :: bool
+    r7 :: int
+    r8 :: object
+    r9 :: bool
+L0:
+    r0 = set()
+    r1 = 1
+    r2 = box(int, r1)
+    r3 = r0.add(r2)
+    r4 = 2
+    r5 = box(int, r4)
+    r6 = r0.add(r5)
+    r7 = 3
+    r8 = box(int, r7)
+    r9 = r0.add(r8)
+    return r0
+
+[case testNewEmptySet]
+from typing import Set
+def f() -> Set[int]:
+    return set()
+[out]
+def f():
+    r0 :: object
+L0:
+    r0 = set()
+    return r0

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -362,6 +362,24 @@ assert eq('foo') == 0
 assert eq('zar') == 1
 assert eq('bar') == 2
 
+[case testSetLiteral]
+from typing import Set
+def f() -> Set[int]:
+    return {1, 2, 3, 5, 8}
+[file driver.py]
+from native import f
+val = f()
+assert 1 in val
+assert 2 in val
+assert 3 in val
+assert 5 in val
+assert 8 in val
+assert len(val) == 5
+s = 0
+for i in val:
+    s += i
+assert s == 19
+
 [case testDictUpdate]
 from typing import Dict
 def f(x: int) -> int:


### PR DESCRIPTION
Set literals are created by calling `PySet_New`, then adding each element in the literal with `PySet_Add`. There isn't a varargs constructor for sets, and generating a different iterable, such as a list, and passing that to the constructor will probably do the same thing in the background.

Sets are still treated as generic objects by this change.

Closes #256.

