### PR TITLE
Fix mypyc on Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ env:
 
 install:
   - export PYTHONVERSION=`python --version | awk '{ print $2 }'`
+  - echo $PYTHONVERSION
+  - ls /opt/python/
   - if [[ $PYTHON_DEBUG_BUILD == 1 ]]; then export PYTHONDIR=~/python-debug/python-$PYTHONVERSION; else export PYTHONDIR="/opt/python/$PYTHONVERSION"; fi
   - if [[ $PYTHON_DEBUG_BUILD == 1 ]]; then VENV=$PYTHONDIR/env; scripts/build-debug-python.sh $PYTHONVERSION $PYTHONDIR $VENV; source $VENV/bin/activate; fi
   - pip install -U pip setuptools wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
 python:
   - "3.5"
   - "3.6"
+  - "3.7-dev"
 env:
   - PYTHON_DEBUG_BUILD=0
   - PYTHON_DEBUG_BUILD=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,12 @@ cache:
 python:
   - "3.5"
   - "3.6"
-  - "3.7-dev"
 env:
   - PYTHON_DEBUG_BUILD=0
   - PYTHON_DEBUG_BUILD=1
 
 install:
   - export PYTHONVERSION=`python --version | awk '{ print $2 }'`
-  - echo $PYTHONVERSION
-  - ls /opt/python/
   - if [[ $PYTHON_DEBUG_BUILD == 1 ]]; then export PYTHONDIR=~/python-debug/python-$PYTHONVERSION; else export PYTHONDIR="/opt/python/$PYTHONVERSION"; fi
   - if [[ $PYTHON_DEBUG_BUILD == 1 ]]; then VENV=$PYTHONDIR/env; scripts/build-debug-python.sh $PYTHONVERSION $PYTHONDIR $VENV; source $VENV/bin/activate; fi
   - pip install -U pip setuptools wheel
@@ -24,7 +21,7 @@ install:
 
 script:
   - export PYTHONPATH=`pwd`/external/mypy
-  - export PYTHONCONFIG="$PYTHONDIR/bin/python3-config"
+  - export PYTHONCONFIG="$PYTHONDIR/bin/python-config"
   - export LD_LIBRARY_PATH="$PYTHONDIR/lib"
   - if [[ $PYTHON_DEBUG_BUILD != 1 ]]; then pytest -n4 mypyc; fi
   - if [[ $PYTHON_DEBUG_BUILD == 1 ]]; then pytest -n4 mypyc/test/test_run.py mypyc/test/test_external.py -k 'not test_self_type_check'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 
 script:
   - export PYTHONPATH=`pwd`/external/mypy
-  - export PYTHONCONFIG="$PYTHONDIR/bin/python-config"
+  - export PYTHONCONFIG="$PYTHONDIR/bin/python3-config"
   - export LD_LIBRARY_PATH="$PYTHONDIR/lib"
   - if [[ $PYTHON_DEBUG_BUILD != 1 ]]; then pytest -n4 mypyc; fi
   - if [[ $PYTHON_DEBUG_BUILD == 1 ]]; then pytest -n4 mypyc/test/test_run.py mypyc/test/test_external.py -k 'not test_self_type_check'; fi


### PR DESCRIPTION
How Python tracks sys.exc_info() objects changed in Python 3.7. We
want to keep peeking directly at the objects to save a bunch of
annoying refcount traffic mandated by the public API, so we just case
on what version we are using.

Also add 3.7-dev to travis. (3.7 isn't there yet??)