### PR TITLE
Fix empty tuple crash

### DIFF
--- a/mypyc/buildc.py
+++ b/mypyc/buildc.py
@@ -84,12 +84,8 @@ from distutils.core import setup, Extension
 from distutils import sysconfig
 import sys
 
-module = Extension('{package_name}',
-                   sources=['{cpath}'],
-                   extra_compile_args=['-Wno-unused-function', '-Wno-unused-label', '-Werror',
-                                       '-Wno-unreachable-code', '-Wno-unused-variable'],
-                   libraries=[{libraries}],
-                   library_dirs=[{library_dirs}])
+extra_compile_args = ['-Werror', '-Wno-unused-function', '-Wno-unused-label',
+                      '-Wno-unreachable-code', '-Wno-unused-variable']
 
 vars = sysconfig.get_config_vars()
 
@@ -103,6 +99,13 @@ if sys.platform == 'darwin':
 # library in the directory that they live in.
 elif sys.platform == 'linux':
     vars['LDSHARED'] += ' -Wl,-rpath,"$ORIGIN"'
+    extra_compile_args += ['-Wno-unused-but-set-variable']
+
+module = Extension('{package_name}',
+                   sources=['{cpath}'],
+                   extra_compile_args=extra_compile_args,
+                   libraries=[{libraries}],
+                   library_dirs=[{library_dirs}])
 
 setup(name='{package_name}',
       version='1.0',

--- a/mypyc/buildc.py
+++ b/mypyc/buildc.py
@@ -87,12 +87,11 @@ import sys
 module = Extension('{package_name}',
                    sources=['{cpath}'],
                    extra_compile_args=['-Wno-unused-function', '-Wno-unused-label', '-Werror',
-                                       '-Wno-unreachable-code', '-Wno-unused-variables'],
+                                       '-Wno-unreachable-code', '-Wno-unused-variable'],
                    libraries=[{libraries}],
                    library_dirs=[{library_dirs}])
 
 vars = sysconfig.get_config_vars()
-
 # On OS X, Force the creation of dynamic libraries instead of bundles so that
 # we can link against multi-module shared libraries.
 # From https://stackoverflow.com/a/32765319

--- a/mypyc/buildc.py
+++ b/mypyc/buildc.py
@@ -92,6 +92,7 @@ module = Extension('{package_name}',
                    library_dirs=[{library_dirs}])
 
 vars = sysconfig.get_config_vars()
+
 # On OS X, Force the creation of dynamic libraries instead of bundles so that
 # we can link against multi-module shared libraries.
 # From https://stackoverflow.com/a/32765319

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -157,9 +157,14 @@ class Emitter:
     def tuple_c_declaration(self, rtuple: RTuple) -> List[str]:
         result = ['struct {} {{'.format(self.tuple_struct_name(rtuple))]
         i = 0
-        for typ in rtuple.types:
-            result.append('    {}f{};'.format(self.ctype_spaced(typ), i))
-            i += 1
+        if len(rtuple.types) == 0:  # empty tuple
+            # The behavior of empty structs in C is compiler dependent so we add a dummy variable
+            # to avoid empty tuples being defined as empty structs.
+            result.append('int dummy_var_to_avoid_empty_struct;')
+        else:
+            for typ in rtuple.types:
+                result.append('    {}f{};'.format(self.ctype_spaced(typ), i))
+                i += 1
         result.append('};')
         result.append('')
 
@@ -445,7 +450,10 @@ class Emitter:
         if not isinstance(rtype, RTuple):
             self.emit_line('if ({} == {}) {{'.format(value, self.c_error_value(rtype)))
         else:
-            self.emit_line('if ({}.f0 == {}) {{'.format(value, self.c_error_value(rtype.types[0])))
+            if len(rtype.types) == 0:
+                return  # empty tuples can't fail.
+            else:
+                self.emit_line('if ({}.f0 == {}) {{'.format(value, self.c_error_value(rtype.types[0])))
         self.emit_lines(failure, '}')
 
     def emit_gc_visit(self, target: str, rtype: RType) -> None:

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -453,7 +453,8 @@ class Emitter:
             if len(rtype.types) == 0:
                 return  # empty tuples can't fail.
             else:
-                self.emit_line('if ({}.f0 == {}) {{'.format(value, self.c_error_value(rtype.types[0])))
+                self.emit_line('if ({}.f0 == {}) {{'.format(value,
+                                                            self.c_error_value(rtype.types[0])))
         self.emit_lines(failure, '}')
 
     def emit_gc_visit(self, target: str, rtype: RType) -> None:

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -156,12 +156,12 @@ class Emitter:
 
     def tuple_c_declaration(self, rtuple: RTuple) -> List[str]:
         result = ['struct {} {{'.format(self.tuple_struct_name(rtuple))]
-        i = 0
         if len(rtuple.types) == 0:  # empty tuple
             # The behavior of empty structs in C is compiler dependent so we add a dummy variable
             # to avoid empty tuples being defined as empty structs.
             result.append('int dummy_var_to_avoid_empty_struct;')
         else:
+            i = 0
             for typ in rtuple.types:
                 result.append('    {}f{};'.format(self.ctype_spaced(typ), i))
                 i += 1

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -151,8 +151,11 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         dest = self.reg(op)
         tuple_type = op.tuple_type
         self.emitter.declare_tuple_struct(tuple_type)
-        for i, item in enumerate(op.items):
-            self.emit_line('{}.f{} = {};'.format(dest, i, self.reg(item)))
+        if len(op.items) == 0:  # empty tuple
+            self.emit_line('{}.dummy_var_to_avoid_empty_struct = 0;'.format(dest))
+        else:
+            for i, item in enumerate(op.items):
+                self.emit_line('{}.f{} = {};'.format(dest, i, self.reg(item)))
         self.emit_inc_ref(dest, tuple_type)
 
     def visit_assign(self, op: Assign) -> None:

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -199,6 +199,14 @@ print(f((1,2)))
 [out]
 (1, 2)
 
+[case testEmptyTupleFunctionWithTupleType]
+from typing import Tuple
+def f() -> Tuple[()]:
+    return ()
+[file driver.py]
+from native import f
+assert f() == ()
+
 [case testTupleGet]
 from typing import Tuple
 def f(x: Tuple[Tuple[int, bool], int]) -> int:

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -207,6 +207,14 @@ def f() -> Tuple[()]:
 from native import f
 assert f() == ()
 
+[case testEmptyTupleFunctionWithAnyType]
+from typing import Any
+def f() -> Any:
+    return ()
+[file driver.py]
+from native import f
+assert f() == ()
+
 [case testTupleGet]
 from typing import Tuple
 def f(x: Tuple[Tuple[int, bool], int]) -> int:


### PR DESCRIPTION
Adds tests for empty tuples and updates flags so build passes on MacOS and Linux. Resolves https://github.com/JukkaL/mypyc/issues/278.