### PR TITLE
Support default arguments when calling native functions

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -585,7 +585,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                       FuncSignature(rt_args, ret_type), blocks, env)
 
     def gen_arg_default(self) -> None:
-        """ Generate blocks for arguments that have default values.
+        """Generate blocks for arguments that have default values.
+
         If the passed value is an error value, then assign the default value to the argument.
         """
         fitem = self.fn_info.fitem
@@ -1345,13 +1346,11 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
     def missing_args_to_error_values(self,
                                      args: List[Optional[Value]],
                                      types: List[Type]) -> List[Value]:
-        """ Generate LoadErrorValues for missing arguments
-        """
+        """Generate LoadErrorValues for missing arguments."""
         ret_args = []  # type: List[Value]
-        for index, reg in enumerate(args):
+        for reg, arg_type in zip(args, types):
             if reg is None:
-                arg_type = self.type_to_rtype(types[index])
-                reg = LoadErrorValue(arg_type)
+                reg = LoadErrorValue(self.type_to_rtype(arg_type))
                 reg.is_borrowed = True
                 self.add(reg)
             ret_args.append(reg)

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -1468,6 +1468,103 @@ L0:
     r6 = None
     return r6
 
+[case testFunctionCallWithDefaultArgs]
+def f(x: int, y: int = 3, z: str = "test") -> None:
+    return None
+def g() -> None:
+    f(2)
+    f(y = 3, x = 6)
+[out]
+def f(x, y, z):
+    x, y :: int
+    z :: str
+    r0 :: int
+    r1 :: str
+    r2 :: None
+L0:
+    if is_error(y) goto L1 else goto L2
+L1:
+    r0 = 3
+    y = r0
+L2:
+    if is_error(z) goto L3 else goto L4
+L3:
+    r1 = unicode_0 :: static  ('test')
+    z = r1
+L4:
+    r2 = None
+    return r2
+def g():
+    r0, r1 :: int
+    r2 :: str
+    r3 :: None
+    r4, r5 :: int
+    r6 :: str
+    r7, r8 :: None
+L0:
+    r0 = 2
+    r1 = <error> :: int
+    r2 = <error> :: str
+    r3 = f(r0, r1, r2)
+    r4 = 3
+    r5 = 6
+    r6 = <error> :: str
+    r7 = f(r5, r4, r6)
+    r8 = None
+    return r8
+
+[case testMethodCallWithDefaultArgs]
+class A:
+    def f(self, x: int, y: int = 3, z: str = "test") -> None:
+        return None
+
+def g() -> None:
+    a = A()
+    a.f(2)
+    a.f(y = 3, x = 6)
+[out]
+def A.f(self, x, y, z):
+    self :: A
+    x, y :: int
+    z :: str
+    r0 :: int
+    r1 :: str
+    r2 :: None
+L0:
+    if is_error(y) goto L1 else goto L2
+L1:
+    r0 = 3
+    y = r0
+L2:
+    if is_error(z) goto L3 else goto L4
+L3:
+    r1 = unicode_0 :: static  ('test')
+    z = r1
+L4:
+    r2 = None
+    return r2
+def g():
+    r0, a :: A
+    r1, r2 :: int
+    r3 :: str
+    r4 :: None
+    r5, r6 :: int
+    r7 :: str
+    r8, r9 :: None
+L0:
+    r0 = A()
+    a = r0
+    r1 = 2
+    r2 = <error> :: int
+    r3 = <error> :: str
+    r4 = a.f(r1, r2, r3)
+    r5 = 3
+    r6 = 6
+    r7 = <error> :: str
+    r8 = a.f(r6, r5, r7)
+    r9 = None
+    return r9
+
 [case testListComprehension]
 from typing import List
 

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -287,6 +287,36 @@ print(f((1,2,3,4)))
 [out]
 2
 
+[case testFunctionCallWithDefaultArgs]
+from typing import Tuple, List
+def f(x: int, y: int = 3, s: str = "test", l: List[int] = []) -> Tuple[int, str]:
+    l.append(x + y)
+    def inner() -> int:
+        return l[-1]
+    return inner(), s
+def g() -> None:
+    assert f(2) == (5, "test")
+    assert f(s = "123", x = -2) == (1, "123")
+[file driver.py]
+from native import g
+g()
+
+[case testMethodCallWithDefaultArgs]
+from typing import Tuple, List
+class A:
+    def f(self, x: int, y: int = 3, s: str = "test", l: List[int] = []) -> Tuple[int, str]:
+        l.append(x + y)
+        def inner() -> int:
+            return l[-1]
+        return inner(), s
+def g() -> None:
+    a = A()
+    assert a.f(2) == (5, "test")
+    assert a.f(s = "123", x = -2) == (1, "123")
+[file driver.py]
+from native import g
+g()
+
 [case testPycall]
 import testmodule
 

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -289,10 +289,9 @@ print(f((1,2,3,4)))
 
 [case testFunctionCallWithDefaultArgs]
 from typing import Tuple, List
-def f(x: int, y: int = 3, s: str = "test", l: List[int] = []) -> Tuple[int, str]:
-    l.append(x + y)
+def f(x: int, y: int = 3, s: str = "test") -> Tuple[int, str]:
     def inner() -> int:
-        return l[-1]
+        return x + y
     return inner(), s
 def g() -> None:
     assert f(2) == (5, "test")
@@ -304,10 +303,9 @@ g()
 [case testMethodCallWithDefaultArgs]
 from typing import Tuple, List
 class A:
-    def f(self, x: int, y: int = 3, s: str = "test", l: List[int] = []) -> Tuple[int, str]:
-        l.append(x + y)
+    def f(self, x: int, y: int = 3, s: str = "test") -> Tuple[int, str]:
         def inner() -> int:
-            return l[-1]
+            return x + y
         return inner(), s
 def g() -> None:
     a = A()


### PR DESCRIPTION
This PR supports calling native functions with default arguments. The caller will pass error value for the missing arguments and the callee will initialize the default values for passed arguments that have error values. But this PR can not make default arguments to be initialized just one for multiple calls.

Try to solve first part of #40