### PR TITLE
Add support for calling functions with star args and star2 args

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1366,10 +1366,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                 and callee.fullname is not None
                 and all(kind in (ARG_POS, ARG_NAMED) for kind in expr.arg_kinds)):
             # Normalize keyword args to positionals.
-            arg_values_with_nones = self.keyword_args_to_positional(arg_values,
-                                                                    expr.arg_kinds,
-                                                                    expr.arg_names,
-                                                                    signature)
+            arg_values_with_nones = self.keyword_args_to_positional(
+                arg_values, expr.arg_kinds, expr.arg_names, signature)
             # Put in errors for missing args, potentially to be filled in with default args later.
             arg_values = self.missing_args_to_error_values(arg_values_with_nones,
                                                            signature.arg_types)
@@ -1482,10 +1480,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                     assert arg_names is not None, "arg_kinds present but arg_names is not"
 
                 # Normalize keyword args to positionals.
-                arg_values_with_nones = self.keyword_args_to_positional(arg_values,
-                                                                        arg_kinds,
-                                                                        arg_names,
-                                                                        signature)
+                arg_values_with_nones = self.keyword_args_to_positional(
+                    arg_values, arg_kinds, arg_names, signature)
                 arg_values = self.missing_args_to_error_values(arg_values_with_nones,
                                                                signature.arg_types)
 

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1235,7 +1235,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             pos_args_list = self.primitive_op(new_list_op, pos_arg_values, line)
             for list_value in star_arg_list_values:
                 # TODO: Write a C-primitive for extend.
-                pos_args_list = self.py_method_call(pos_args_list, 'extend', [list_value], line)
+                self.py_method_call(pos_args_list, 'extend', [list_value], line)
 
             pos_args_tuple = self.primitive_op(list_tuple_op, [pos_args_list], line)
             kw_args_dict = self.make_dict(kw_arg_key_value_pairs, line)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1380,8 +1380,11 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
     def missing_args_to_error_values(self,
                                      args: List[Optional[Value]],
                                      types: List[Type]) -> List[Value]:
-        """Generate LoadErrorValues for missing arguments. These get resolved to default values
-        if they exist for the function in question. See gen_arg_default."""
+        """Generate LoadErrorValues for missing arguments.
+
+        These get resolved to default values if they exist for the function in question. See
+        gen_arg_default.
+        """
         ret_args = []  # type: List[Value]
         for reg, arg_type in zip(args, types):
             if reg is None:

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1264,10 +1264,16 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             else:
                 assert False, ("Argument kind should not be possible:", kind)
 
-        pos_args_list = self.primitive_op(new_list_op, pos_arg_values, line)
-        for star_arg_value in star_arg_values:
-            self.primitive_op(list_extend_op, [pos_args_list, star_arg_value], line)
-        pos_args_tuple = self.primitive_op(list_tuple_op, [pos_args_list], line)
+        if len(star_arg_values) == 0:
+            # We can directly construct a tuple if there are no star args.
+            pos_args_tuple = self.add(TupleSet(pos_arg_values, line))
+        else:
+            # Otherwise we construct a list and call extend it with the star args, since tuples
+            # don't have an extend method.
+            pos_args_list = self.primitive_op(new_list_op, pos_arg_values, line)
+            for star_arg_value in star_arg_values:
+                self.primitive_op(list_extend_op, [pos_args_list, star_arg_value], line)
+            pos_args_tuple = self.primitive_op(list_tuple_op, [pos_args_list], line)
 
         kw_args_dict = self.make_dict(kw_arg_key_value_pairs, line)
         # NOTE: mypy currently only supports a single ** arg, but python supports multiple.

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1264,7 +1264,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                     dict_value = self.py_call(dict_function, [value], line)
                     star2_arg_dict_values.append(dict_value)
                 else:
-                    raise NotImplementedError
+                    assert False, ("Argument kind should not be possible:", kind)
 
             pos_args_list = self.primitive_op(new_list_op, pos_arg_values, line)
             for list_value in star_arg_list_values:

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -61,7 +61,7 @@ from mypyc.ops import (
 )
 from mypyc.ops_primitive import binary_ops, unary_ops, func_ops, method_ops, name_ref_ops
 from mypyc.ops_list import (
-    list_append_op, list_len_op, list_get_item_op, list_set_item_op, new_list_op,
+    list_append_op, list_extend_op, list_len_op, list_get_item_op, list_set_item_op, new_list_op,
 )
 from mypyc.ops_tuple import list_tuple_op
 from mypyc.ops_dict import new_dict_op, dict_get_item_op, dict_set_item_op, dict_update_op
@@ -1246,10 +1246,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
 
             pos_arg_values = []
             kw_arg_key_value_pairs = []
-            star_arg_list_values = []
-            star2_arg_dict_values = []
-            list_function = self.load_module_attr_by_fullname('builtins.list', line)
-            dict_function = self.load_module_attr_by_fullname('builtins.dict', line)
+            star_arg_values = []
+            star2_arg_values = []
             for value, kind, name in zip(arg_values, arg_kinds, arg_names):
                 if kind == ARG_POS:
                     pos_arg_values.append(value)
@@ -1258,25 +1256,22 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                     key = self.load_static_unicode(name)
                     kw_arg_key_value_pairs.append((key, value))
                 elif kind == ARG_STAR:
-                    list_value = self.py_call(list_function, [value], line)
-                    star_arg_list_values.append(list_value)
+                    star_arg_values.append(value)
                 elif kind == ARG_STAR2:
-                    dict_value = self.py_call(dict_function, [value], line)
-                    star2_arg_dict_values.append(dict_value)
+                    star2_arg_values.append(value)
                 else:
                     assert False, ("Argument kind should not be possible:", kind)
 
             pos_args_list = self.primitive_op(new_list_op, pos_arg_values, line)
-            for list_value in star_arg_list_values:
-                # TODO: Write a C-primitive for extend.
-                self.py_method_call(pos_args_list, 'extend', [list_value], line)
+            for star_arg_value in star_arg_values:
+                self.primitive_op(list_extend_op, [pos_args_list, star_arg_value], line)
             pos_args_tuple = self.primitive_op(list_tuple_op, [pos_args_list], line)
 
             kw_args_dict = self.make_dict(kw_arg_key_value_pairs, line)
             # NOTE: mypy currently only supports a single ** arg, but python supports multiple.
             # This code supports multiple primarily to make the logic easier to follow.
-            for dict_value in star2_arg_dict_values:
-                self.primitive_op(dict_update_op, [kw_args_dict, dict_value], line)
+            for star2_arg_value in star2_arg_values:
+                self.primitive_op(dict_update_op, [kw_args_dict, star2_arg_value], line)
 
             return self.primitive_op(py_call_with_kwargs_op,
                                      [function, pos_args_tuple, kw_args_dict],

--- a/mypyc/ops_list.py
+++ b/mypyc/ops_list.py
@@ -51,6 +51,13 @@ list_append_op = method_op(
     error_kind=ERR_FALSE,
     emit=simple_emit('{dest} = PyList_Append({args[0]}, {args[1]}) != -1;'))
 
+list_extend_op = method_op(
+    name='extend',
+    arg_types=[list_rprimitive, object_rprimitive],
+    result_type=object_rprimitive,
+    error_kind=ERR_MAGIC,
+    emit=simple_emit('{dest} = _PyList_Extend((PyListObject *) {args[0]}, {args[1]});'))
+
 
 def emit_multiply_helper(emitter: EmitterInterface, dest: str, lst: str, num: str) -> None:
     temp = emitter.temp_name()

--- a/test-data/fixtures/ir.py
+++ b/test-data/fixtures/ir.py
@@ -3,11 +3,13 @@
 
 from typing import (
     TypeVar, Generic, List, Iterator, Iterable, Sized, Dict, Optional, Tuple, Any,
-    overload,
+    overload, Mapping, Union
 )
 
 T = TypeVar('T')
 S = TypeVar('S')
+K = TypeVar('K') # for keys in mapping
+V = TypeVar('V') # for values in mapping
 
 class object:
     def __init__(self) -> None: pass
@@ -82,15 +84,16 @@ class list(Generic[T], Iterable[T], Sized):
     def insert(self, i: int, x: T) -> None: pass
     def sort(self) -> None: pass
 
-class dict(Generic[T, S]):
-    def __getitem__(self, x: T) -> S: pass
-    def __setitem__(self, x: T, y: S) -> None: pass
-    def __delitem__(self, x: T) -> None: pass
-    def __contains__(self, x: T) -> bool: pass
-    def __iter__(self) -> Iterator[T]: pass
-    def update(self, x: Dict[T, S]) -> None: pass
-    def pop(self, x: int) -> T: pass
-    def keys(self) -> list[T]: pass
+class dict(Mapping[K, V]):
+    def __getitem__(self, key: K) -> V: pass
+    def __setitem__(self, k: K, v: V) -> None: pass
+    def __delitem__(self, k: K) -> None: pass
+    def __contains__(self, item: object) -> bool: pass
+    def __iter__(self) -> Iterator[K]: pass
+    def __len__(self) -> int: pass
+    def update(self, a: Mapping[K, V]) -> None: pass
+    def pop(self, x: int) -> K: pass
+    def keys(self) -> List[K]: pass
 
 class set(Generic[T]):
     def __init__(self, i: Optional[Iterable[T]] = None) -> None: pass

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -1047,78 +1047,98 @@ def call_python_function_with_keyword_arg(x):
     r0 :: int
     r1 :: object
     r2 :: str
-    r3 :: object
-    r4 :: str
-    r5 :: tuple[str]
-    r6 :: dict
-    r7 :: object
-    r8 :: bool
-    r9, r10 :: object
-    r11 :: int
+    r3, r4 :: object
+    r5 :: str
+    r6 :: object
+    r7 :: str
+    r8 :: list
+    r9 :: tuple
+    r10 :: dict
+    r11 :: object
+    r12 :: bool
+    r13 :: object
+    r14 :: int
 L0:
     r0 = 2
     r1 = builtins.module :: static
     r2 = unicode_0 :: static  ('int')
     r3 = getattr r1, r2
-    r4 = unicode_1 :: static  ('base')
-    r5 = (x)
-    r6 = {}
-    r7 = box(int, r0)
-    r8 = r6.__setitem__(r4, r7) :: dict
-    r9 = box(tuple[str], r5)
-    r10 = py_call_with_kwargs(r3, r9, r6)
-    r11 = unbox(int, r10)
-    return r11
+    r4 = builtins.module :: static
+    r5 = unicode_1 :: static  ('list')
+    r6 = getattr r4, r5
+    r7 = unicode_2 :: static  ('base')
+    r8 = [x]
+    r9 = tuple r8 :: list
+    r10 = {}
+    r11 = box(int, r0)
+    r12 = r10.__setitem__(r7, r11) :: dict
+    r13 = py_call_with_kwargs(r3, r9, r10)
+    r14 = unbox(int, r13)
+    return r14
 def call_python_method_with_keyword_args(xs, first, second):
     xs :: list
     first, second, r0 :: int
     r1 :: str
-    r2 :: object
-    r3 :: str
-    r4 :: tuple[int]
-    r5 :: dict
-    r6 :: object
-    r7 :: bool
-    r8, r9 :: object
-    r10 :: None
-    r11 :: int
-    r12 :: str
+    r2, r3 :: object
+    r4 :: str
+    r5 :: object
+    r6 :: str
+    r7 :: object
+    r8 :: list
+    r9 :: tuple
+    r10 :: dict
+    r11 :: object
+    r12 :: bool
     r13 :: object
-    r14, r15 :: str
-    r16 :: tuple[]
-    r17 :: dict
-    r18 :: object
-    r19 :: bool
+    r14 :: None
+    r15 :: int
+    r16 :: str
+    r17, r18 :: object
+    r19 :: str
     r20 :: object
-    r21 :: bool
-    r22, r23 :: object
-    r24 :: None
+    r21, r22 :: str
+    r23 :: list
+    r24 :: tuple
+    r25 :: dict
+    r26 :: object
+    r27 :: bool
+    r28 :: object
+    r29 :: bool
+    r30 :: object
+    r31 :: None
 L0:
     r0 = 0
-    r1 = unicode_2 :: static  ('insert')
+    r1 = unicode_3 :: static  ('insert')
     r2 = getattr xs, r1
-    r3 = unicode_3 :: static  ('x')
-    r4 = (r0)
-    r5 = {}
-    r6 = box(int, first)
-    r7 = r5.__setitem__(r3, r6) :: dict
-    r8 = box(tuple[int], r4)
-    r9 = py_call_with_kwargs(r2, r8, r5)
-    r10 = cast(None, r9)
-    r11 = 1
-    r12 = unicode_2 :: static  ('insert')
-    r13 = getattr xs, r12
-    r14 = unicode_3 :: static  ('x')
-    r15 = unicode_4 :: static  ('i')
-    r16 = ()
-    r17 = {}
-    r18 = box(int, second)
-    r19 = r17.__setitem__(r14, r18) :: dict
-    r20 = box(int, r11)
-    r21 = r17.__setitem__(r15, r20) :: dict
-    r22 = box(tuple[], r16)
-    r23 = py_call_with_kwargs(r13, r22, r17)
-    r24 = cast(None, r23)
+    r3 = builtins.module :: static
+    r4 = unicode_1 :: static  ('list')
+    r5 = getattr r3, r4
+    r6 = unicode_4 :: static  ('x')
+    r7 = box(int, r0)
+    r8 = [r7]
+    r9 = tuple r8 :: list
+    r10 = {}
+    r11 = box(int, first)
+    r12 = r10.__setitem__(r6, r11) :: dict
+    r13 = py_call_with_kwargs(r2, r9, r10)
+    r14 = cast(None, r13)
+    r15 = 1
+    r16 = unicode_3 :: static  ('insert')
+    r17 = getattr xs, r16
+    r18 = builtins.module :: static
+    r19 = unicode_1 :: static  ('list')
+    r20 = getattr r18, r19
+    r21 = unicode_4 :: static  ('x')
+    r22 = unicode_5 :: static  ('i')
+    r23 = []
+    r24 = tuple r23 :: list
+    r25 = {}
+    r26 = box(int, second)
+    r27 = r25.__setitem__(r21, r26) :: dict
+    r28 = box(int, r15)
+    r29 = r25.__setitem__(r22, r28) :: dict
+    r30 = py_call_with_kwargs(r17, r24, r25)
+    r31 = cast(None, r30)
     return xs
 
 [case testObjectAsBoolean]
@@ -1473,9 +1493,89 @@ from typing import Tuple
 def f(a: int, b: int, c: int) -> Tuple[int, int, int]:
     return a, b, c
 def g() -> Tuple[int, int, int]:
-    return f(*[1, 2, 3])
+    return f(*(1, 2, 3))
+def h() -> Tuple[int, int, int]:
+    return f(1, *(2, 3))
 [out]
-nope
+def f(a, b, c):
+    a, b, c :: int
+    r0 :: tuple[int, int, int]
+L0:
+    r0 = (a, b, c)
+    return r0
+def g():
+    r0, r1, r2 :: int
+    r3 :: tuple[int, int, int]
+    r4 :: object
+    r5 :: str
+    r6, r7 :: object
+    r8 :: str
+    r9, r10, r11 :: object
+    r12 :: list
+    r13 :: str
+    r14 :: object
+    r15 :: tuple
+    r16 :: dict
+    r17 :: object
+    r18 :: tuple[int, int, int]
+L0:
+    r0 = 1
+    r1 = 2
+    r2 = 3
+    r3 = (r0, r1, r2)
+    r4 = __main__.globals :: static
+    r5 = unicode_0 :: static  ('f')
+    r6 = r4[r5] :: dict
+    r7 = builtins.module :: static
+    r8 = unicode_1 :: static  ('list')
+    r9 = getattr r7, r8
+    r10 = box(tuple[int, int, int], r3)
+    r11 = py_call(r9, r10)
+    r12 = []
+    r13 = unicode_2 :: static  ('extend')
+    r14 = py_method_call(r12, r13, r11)
+    r15 = tuple r12 :: list
+    r16 = {}
+    r17 = py_call_with_kwargs(r6, r15, r16)
+    r18 = unbox(tuple[int, int, int], r17)
+    return r18
+def h():
+    r0, r1, r2 :: int
+    r3 :: tuple[int, int]
+    r4 :: object
+    r5 :: str
+    r6, r7 :: object
+    r8 :: str
+    r9, r10, r11, r12 :: object
+    r13 :: list
+    r14 :: str
+    r15 :: object
+    r16 :: tuple
+    r17 :: dict
+    r18 :: object
+    r19 :: tuple[int, int, int]
+L0:
+    r0 = 1
+    r1 = 2
+    r2 = 3
+    r3 = (r1, r2)
+    r4 = __main__.globals :: static
+    r5 = unicode_0 :: static  ('f')
+    r6 = r4[r5] :: dict
+    r7 = builtins.module :: static
+    r8 = unicode_1 :: static  ('list')
+    r9 = getattr r7, r8
+    r10 = box(tuple[int, int], r3)
+    r11 = py_call(r9, r10)
+    r12 = box(int, r0)
+    r13 = [r12]
+    r14 = unicode_2 :: static  ('extend')
+    r15 = py_method_call(r13, r14, r11)
+    r16 = tuple r13 :: list
+    r17 = {}
+    r18 = py_call_with_kwargs(r6, r16, r17)
+    r19 = unbox(tuple[int, int, int], r18)
+    return r19
 
 [case testListComprehension]
 from typing import List

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -1049,12 +1049,11 @@ def call_python_function_with_keyword_arg(x):
     r2 :: str
     r3 :: object
     r4 :: str
-    r5 :: list
-    r6 :: tuple
-    r7 :: dict
-    r8 :: object
-    r9 :: bool
-    r10 :: object
+    r5 :: tuple[str]
+    r6 :: dict
+    r7 :: object
+    r8 :: bool
+    r9, r10 :: object
     r11 :: int
 L0:
     r0 = 2
@@ -1062,12 +1061,12 @@ L0:
     r2 = unicode_0 :: static  ('int')
     r3 = getattr r1, r2
     r4 = unicode_1 :: static  ('base')
-    r5 = [x]
-    r6 = tuple r5 :: list
-    r7 = {}
-    r8 = box(int, r0)
-    r9 = r7.__setitem__(r4, r8) :: dict
-    r10 = py_call_with_kwargs(r3, r6, r7)
+    r5 = (x)
+    r6 = {}
+    r7 = box(int, r0)
+    r8 = r6.__setitem__(r4, r7) :: dict
+    r9 = box(tuple[str], r5)
+    r10 = py_call_with_kwargs(r3, r9, r6)
     r11 = unbox(int, r10)
     return r11
 def call_python_method_with_keyword_args(xs, first, second):
@@ -1076,54 +1075,50 @@ def call_python_method_with_keyword_args(xs, first, second):
     r1 :: str
     r2 :: object
     r3 :: str
-    r4 :: object
-    r5 :: list
-    r6 :: tuple
-    r7 :: dict
-    r8 :: object
-    r9 :: bool
-    r10 :: object
-    r11 :: None
-    r12 :: int
-    r13 :: str
-    r14 :: object
-    r15, r16 :: str
-    r17 :: list
-    r18 :: tuple
-    r19 :: dict
+    r4 :: tuple[int]
+    r5 :: dict
+    r6 :: object
+    r7 :: bool
+    r8, r9 :: object
+    r10 :: None
+    r11 :: int
+    r12 :: str
+    r13 :: object
+    r14, r15 :: str
+    r16 :: tuple[]
+    r17 :: dict
+    r18 :: object
+    r19 :: bool
     r20 :: object
     r21 :: bool
-    r22 :: object
-    r23 :: bool
-    r24 :: object
-    r25 :: None
+    r22, r23 :: object
+    r24 :: None
 L0:
     r0 = 0
     r1 = unicode_2 :: static  ('insert')
     r2 = getattr xs, r1
     r3 = unicode_3 :: static  ('x')
-    r4 = box(int, r0)
-    r5 = [r4]
-    r6 = tuple r5 :: list
-    r7 = {}
-    r8 = box(int, first)
-    r9 = r7.__setitem__(r3, r8) :: dict
-    r10 = py_call_with_kwargs(r2, r6, r7)
-    r11 = cast(None, r10)
-    r12 = 1
-    r13 = unicode_2 :: static  ('insert')
-    r14 = getattr xs, r13
-    r15 = unicode_3 :: static  ('x')
-    r16 = unicode_4 :: static  ('i')
-    r17 = []
-    r18 = tuple r17 :: list
-    r19 = {}
-    r20 = box(int, second)
-    r21 = r19.__setitem__(r15, r20) :: dict
-    r22 = box(int, r12)
-    r23 = r19.__setitem__(r16, r22) :: dict
-    r24 = py_call_with_kwargs(r14, r18, r19)
-    r25 = cast(None, r24)
+    r4 = (r0)
+    r5 = {}
+    r6 = box(int, first)
+    r7 = r5.__setitem__(r3, r6) :: dict
+    r8 = box(tuple[int], r4)
+    r9 = py_call_with_kwargs(r2, r8, r5)
+    r10 = cast(None, r9)
+    r11 = 1
+    r12 = unicode_2 :: static  ('insert')
+    r13 = getattr xs, r12
+    r14 = unicode_3 :: static  ('x')
+    r15 = unicode_4 :: static  ('i')
+    r16 = ()
+    r17 = {}
+    r18 = box(int, second)
+    r19 = r17.__setitem__(r14, r18) :: dict
+    r20 = box(int, r11)
+    r21 = r17.__setitem__(r15, r20) :: dict
+    r22 = box(tuple[], r16)
+    r23 = py_call_with_kwargs(r13, r22, r17)
+    r24 = cast(None, r23)
     return xs
 
 [case testObjectAsBoolean]
@@ -1578,11 +1573,10 @@ def g():
     r13 :: object
     r14 :: str
     r15 :: object
-    r16 :: list
-    r17 :: tuple
-    r18 :: dict
-    r19 :: bool
-    r20 :: object
+    r16 :: tuple[]
+    r17 :: dict
+    r18 :: bool
+    r19, r20 :: object
     r21 :: tuple[int, int, int]
 L0:
     r0 = unicode_0 :: static  ('a')
@@ -1601,11 +1595,11 @@ L0:
     r13 = __main__.globals :: static
     r14 = unicode_3 :: static  ('f')
     r15 = r13[r14] :: dict
-    r16 = []
-    r17 = tuple r16 :: list
-    r18 = {}
-    r19 = r18.update(r6) :: dict
-    r20 = py_call_with_kwargs(r15, r17, r18)
+    r16 = ()
+    r17 = {}
+    r18 = r17.update(r6) :: dict
+    r19 = box(tuple[], r16)
+    r20 = py_call_with_kwargs(r15, r19, r17)
     r21 = unbox(tuple[int, int, int], r20)
     return r21
 def h():
@@ -1621,13 +1615,12 @@ def h():
     r9 :: bool
     r10 :: object
     r11 :: str
-    r12, r13 :: object
-    r14 :: list
-    r15 :: tuple
-    r16 :: dict
-    r17 :: bool
-    r18 :: object
-    r19 :: tuple[int, int, int]
+    r12 :: object
+    r13 :: tuple[int]
+    r14 :: dict
+    r15 :: bool
+    r16, r17 :: object
+    r18 :: tuple[int, int, int]
 L0:
     r0 = 1
     r1 = unicode_1 :: static  ('b')
@@ -1642,14 +1635,13 @@ L0:
     r10 = __main__.globals :: static
     r11 = unicode_3 :: static  ('f')
     r12 = r10[r11] :: dict
-    r13 = box(int, r0)
-    r14 = [r13]
-    r15 = tuple r14 :: list
-    r16 = {}
-    r17 = r16.update(r5) :: dict
-    r18 = py_call_with_kwargs(r12, r15, r16)
-    r19 = unbox(tuple[int, int, int], r18)
-    return r19
+    r13 = (r0)
+    r14 = {}
+    r15 = r14.update(r5) :: dict
+    r16 = box(tuple[int], r13)
+    r17 = py_call_with_kwargs(r12, r16, r14)
+    r18 = unbox(tuple[int, int, int], r17)
+    return r18
 
 [case testFunctionCallWithDefaultArgs]
 def f(x: int, y: int = 3, z: str = "test") -> None:

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -1047,113 +1047,83 @@ def call_python_function_with_keyword_arg(x):
     r0 :: int
     r1 :: object
     r2 :: str
-    r3, r4 :: object
-    r5 :: str
-    r6, r7 :: object
-    r8 :: str
-    r9 :: object
-    r10 :: str
-    r11 :: list
-    r12 :: tuple
-    r13 :: dict
-    r14 :: object
-    r15 :: bool
-    r16 :: object
-    r17 :: int
+    r3 :: object
+    r4 :: str
+    r5 :: list
+    r6 :: tuple
+    r7 :: dict
+    r8 :: object
+    r9 :: bool
+    r10 :: object
+    r11 :: int
 L0:
     r0 = 2
     r1 = builtins.module :: static
     r2 = unicode_0 :: static  ('int')
     r3 = getattr r1, r2
-    r4 = builtins.module :: static
-    r5 = unicode_1 :: static  ('list')
-    r6 = getattr r4, r5
-    r7 = builtins.module :: static
-    r8 = unicode_2 :: static  ('dict')
-    r9 = getattr r7, r8
-    r10 = unicode_3 :: static  ('base')
-    r11 = [x]
-    r12 = tuple r11 :: list
-    r13 = {}
-    r14 = box(int, r0)
-    r15 = r13.__setitem__(r10, r14) :: dict
-    r16 = py_call_with_kwargs(r3, r12, r13)
-    r17 = unbox(int, r16)
-    return r17
+    r4 = unicode_1 :: static  ('base')
+    r5 = [x]
+    r6 = tuple r5 :: list
+    r7 = {}
+    r8 = box(int, r0)
+    r9 = r7.__setitem__(r4, r8) :: dict
+    r10 = py_call_with_kwargs(r3, r6, r7)
+    r11 = unbox(int, r10)
+    return r11
 def call_python_method_with_keyword_args(xs, first, second):
     xs :: list
     first, second, r0 :: int
     r1 :: str
-    r2, r3 :: object
-    r4 :: str
-    r5, r6 :: object
-    r7 :: str
+    r2 :: object
+    r3 :: str
+    r4 :: object
+    r5 :: list
+    r6 :: tuple
+    r7 :: dict
     r8 :: object
-    r9 :: str
+    r9 :: bool
     r10 :: object
-    r11 :: list
-    r12 :: tuple
-    r13 :: dict
+    r11 :: None
+    r12 :: int
+    r13 :: str
     r14 :: object
-    r15 :: bool
-    r16 :: object
-    r17 :: None
-    r18 :: int
-    r19 :: str
-    r20, r21 :: object
-    r22 :: str
-    r23, r24 :: object
-    r25 :: str
-    r26 :: object
-    r27, r28 :: str
-    r29 :: list
-    r30 :: tuple
-    r31 :: dict
-    r32 :: object
-    r33 :: bool
-    r34 :: object
-    r35 :: bool
-    r36 :: object
-    r37 :: None
+    r15, r16 :: str
+    r17 :: list
+    r18 :: tuple
+    r19 :: dict
+    r20 :: object
+    r21 :: bool
+    r22 :: object
+    r23 :: bool
+    r24 :: object
+    r25 :: None
 L0:
     r0 = 0
-    r1 = unicode_4 :: static  ('insert')
+    r1 = unicode_2 :: static  ('insert')
     r2 = getattr xs, r1
-    r3 = builtins.module :: static
-    r4 = unicode_1 :: static  ('list')
-    r5 = getattr r3, r4
-    r6 = builtins.module :: static
-    r7 = unicode_2 :: static  ('dict')
-    r8 = getattr r6, r7
-    r9 = unicode_5 :: static  ('x')
-    r10 = box(int, r0)
-    r11 = [r10]
-    r12 = tuple r11 :: list
-    r13 = {}
-    r14 = box(int, first)
-    r15 = r13.__setitem__(r9, r14) :: dict
-    r16 = py_call_with_kwargs(r2, r12, r13)
-    r17 = cast(None, r16)
-    r18 = 1
-    r19 = unicode_4 :: static  ('insert')
-    r20 = getattr xs, r19
-    r21 = builtins.module :: static
-    r22 = unicode_1 :: static  ('list')
-    r23 = getattr r21, r22
-    r24 = builtins.module :: static
-    r25 = unicode_2 :: static  ('dict')
-    r26 = getattr r24, r25
-    r27 = unicode_5 :: static  ('x')
-    r28 = unicode_6 :: static  ('i')
-    r29 = []
-    r30 = tuple r29 :: list
-    r31 = {}
-    r32 = box(int, second)
-    r33 = r31.__setitem__(r27, r32) :: dict
-    r34 = box(int, r18)
-    r35 = r31.__setitem__(r28, r34) :: dict
-    r36 = py_call_with_kwargs(r20, r30, r31)
-    r37 = cast(None, r36)
+    r3 = unicode_3 :: static  ('x')
+    r4 = box(int, r0)
+    r5 = [r4]
+    r6 = tuple r5 :: list
+    r7 = {}
+    r8 = box(int, first)
+    r9 = r7.__setitem__(r3, r8) :: dict
+    r10 = py_call_with_kwargs(r2, r6, r7)
+    r11 = cast(None, r10)
+    r12 = 1
+    r13 = unicode_2 :: static  ('insert')
+    r14 = getattr xs, r13
+    r15 = unicode_3 :: static  ('x')
+    r16 = unicode_4 :: static  ('i')
+    r17 = []
+    r18 = tuple r17 :: list
+    r19 = {}
+    r20 = box(int, second)
+    r21 = r19.__setitem__(r15, r20) :: dict
+    r22 = box(int, r12)
+    r23 = r19.__setitem__(r16, r22) :: dict
+    r24 = py_call_with_kwargs(r14, r18, r19)
+    r25 = cast(None, r24)
     return xs
 
 [case testObjectAsBoolean]
@@ -1523,18 +1493,13 @@ def g():
     r3 :: tuple[int, int, int]
     r4 :: object
     r5 :: str
-    r6, r7 :: object
-    r8 :: str
-    r9, r10 :: object
-    r11 :: str
-    r12, r13, r14 :: object
-    r15 :: list
-    r16 :: str
-    r17 :: object
-    r18 :: tuple
-    r19 :: dict
-    r20 :: object
-    r21 :: tuple[int, int, int]
+    r6 :: object
+    r7 :: list
+    r8, r9 :: object
+    r10 :: tuple
+    r11 :: dict
+    r12 :: object
+    r13 :: tuple[int, int, int]
 L0:
     r0 = 1
     r1 = 2
@@ -1543,39 +1508,26 @@ L0:
     r4 = __main__.globals :: static
     r5 = unicode_0 :: static  ('f')
     r6 = r4[r5] :: dict
-    r7 = builtins.module :: static
-    r8 = unicode_1 :: static  ('list')
-    r9 = getattr r7, r8
-    r10 = builtins.module :: static
-    r11 = unicode_2 :: static  ('dict')
-    r12 = getattr r10, r11
-    r13 = box(tuple[int, int, int], r3)
-    r14 = py_call(r9, r13)
-    r15 = []
-    r16 = unicode_3 :: static  ('extend')
-    r17 = py_method_call(r15, r16, r14)
-    r18 = tuple r15 :: list
-    r19 = {}
-    r20 = py_call_with_kwargs(r6, r18, r19)
-    r21 = unbox(tuple[int, int, int], r20)
-    return r21
+    r7 = []
+    r8 = box(tuple[int, int, int], r3)
+    r9 = r7.extend(r8) :: list
+    r10 = tuple r7 :: list
+    r11 = {}
+    r12 = py_call_with_kwargs(r6, r10, r11)
+    r13 = unbox(tuple[int, int, int], r12)
+    return r13
 def h():
     r0, r1, r2 :: int
     r3 :: tuple[int, int]
     r4 :: object
     r5 :: str
     r6, r7 :: object
-    r8 :: str
+    r8 :: list
     r9, r10 :: object
-    r11 :: str
-    r12, r13, r14, r15 :: object
-    r16 :: list
-    r17 :: str
-    r18 :: object
-    r19 :: tuple
-    r20 :: dict
-    r21 :: object
-    r22 :: tuple[int, int, int]
+    r11 :: tuple
+    r12 :: dict
+    r13 :: object
+    r14 :: tuple[int, int, int]
 L0:
     r0 = 1
     r1 = 2
@@ -1584,23 +1536,15 @@ L0:
     r4 = __main__.globals :: static
     r5 = unicode_0 :: static  ('f')
     r6 = r4[r5] :: dict
-    r7 = builtins.module :: static
-    r8 = unicode_1 :: static  ('list')
-    r9 = getattr r7, r8
-    r10 = builtins.module :: static
-    r11 = unicode_2 :: static  ('dict')
-    r12 = getattr r10, r11
-    r13 = box(tuple[int, int], r3)
-    r14 = py_call(r9, r13)
-    r15 = box(int, r0)
-    r16 = [r15]
-    r17 = unicode_3 :: static  ('extend')
-    r18 = py_method_call(r16, r17, r14)
-    r19 = tuple r16 :: list
-    r20 = {}
-    r21 = py_call_with_kwargs(r6, r19, r20)
-    r22 = unbox(tuple[int, int, int], r21)
-    return r22
+    r7 = box(int, r0)
+    r8 = [r7]
+    r9 = box(tuple[int, int], r3)
+    r10 = r8.extend(r9) :: list
+    r11 = tuple r8 :: list
+    r12 = {}
+    r13 = py_call_with_kwargs(r6, r11, r12)
+    r14 = unbox(tuple[int, int, int], r13)
+    return r14
 
 [case testStar2Args]
 from typing import Tuple
@@ -1633,17 +1577,13 @@ def g():
     r12 :: bool
     r13 :: object
     r14 :: str
-    r15, r16 :: object
-    r17 :: str
-    r18, r19 :: object
-    r20 :: str
-    r21, r22 :: object
-    r23 :: list
-    r24 :: tuple
-    r25 :: dict
-    r26 :: bool
-    r27 :: object
-    r28 :: tuple[int, int, int]
+    r15 :: object
+    r16 :: list
+    r17 :: tuple
+    r18 :: dict
+    r19 :: bool
+    r20 :: object
+    r21 :: tuple[int, int, int]
 L0:
     r0 = unicode_0 :: static  ('a')
     r1 = 1
@@ -1661,20 +1601,13 @@ L0:
     r13 = __main__.globals :: static
     r14 = unicode_3 :: static  ('f')
     r15 = r13[r14] :: dict
-    r16 = builtins.module :: static
-    r17 = unicode_4 :: static  ('list')
-    r18 = getattr r16, r17
-    r19 = builtins.module :: static
-    r20 = unicode_5 :: static  ('dict')
-    r21 = getattr r19, r20
-    r22 = py_call(r21, r6)
-    r23 = []
-    r24 = tuple r23 :: list
-    r25 = {}
-    r26 = r25.update(r22) :: dict
-    r27 = py_call_with_kwargs(r15, r24, r25)
-    r28 = unbox(tuple[int, int, int], r27)
-    return r28
+    r16 = []
+    r17 = tuple r16 :: list
+    r18 = {}
+    r19 = r18.update(r6) :: dict
+    r20 = py_call_with_kwargs(r15, r17, r18)
+    r21 = unbox(tuple[int, int, int], r20)
+    return r21
 def h():
     r0 :: int
     r1 :: str
@@ -1689,16 +1622,12 @@ def h():
     r10 :: object
     r11 :: str
     r12, r13 :: object
-    r14 :: str
-    r15, r16 :: object
-    r17 :: str
-    r18, r19, r20 :: object
-    r21 :: list
-    r22 :: tuple
-    r23 :: dict
-    r24 :: bool
-    r25 :: object
-    r26 :: tuple[int, int, int]
+    r14 :: list
+    r15 :: tuple
+    r16 :: dict
+    r17 :: bool
+    r18 :: object
+    r19 :: tuple[int, int, int]
 L0:
     r0 = 1
     r1 = unicode_1 :: static  ('b')
@@ -1713,21 +1642,14 @@ L0:
     r10 = __main__.globals :: static
     r11 = unicode_3 :: static  ('f')
     r12 = r10[r11] :: dict
-    r13 = builtins.module :: static
-    r14 = unicode_4 :: static  ('list')
-    r15 = getattr r13, r14
-    r16 = builtins.module :: static
-    r17 = unicode_5 :: static  ('dict')
-    r18 = getattr r16, r17
-    r19 = py_call(r18, r5)
-    r20 = box(int, r0)
-    r21 = [r20]
-    r22 = tuple r21 :: list
-    r23 = {}
-    r24 = r23.update(r19) :: dict
-    r25 = py_call_with_kwargs(r12, r22, r23)
-    r26 = unbox(tuple[int, int, int], r25)
-    return r26
+    r13 = box(int, r0)
+    r14 = [r13]
+    r15 = tuple r14 :: list
+    r16 = {}
+    r17 = r16.update(r5) :: dict
+    r18 = py_call_with_kwargs(r12, r15, r16)
+    r19 = unbox(tuple[int, int, int], r18)
+    return r19
 
 [case testFunctionCallWithDefaultArgs]
 def f(x: int, y: int = 3, z: str = "test") -> None:

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -1468,6 +1468,15 @@ L0:
     r6 = None
     return r6
 
+[case testStarArgs]
+from typing import Tuple
+def f(a: int, b: int, c: int) -> Tuple[int, int, int]:
+    return a, b, c
+def g() -> Tuple[int, int, int]:
+    return f(*[1, 2, 3])
+[out]
+nope
+
 [case testListComprehension]
 from typing import List
 

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -1049,15 +1049,17 @@ def call_python_function_with_keyword_arg(x):
     r2 :: str
     r3, r4 :: object
     r5 :: str
-    r6 :: object
-    r7 :: str
-    r8 :: list
-    r9 :: tuple
-    r10 :: dict
-    r11 :: object
-    r12 :: bool
-    r13 :: object
-    r14 :: int
+    r6, r7 :: object
+    r8 :: str
+    r9 :: object
+    r10 :: str
+    r11 :: list
+    r12 :: tuple
+    r13 :: dict
+    r14 :: object
+    r15 :: bool
+    r16 :: object
+    r17 :: int
 L0:
     r0 = 2
     r1 = builtins.module :: static
@@ -1066,79 +1068,92 @@ L0:
     r4 = builtins.module :: static
     r5 = unicode_1 :: static  ('list')
     r6 = getattr r4, r5
-    r7 = unicode_2 :: static  ('base')
-    r8 = [x]
-    r9 = tuple r8 :: list
-    r10 = {}
-    r11 = box(int, r0)
-    r12 = r10.__setitem__(r7, r11) :: dict
-    r13 = py_call_with_kwargs(r3, r9, r10)
-    r14 = unbox(int, r13)
-    return r14
+    r7 = builtins.module :: static
+    r8 = unicode_2 :: static  ('dict')
+    r9 = getattr r7, r8
+    r10 = unicode_3 :: static  ('base')
+    r11 = [x]
+    r12 = tuple r11 :: list
+    r13 = {}
+    r14 = box(int, r0)
+    r15 = r13.__setitem__(r10, r14) :: dict
+    r16 = py_call_with_kwargs(r3, r12, r13)
+    r17 = unbox(int, r16)
+    return r17
 def call_python_method_with_keyword_args(xs, first, second):
     xs :: list
     first, second, r0 :: int
     r1 :: str
     r2, r3 :: object
     r4 :: str
-    r5 :: object
-    r6 :: str
-    r7 :: object
-    r8 :: list
-    r9 :: tuple
-    r10 :: dict
-    r11 :: object
-    r12 :: bool
-    r13 :: object
-    r14 :: None
-    r15 :: int
-    r16 :: str
-    r17, r18 :: object
+    r5, r6 :: object
+    r7 :: str
+    r8 :: object
+    r9 :: str
+    r10 :: object
+    r11 :: list
+    r12 :: tuple
+    r13 :: dict
+    r14 :: object
+    r15 :: bool
+    r16 :: object
+    r17 :: None
+    r18 :: int
     r19 :: str
-    r20 :: object
-    r21, r22 :: str
-    r23 :: list
-    r24 :: tuple
-    r25 :: dict
+    r20, r21 :: object
+    r22 :: str
+    r23, r24 :: object
+    r25 :: str
     r26 :: object
-    r27 :: bool
-    r28 :: object
-    r29 :: bool
-    r30 :: object
-    r31 :: None
+    r27, r28 :: str
+    r29 :: list
+    r30 :: tuple
+    r31 :: dict
+    r32 :: object
+    r33 :: bool
+    r34 :: object
+    r35 :: bool
+    r36 :: object
+    r37 :: None
 L0:
     r0 = 0
-    r1 = unicode_3 :: static  ('insert')
+    r1 = unicode_4 :: static  ('insert')
     r2 = getattr xs, r1
     r3 = builtins.module :: static
     r4 = unicode_1 :: static  ('list')
     r5 = getattr r3, r4
-    r6 = unicode_4 :: static  ('x')
-    r7 = box(int, r0)
-    r8 = [r7]
-    r9 = tuple r8 :: list
-    r10 = {}
-    r11 = box(int, first)
-    r12 = r10.__setitem__(r6, r11) :: dict
-    r13 = py_call_with_kwargs(r2, r9, r10)
-    r14 = cast(None, r13)
-    r15 = 1
-    r16 = unicode_3 :: static  ('insert')
-    r17 = getattr xs, r16
-    r18 = builtins.module :: static
-    r19 = unicode_1 :: static  ('list')
-    r20 = getattr r18, r19
-    r21 = unicode_4 :: static  ('x')
-    r22 = unicode_5 :: static  ('i')
-    r23 = []
-    r24 = tuple r23 :: list
-    r25 = {}
-    r26 = box(int, second)
-    r27 = r25.__setitem__(r21, r26) :: dict
-    r28 = box(int, r15)
-    r29 = r25.__setitem__(r22, r28) :: dict
-    r30 = py_call_with_kwargs(r17, r24, r25)
-    r31 = cast(None, r30)
+    r6 = builtins.module :: static
+    r7 = unicode_2 :: static  ('dict')
+    r8 = getattr r6, r7
+    r9 = unicode_5 :: static  ('x')
+    r10 = box(int, r0)
+    r11 = [r10]
+    r12 = tuple r11 :: list
+    r13 = {}
+    r14 = box(int, first)
+    r15 = r13.__setitem__(r9, r14) :: dict
+    r16 = py_call_with_kwargs(r2, r12, r13)
+    r17 = cast(None, r16)
+    r18 = 1
+    r19 = unicode_4 :: static  ('insert')
+    r20 = getattr xs, r19
+    r21 = builtins.module :: static
+    r22 = unicode_1 :: static  ('list')
+    r23 = getattr r21, r22
+    r24 = builtins.module :: static
+    r25 = unicode_2 :: static  ('dict')
+    r26 = getattr r24, r25
+    r27 = unicode_5 :: static  ('x')
+    r28 = unicode_6 :: static  ('i')
+    r29 = []
+    r30 = tuple r29 :: list
+    r31 = {}
+    r32 = box(int, second)
+    r33 = r31.__setitem__(r27, r32) :: dict
+    r34 = box(int, r18)
+    r35 = r31.__setitem__(r28, r34) :: dict
+    r36 = py_call_with_kwargs(r20, r30, r31)
+    r37 = cast(None, r36)
     return xs
 
 [case testObjectAsBoolean]
@@ -1510,14 +1525,16 @@ def g():
     r5 :: str
     r6, r7 :: object
     r8 :: str
-    r9, r10, r11 :: object
-    r12 :: list
-    r13 :: str
-    r14 :: object
-    r15 :: tuple
-    r16 :: dict
+    r9, r10 :: object
+    r11 :: str
+    r12, r13, r14 :: object
+    r15 :: list
+    r16 :: str
     r17 :: object
-    r18 :: tuple[int, int, int]
+    r18 :: tuple
+    r19 :: dict
+    r20 :: object
+    r21 :: tuple[int, int, int]
 L0:
     r0 = 1
     r1 = 2
@@ -1529,16 +1546,19 @@ L0:
     r7 = builtins.module :: static
     r8 = unicode_1 :: static  ('list')
     r9 = getattr r7, r8
-    r10 = box(tuple[int, int, int], r3)
-    r11 = py_call(r9, r10)
-    r12 = []
-    r13 = unicode_2 :: static  ('extend')
-    r14 = py_method_call(r12, r13, r11)
-    r15 = tuple r12 :: list
-    r16 = {}
-    r17 = py_call_with_kwargs(r6, r15, r16)
-    r18 = unbox(tuple[int, int, int], r17)
-    return r18
+    r10 = builtins.module :: static
+    r11 = unicode_2 :: static  ('dict')
+    r12 = getattr r10, r11
+    r13 = box(tuple[int, int, int], r3)
+    r14 = py_call(r9, r13)
+    r15 = []
+    r16 = unicode_3 :: static  ('extend')
+    r17 = py_method_call(r15, r16, r14)
+    r18 = tuple r15 :: list
+    r19 = {}
+    r20 = py_call_with_kwargs(r6, r18, r19)
+    r21 = unbox(tuple[int, int, int], r20)
+    return r21
 def h():
     r0, r1, r2 :: int
     r3 :: tuple[int, int]
@@ -1546,14 +1566,16 @@ def h():
     r5 :: str
     r6, r7 :: object
     r8 :: str
-    r9, r10, r11, r12 :: object
-    r13 :: list
-    r14 :: str
-    r15 :: object
-    r16 :: tuple
-    r17 :: dict
+    r9, r10 :: object
+    r11 :: str
+    r12, r13, r14, r15 :: object
+    r16 :: list
+    r17 :: str
     r18 :: object
-    r19 :: tuple[int, int, int]
+    r19 :: tuple
+    r20 :: dict
+    r21 :: object
+    r22 :: tuple[int, int, int]
 L0:
     r0 = 1
     r1 = 2
@@ -1565,17 +1587,147 @@ L0:
     r7 = builtins.module :: static
     r8 = unicode_1 :: static  ('list')
     r9 = getattr r7, r8
-    r10 = box(tuple[int, int], r3)
-    r11 = py_call(r9, r10)
-    r12 = box(int, r0)
-    r13 = [r12]
-    r14 = unicode_2 :: static  ('extend')
-    r15 = py_method_call(r13, r14, r11)
-    r16 = tuple r13 :: list
-    r17 = {}
-    r18 = py_call_with_kwargs(r6, r16, r17)
-    r19 = unbox(tuple[int, int, int], r18)
-    return r19
+    r10 = builtins.module :: static
+    r11 = unicode_2 :: static  ('dict')
+    r12 = getattr r10, r11
+    r13 = box(tuple[int, int], r3)
+    r14 = py_call(r9, r13)
+    r15 = box(int, r0)
+    r16 = [r15]
+    r17 = unicode_3 :: static  ('extend')
+    r18 = py_method_call(r16, r17, r14)
+    r19 = tuple r16 :: list
+    r20 = {}
+    r21 = py_call_with_kwargs(r6, r19, r20)
+    r22 = unbox(tuple[int, int, int], r21)
+    return r22
+
+[case testStar2Args]
+from typing import Tuple
+def f(a: int, b: int, c: int) -> Tuple[int, int, int]:
+    return a, b, c
+def g() -> Tuple[int, int, int]:
+    return f(**{'a': 1, 'b': 2, 'c': 3})
+def h() -> Tuple[int, int, int]:
+    return f(1, **{'b': 2, 'c': 3})
+[out]
+def f(a, b, c):
+    a, b, c :: int
+    r0 :: tuple[int, int, int]
+L0:
+    r0 = (a, b, c)
+    return r0
+def g():
+    r0 :: str
+    r1 :: int
+    r2 :: str
+    r3 :: int
+    r4 :: str
+    r5 :: int
+    r6 :: dict
+    r7 :: object
+    r8 :: bool
+    r9 :: object
+    r10 :: bool
+    r11 :: object
+    r12 :: bool
+    r13 :: object
+    r14 :: str
+    r15, r16 :: object
+    r17 :: str
+    r18, r19 :: object
+    r20 :: str
+    r21, r22 :: object
+    r23 :: list
+    r24 :: tuple
+    r25 :: dict
+    r26 :: bool
+    r27 :: object
+    r28 :: tuple[int, int, int]
+L0:
+    r0 = unicode_0 :: static  ('a')
+    r1 = 1
+    r2 = unicode_1 :: static  ('b')
+    r3 = 2
+    r4 = unicode_2 :: static  ('c')
+    r5 = 3
+    r6 = {}
+    r7 = box(int, r1)
+    r8 = r6.__setitem__(r0, r7) :: dict
+    r9 = box(int, r3)
+    r10 = r6.__setitem__(r2, r9) :: dict
+    r11 = box(int, r5)
+    r12 = r6.__setitem__(r4, r11) :: dict
+    r13 = __main__.globals :: static
+    r14 = unicode_3 :: static  ('f')
+    r15 = r13[r14] :: dict
+    r16 = builtins.module :: static
+    r17 = unicode_4 :: static  ('list')
+    r18 = getattr r16, r17
+    r19 = builtins.module :: static
+    r20 = unicode_5 :: static  ('dict')
+    r21 = getattr r19, r20
+    r22 = py_call(r21, r6)
+    r23 = []
+    r24 = tuple r23 :: list
+    r25 = {}
+    r26 = r25.update(r22) :: dict
+    r27 = py_call_with_kwargs(r15, r24, r25)
+    r28 = unbox(tuple[int, int, int], r27)
+    return r28
+def h():
+    r0 :: int
+    r1 :: str
+    r2 :: int
+    r3 :: str
+    r4 :: int
+    r5 :: dict
+    r6 :: object
+    r7 :: bool
+    r8 :: object
+    r9 :: bool
+    r10 :: object
+    r11 :: str
+    r12, r13 :: object
+    r14 :: str
+    r15, r16 :: object
+    r17 :: str
+    r18, r19, r20 :: object
+    r21 :: list
+    r22 :: tuple
+    r23 :: dict
+    r24 :: bool
+    r25 :: object
+    r26 :: tuple[int, int, int]
+L0:
+    r0 = 1
+    r1 = unicode_1 :: static  ('b')
+    r2 = 2
+    r3 = unicode_2 :: static  ('c')
+    r4 = 3
+    r5 = {}
+    r6 = box(int, r2)
+    r7 = r5.__setitem__(r1, r6) :: dict
+    r8 = box(int, r4)
+    r9 = r5.__setitem__(r3, r8) :: dict
+    r10 = __main__.globals :: static
+    r11 = unicode_3 :: static  ('f')
+    r12 = r10[r11] :: dict
+    r13 = builtins.module :: static
+    r14 = unicode_4 :: static  ('list')
+    r15 = getattr r13, r14
+    r16 = builtins.module :: static
+    r17 = unicode_5 :: static  ('dict')
+    r18 = getattr r16, r17
+    r19 = py_call(r18, r5)
+    r20 = box(int, r0)
+    r21 = [r20]
+    r22 = tuple r21 :: list
+    r23 = {}
+    r24 = r23.update(r19) :: dict
+    r25 = py_call_with_kwargs(r12, r22, r23)
+    r26 = unbox(tuple[int, int, int], r25)
+    return r26
 
 [case testListComprehension]
 from typing import List

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -616,17 +616,16 @@ L0:
     r2 = unicode_0 :: static  ('int')
     r3 = getattr r1, r2
     r4 = unicode_1 :: static  ('base')
-    r5 = [x]
-    r6 = tuple r5 :: list
-    dec_ref r5
-    r7 = {}
-    r8 = box(int, r0)
-    r9 = r7.__setitem__(r4, r8) :: dict
-    dec_ref r8
-    r10 = py_call_with_kwargs(r3, r6, r7)
-    dec_ref r3
-    dec_ref r6
+    r5 = (x)
+    r6 = {}
+    r7 = box(int, r0)
+    r8 = r6.__setitem__(r4, r7) :: dict
     dec_ref r7
+    r9 = box(tuple[str], r5)
+    r10 = py_call_with_kwargs(r3, r9, r6)
+    dec_ref r3
+    dec_ref r9
+    dec_ref r6
     r11 = unbox(int, r10)
     dec_ref r10
     return r11

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -607,17 +607,29 @@ L0:
     return r0
 
 [case testPyMethodCall]
-from typing import List
-def g(x: List[int], y: List[int]) -> None:
-    x.extend(y)
+def g(x: str) -> int:
+    return int(x, base=2)
 [out]
 L0:
-    r0 = unicode_0 :: static  ('extend')
-    r1 = py_method_call(x, r0, y)
-    r2 = cast(None, r1)
-    dec_ref r2
-    r3 = None
-    return r3
+    r0 = 2
+    r1 = builtins.module :: static
+    r2 = unicode_0 :: static  ('int')
+    r3 = getattr r1, r2
+    r4 = unicode_1 :: static  ('base')
+    r5 = [x]
+    r6 = tuple r5 :: list
+    dec_ref r5
+    r7 = {}
+    r8 = box(int, r0)
+    r9 = r7.__setitem__(r4, r8) :: dict
+    dec_ref r8
+    r10 = py_call_with_kwargs(r3, r6, r7)
+    dec_ref r3
+    dec_ref r6
+    dec_ref r7
+    r11 = unbox(int, r10)
+    dec_ref r10
+    return r11
 
 [case testListAppend]
 from typing import List

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -1514,6 +1514,20 @@ def test_star2_args() -> None:
 import native
 native.test_star2_args()
 
+[case testStarAndStar2Args]
+from typing import Tuple
+
+def g(a: int, b: int, c: int) -> Tuple[int, int, int]:
+    return a, b, c
+
+def test_star_and_star2_args() -> None:
+    assert g(1, *(2,), **{'c': 3}) == (1, 2, 3)
+    assert g(*[1], **{'b': 2, 'c': 3}) == (1, 2, 3)
+
+[file driver.py]
+import native
+native.test_star_and_star2_args()
+
 [case testArbitraryLvalues]
 from typing import List, Dict, Any
 

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -1483,14 +1483,13 @@ native.test_call_module_function_with_keyword_args()
 native.test_call_python_function_with_keyword_args()
 native.test_call_lambda_function_with_keyword_args()
 
-[case testStarAndDoubleStarArgs]
+[case testStarArgs]
 from typing import Tuple
 
 def g(a: int, b: int, c: int) -> Tuple[int, int, int]:
     return a, b, c
 
 def test_star_args() -> None:
-    print(g(*[1, 2, 3]))
     assert g(*[1, 2, 3]) == (1, 2, 3)
     assert g(*(1, 2, 3)) == (1, 2, 3)
     assert g(*(1,), *[2, 3]) == (1, 2, 3)

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -1522,6 +1522,7 @@ def test_star_args() -> None:
     assert g(*(1, 2, 3)) == (1, 2, 3)
     assert g(*(1,), *[2, 3]) == (1, 2, 3)
     assert g(*(), *(1,), *(), *(2,), *(3,), *()) == (1, 2, 3)
+    assert g(*range(3)) == (0, 1, 2)
 
 [file driver.py]
 import native

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -1490,12 +1490,13 @@ def g(a: int, b: int, c: int) -> Tuple[int, int, int]:
     return a, b, c
 
 def test_star_args() -> None:
+    print(g(*[1, 2, 3]))
     assert g(*[1, 2, 3]) == (1, 2, 3)
     assert g(*(1, 2, 3)) == (1, 2, 3)
-    assert g(*(1), *[2, 3]) == (1, 2, 3)
-    assert g(*[], *(1), *(), *[2], *[], *(3), *()) == (1, 2, 3)
+    assert g(*(1,), *[2, 3]) == (1, 2, 3)
+    assert g(*(), *(1,), *(), *(2,), *(3,), *()) == (1, 2, 3)
 
-[case driver.py]
+[file driver.py]
 import native
 native.test_star_args()
 

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -1568,6 +1568,26 @@ def test_star_and_star2_args() -> None:
 import native
 native.test_star_and_star2_args()
 
+[case testAllTheArgCombinations]
+from typing import Tuple
+def g(a: int, b: int, c: int, d: int = -1) -> Tuple[int, int, int, int]:
+    return a, b, c, d
+
+class C:
+    def g(self, a: int, b: int, c: int, d: int = -1) -> Tuple[int, int, int, int]:
+        return a, b, c, d
+
+def test_all_the_arg_combinations() -> None:
+    assert g(1, *(2,), **{'c': 3}) == (1, 2, 3, -1)
+    assert g(*[1], **{'b': 2, 'c': 3, 'd': 4}) == (1, 2, 3, 4)
+    c = C()
+    assert c.g(1, *(2,), **{'c': 3}) == (1, 2, 3, -1)
+    assert c.g(*[1], **{'b': 2, 'c': 3, 'd': 4}) == (1, 2, 3, 4)
+
+[file driver.py]
+import native
+native.test_all_the_arg_combinations()
+
 [case testArbitraryLvalues]
 from typing import List, Dict, Any
 

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -1483,6 +1483,22 @@ native.test_call_module_function_with_keyword_args()
 native.test_call_python_function_with_keyword_args()
 native.test_call_lambda_function_with_keyword_args()
 
+[case testStarAndDoubleStarArgs]
+from typing import Tuple
+
+def g(a: int, b: int, c: int) -> Tuple[int, int, int]:
+    return a, b, c
+
+def test_star_args() -> None:
+    assert g(*[1, 2, 3]) == (1, 2, 3)
+    assert g(*(1, 2, 3)) == (1, 2, 3)
+    assert g(*(1), *[2, 3]) == (1, 2, 3)
+    assert g(*[], *(1), *(), *[2], *[], *(3), *()) == (1, 2, 3)
+
+[case driver.py]
+import native
+native.test_star_args()
+
 [case testArbitraryLvalues]
 from typing import List, Dict, Any
 

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -1545,13 +1545,19 @@ native.test_star2_args()
 
 [case testStarAndStar2Args]
 from typing import Tuple
-
 def g(a: int, b: int, c: int) -> Tuple[int, int, int]:
     return a, b, c
+
+class C:
+    def g(self, a: int, b: int, c: int) -> Tuple[int, int, int]:
+        return a, b, c
 
 def test_star_and_star2_args() -> None:
     assert g(1, *(2,), **{'c': 3}) == (1, 2, 3)
     assert g(*[1], **{'b': 2, 'c': 3}) == (1, 2, 3)
+    c = C()
+    assert c.g(1, *(2,), **{'c': 3}) == (1, 2, 3)
+    assert c.g(*[1], **{'b': 2, 'c': 3}) == (1, 2, 3)
 
 [file driver.py]
 import native

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -1499,6 +1499,21 @@ def test_star_args() -> None:
 import native
 native.test_star_args()
 
+[case testStar2Args]
+from typing import Tuple
+
+def g(a: int, b: int, c: int) -> Tuple[int, int, int]:
+    return a, b, c
+
+def test_star2_args() -> None:
+    assert g(**{'a': 1, 'b': 2, 'c': 3}) == (1, 2, 3)
+    assert g(**{'c': 3, 'a': 1, 'b': 2}) == (1, 2, 3)
+    assert g(b=2, **{'a': 1, 'c': 3}) == (1, 2, 3)
+
+[file driver.py]
+import native
+native.test_star2_args()
+
 [case testArbitraryLvalues]
 from typing import List, Dict, Any
 


### PR DESCRIPTION
Addresses https://github.com/JukkaL/mypyc/issues/259.
Adds a new primitive func_op for `_PyList_Extend` for concatenating star args together.

Also:

- Renames args to arg_values in a few places to match py_call. The reasoning for this naming is that an argument has multiple properties: kind, type, and value.
- Refactors IRBuilder.translate_call, moving logic around.

Not without a few caveats though. As of `mypy 0.630+dev-c13d6f1d9d20c6dec7c33a3c1b5f1e1f1a0b22d1`, mypy does not support extreme usages of `*` and `**`. For instance, in the snippet below, mypy will complain about all of the print statements, even though python runs the code just fine:
```python
from typing import Tuple

def g(a: int, b: int, c: int) -> Tuple[int, int, int]:
    return a, b, c

print(g(**{'a': 1}, **{'b': 2, 'c': 3}))
print(g(**{'a': 1, 'c': 3}, b=2))
print(g(*[1], b=2, **{'c': 3}))
```
As a result, functions calls like in the snippet above are also not supported by mypyc.
