### PR TITLE
Added support for tuples as class attributes and function return types

### DIFF
--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -173,25 +173,18 @@ class Emitter:
 
     def tuple_undefined_check_cond(
             self, rtuple: RTuple, tuple_expr_in_c: str,
-            c_compare_type_func: Callable[[RType], str], compare: str) -> str:
-        # see tuple_c_declaration() above
-        if len(rtuple.types) == 0:
-            return '{} {} {}'.format(
-                tuple_expr_in_c + '.dummy_var_to_avoid_empty_struct',
-                compare,
-                c_compare_type_func(int_rprimitive)
-            )
+            c_type_compare_val: Callable[[RType], str], compare: str) -> str:
+        item_type = rtuple.types[0]
+        if not isinstance(item_type, RTuple):
+            return '{}.f0 {} {}'\
+                .format(tuple_expr_in_c, compare, c_type_compare_val(item_type))
+        elif isinstance(item_type, RTuple) and len(item_type.types) == 0:
+            # empty tuple
+            return '{}.dummy_var_to_avoid_empty_struct {} {}'\
+                .format(tuple_expr_in_c, compare, c_type_compare_val(int_rprimitive))
         else:
-            item_expr_in_c = tuple_expr_in_c + '.f0'
-            item_type = rtuple.types[0]
-            while isinstance(item_type, RTuple):
-                item_type = item_type.types[0]
-                item_expr_in_c += '.f0'
-            return '{} {} {}'.format(
-                item_expr_in_c,
-                compare,
-                c_compare_type_func(item_type)
-            )
+            return self.tuple_undefined_check_cond(
+                item_type, tuple_expr_in_c + '.f0', c_type_compare_val, compare)
 
     def tuple_undefined_value(self, rtuple: RTuple) -> str:
         context = self.context

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -176,8 +176,15 @@ class Emitter:
         name = 'tuple_undefined_' + id
         if name not in context.statics:
             struct_name = self.tuple_struct_name(rtuple)
-            values = ', '.join(self.c_undefined_value(item)
-                               for item in rtuple.types)
+            undefined_values = []
+            for item in rtuple.types:
+                if not isinstance(item, RTuple):
+                    undefined_values.append(self.c_undefined_value(item))
+                else:
+                    # TODO this needs to be recursive
+                    undefined_values.append(
+                        '{{ {} }}'.format(', '.join(map(self.c_undefined_value, item.types))))
+            values = ', '.join(undefined_values)
             init = 'struct {} {} = {{ {} }};'.format(struct_name, name, values)
             context.statics[name] = init
         return name

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -176,12 +176,12 @@ class Emitter:
             c_type_compare_val: Callable[[RType], str], compare: str) -> str:
         item_type = rtuple.types[0]
         if not isinstance(item_type, RTuple):
-            return '{}.f0 {} {}'\
-                .format(tuple_expr_in_c, compare, c_type_compare_val(item_type))
+            return '{}.f0 {} {}'.format(
+                tuple_expr_in_c, compare, c_type_compare_val(item_type))
         elif isinstance(item_type, RTuple) and len(item_type.types) == 0:
             # empty tuple
-            return '{}.dummy_var_to_avoid_empty_struct {} {}'\
-                .format(tuple_expr_in_c, compare, c_type_compare_val(int_rprimitive))
+            return '{}.dummy_var_to_avoid_empty_struct {} {}'.format(
+                tuple_expr_in_c, compare, c_type_compare_val(int_rprimitive))
         else:
             return self.tuple_undefined_check_cond(
                 item_type, tuple_expr_in_c + '.f0', c_type_compare_val, compare)

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -171,11 +171,8 @@ class Emitter:
         return result
 
     def tuple_check_cond(
-            self,
-            rtuple: RTuple,
-            tuple_expr_in_c: str,
-            c_compare_type_func: Callable[[RType], str],
-            compare: str) -> str:
+            self, rtuple: RTuple, tuple_expr_in_c: str,
+            c_compare_type_func: Callable[[RType], str], compare: str) -> str:
         item_expr_in_c = tuple_expr_in_c + '.f0'
         item_type = rtuple.types[0]
         while isinstance(item_type, RTuple):

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -199,7 +199,7 @@ def generate_native_getters_and_setters(cl: ClassIR,
                 attr_expr = 'self->{}'.format(attr)
                 emitter.emit_line(
                     'if ({}) {{'.format(
-                        emitter.tuple_check_cond(
+                        emitter.tuple_undefined_check_cond(
                             rtype, attr_expr, emitter.c_undefined_value, '==')))
             else:
                 emitter.emit_line(
@@ -224,7 +224,7 @@ def generate_native_getters_and_setters(cl: ClassIR,
                 attr_expr = 'self->{}'.format(attr)
                 emitter.emit_line(
                     'if ({}) {{'
-                    .format(emitter.tuple_check_cond(
+                    .format(emitter.tuple_undefined_check_cond(
                         rtype, attr_expr, emitter.c_undefined_value, "!=")))
             else:
                 emitter.emit_line('if (self->{} != {}) {{'
@@ -485,7 +485,8 @@ def generate_getter(cl: ClassIR,
         attr_expr = 'self->{}'.format(attr)
         emitter.emit_line(
             'if ({}) {{'.format(
-                emitter.tuple_check_cond(rtype, attr_expr, emitter.c_undefined_value, '==')))
+                emitter.tuple_undefined_check_cond(
+                    rtype, attr_expr, emitter.c_undefined_value, '==')))
     else:
         emitter.emit_line('if (self->{} == {}) {{'.format(attr, emitter.c_undefined_value(rtype)))
     emitter.emit_line('PyErr_SetString(PyExc_AttributeError,')
@@ -514,7 +515,8 @@ def generate_setter(cl: ClassIR,
             emitter.emit_line(
                 'if ({}) {{'
                 .format(
-                    emitter.tuple_check_cond(rtype, attr_expr, emitter.c_undefined_value, '!=')))
+                    emitter.tuple_undefined_check_cond(
+                        rtype, attr_expr, emitter.c_undefined_value, '!=')))
         else:
             emitter.emit_line(
                 'if (self->{} != {}) {{'.format(attr, emitter.c_undefined_value(rtype)))

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -6,9 +6,7 @@ from typing import Optional, List, Tuple
 
 from mypyc.common import PREFIX, NATIVE_PREFIX, REG_PREFIX, DUNDER_PREFIX
 from mypyc.emit import Emitter
-from mypyc.emitfunc import (
-    native_function_header, generate_tuple_check_code
-)
+from mypyc.emitfunc import native_function_header
 from mypyc.ops import (
     ClassIR, FuncIR, RType, RTuple, Environment, object_rprimitive, FuncSignature,
     VTableMethod, VTableAttr, VTableEntries
@@ -201,7 +199,8 @@ def generate_native_getters_and_setters(cl: ClassIR,
                 attr_expr = 'self->{}'.format(attr)
                 emitter.emit_line(
                     'if ({}) {{'.format(
-                        generate_tuple_check_code(rtype, attr_expr, emitter.c_undefined_value)))
+                        emitter.tuple_check_cond(
+                            rtype, attr_expr, emitter.c_undefined_value, '==')))
             else:
                 emitter.emit_line(
                     'if (self->{} == {}) {{'.format(attr, emitter.c_undefined_value(rtype)))
@@ -225,7 +224,7 @@ def generate_native_getters_and_setters(cl: ClassIR,
                 attr_expr = 'self->{}'.format(attr)
                 emitter.emit_line(
                     'if ({}) {{'
-                    .format(generate_tuple_check_code(
+                    .format(emitter.tuple_check_cond(
                         rtype, attr_expr, emitter.c_undefined_value, "!=")))
             else:
                 emitter.emit_line('if (self->{} != {}) {{'
@@ -486,7 +485,7 @@ def generate_getter(cl: ClassIR,
         attr_expr = 'self->{}'.format(attr)
         emitter.emit_line(
             'if ({}) {{'.format(
-                generate_tuple_check_code(rtype, attr_expr, emitter.c_undefined_value)))
+                emitter.tuple_check_cond(rtype, attr_expr, emitter.c_undefined_value, '==')))
     else:
         emitter.emit_line('if (self->{} == {}) {{'.format(attr, emitter.c_undefined_value(rtype)))
     emitter.emit_line('PyErr_SetString(PyExc_AttributeError,')
@@ -515,7 +514,7 @@ def generate_setter(cl: ClassIR,
             emitter.emit_line(
                 'if ({}) {{'
                 .format(
-                    generate_tuple_check_code(rtype, attr_expr, emitter.c_undefined_value, '!=')))
+                    emitter.tuple_check_cond(rtype, attr_expr, emitter.c_undefined_value, '!=')))
         else:
             emitter.emit_line(
                 'if (self->{} != {}) {{'.format(attr, emitter.c_undefined_value(rtype)))

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -526,6 +526,7 @@ def generate_readonly_getter(cl: ClassIR,
                                                                    func_ir.cname(emitter.names)))
     emitter.emit_line('}')
 
+
 def emit_undefined_check(rtype: RType, emitter: Emitter, attr: str, compare: str) ->None:
     if isinstance(rtype, RTuple):
         attr_expr = 'self->{}'.format(attr)

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -11,7 +11,6 @@ from mypyc.ops import (
     EmitterInterface, Unreachable, is_int_rprimitive, NAMESPACE_STATIC, NAMESPACE_TYPE,
     RaiseStandardError,
 )
-from typing import Callable
 from mypyc.namegen import NameGenerator
 
 

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -15,23 +15,6 @@ from typing import Callable
 from mypyc.namegen import NameGenerator
 
 
-def generate_tuple_check_code(
-        rtuple: RTuple,
-        tuple_expr_in_c: str,
-        c_compare_type_func: Callable[[RType], str],
-        compare: str = '==') -> str:
-    item_expr_in_c = tuple_expr_in_c + '.f0'
-    item_type = rtuple.types[0]
-    while isinstance(item_type, RTuple):
-        item_type = item_type.types[0]
-        item_expr_in_c += '.f0'
-    return '{} {} {}'.format(
-        item_expr_in_c,
-        compare,
-        c_compare_type_func(item_type)
-    )
-
-
 def native_function_type(fn: FuncIR, emitter: Emitter) -> str:
     args = ', '.join(emitter.ctype(arg.type) for arg in fn.args)
     ret = emitter.ctype(fn.ret_type)
@@ -118,7 +101,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
             compare = '!=' if op.negated else '=='
             if isinstance(typ, RTuple):
                 # TODO: What about empty tuple?
-                cond = generate_tuple_check_code(typ,
+                cond = self.emitter.tuple_check_cond(typ,
                                             self.reg(op.left),
                                             self.c_error_value,
                                             compare)

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -101,10 +101,10 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
             compare = '!=' if op.negated else '=='
             if isinstance(typ, RTuple):
                 # TODO: What about empty tuple?
-                cond = self.emitter.tuple_check_cond(typ,
-                                            self.reg(op.left),
-                                            self.c_error_value,
-                                            compare)
+                cond = self.emitter.tuple_undefined_check_cond(typ,
+                                                               self.reg(op.left),
+                                                               self.c_error_value,
+                                                               compare)
             else:
                 cond = '{} {} {}'.format(self.reg(op.left),
                                          compare,

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -2277,7 +2277,6 @@ def g() -> None:
     except Exception:
         print("caught the exception")
 
-
 def h() -> Tuple[Tuple[Tuple[int, int], int], int, str, object]:
     raise Exception('Intentional exception')
 [file driver.py]

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -2268,14 +2268,14 @@ class C:
     b: Tuple[Tuple[Tuple[int, int], int], int, str, object]
 def f() -> None:
     c = C()
-    c.b = (((1, 2), 2), 1, "hi", "hi2")
+    c.b = (((1, 2), 2), 1, 'hi', 'hi2')
     print(c.b)
 
 def g() -> None:
     try:
         h()
     except Exception:
-        print("caught the exception")
+        print('caught the exception')
 
 def h() -> Tuple[Tuple[Tuple[int, int], int], int, str, object]:
     raise Exception('Intentional exception')

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -2265,6 +2265,13 @@ Lol(a=1, b=[])
 [case testTupleAttr]
 from typing import Tuple
 class C:
-    d: Tuple[Tuple[int, int], int, str, object]
+    a: int
+    b: Tuple[Tuple[Tuple[int, int], int], int, str, object]
+def f() -> None:
+    c = C()
+    c.a = 1
+    c.b = (((1, 2), 2), 1, "hi", "hi2")
 [file driver.py]
+from native import f
+f()
 [out]

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -2261,3 +2261,10 @@ typing.List[native.A] typing.List[typing.Tuple[int, str]] typing.List[typing.Lis
 Lol(a=1, b=[])
 10
 1
+
+[case testTupleAttr]
+from typing import Tuple
+class C:
+    d: Tuple[Tuple[int, int], int, str, object]
+[file driver.py]
+[out]

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -2271,7 +2271,23 @@ def f() -> None:
     c = C()
     c.a = 1
     c.b = (((1, 2), 2), 1, "hi", "hi2")
+    print(c.a)
+    print(c.b)
+
+def g() -> None:
+    try:
+        h()
+    except Exception:
+        print("caught the exception")
+
+
+def h() -> Tuple[Tuple[Tuple[int, int], int], int, str, object]:
+    raise Exception('Intentional exception')
 [file driver.py]
-from native import f
+from native import f, g
 f()
+g()
 [out]
+1
+(((1, 2), 2), 1, 'hi', 'hi2')
+caught the exception

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -2265,13 +2265,10 @@ Lol(a=1, b=[])
 [case testTupleAttr]
 from typing import Tuple
 class C:
-    a: int
     b: Tuple[Tuple[Tuple[int, int], int], int, str, object]
 def f() -> None:
     c = C()
-    c.a = 1
     c.b = (((1, 2), 2), 1, "hi", "hi2")
-    print(c.a)
     print(c.b)
 
 def g() -> None:
@@ -2288,6 +2285,5 @@ from native import f, g
 f()
 g()
 [out]
-1
 (((1, 2), 2), 1, 'hi', 'hi2')
 caught the exception


### PR DESCRIPTION
We now (recursively if necessary) check that the first field of a tuple is the uninitialized type instead of checking that the whole tuple is uninitialized.

Also, the assignment of uninitialized tuple variables do not use other uninitialized tuples in the literal.

Note that this pull request does not handle empty tuples

Closes #245