### PR TITLE
Add set -e to multiline commands in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
       env: PYTHONVERSION=3.6.3
 
 before_install: |
+  set -e
   if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     export PYTHONVERSION=`python --version | awk '{ print $2 }'`
 
@@ -61,6 +62,7 @@ install:
   - pip install -r external/mypy/test-requirements.txt
 
 script: |
+  set -e
   export PYTHONPATH=`pwd`/external/mypy
   if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     export PYTHONCONFIG="$PYTHONDIR/bin/python-config"

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ script: |
     export LD_LIBRARY_PATH="$PYTHONDIR/lib"
     if [[ $PYTHON_DEBUG_BUILD != 1 ]]; then
       pytest -n4 mypyc
+      false
     fi
     if [[ $PYTHON_DEBUG_BUILD == 1 ]]; then
       pytest -n4 mypyc/test/test_run.py mypyc/test/test_external.py -k 'not test_self_type_check'

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,6 @@ script: |
     export LD_LIBRARY_PATH="$PYTHONDIR/lib"
     if [[ $PYTHON_DEBUG_BUILD != 1 ]]; then
       pytest -n4 mypyc
-      false
     fi
     if [[ $PYTHON_DEBUG_BUILD == 1 ]]; then
       pytest -n4 mypyc/test/test_run.py mypyc/test/test_external.py -k 'not test_self_type_check'


### PR DESCRIPTION
Previously tests could fail and Travis would still say the build succeeded: https://travis-ci.org/JukkaL/mypyc/jobs/406481759
This fix adds the `set -e` command before multiline commands, so that any command that fails will force the multiline commands to exit with the exit code of the failing command.
See https://travis-ci.com/ed1d1a8d/mypyc/jobs/135691332and compare to the first link for evidence that this change works.