### PR TITLE
Rework the handling of type objects to use pointers directly

### DIFF
--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -58,6 +58,15 @@ static inline CPyVTableItem *CPy_FindTraitVtable(PyTypeObject *trait, CPyVTableI
     }
 }
 
+// At load time, we need to patch up trait vtables to contain actual pointers
+// to the type objects of the trait, rather than an indirection.
+static inline void CPy_FixupTraitVtable(CPyVTableItem *vtable, int count) {
+    int i;
+    for (i = 0; i < count; i++) {
+        vtable[i*2] = *(CPyVTableItem *)vtable[i*2];
+    }
+}
+
 // Get attribute value using vtable (may return an undefined value)
 #define CPY_GET_ATTR(obj, type, vtable_index, object_type, attr_type)    \
     ((attr_type (*)(object_type *))((object_type *)obj)->vtable[vtable_index])((object_type *)obj)

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -331,7 +331,7 @@ class Emitter:
         elif isinstance(typ, RInstance):
             if declare_dest:
                 self.emit_line('PyObject *{};'.format(dest))
-            self.emit_arg_check(src, dest, typ, '(PyObject_TypeCheck({}, &{}))'.format(src,
+            self.emit_arg_check(src, dest, typ, '(PyObject_TypeCheck({}, {}))'.format(src,
                     self.type_struct_name(typ.class_ir)), optional)
             self.emit_lines(
                 '    {} = {};'.format(dest, src),

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -182,7 +182,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         obj = self.reg(op.obj)
         rtype = op.class_type
         version = '_TRAIT' if rtype.class_ir.is_trait else ''
-        self.emit_line('%s = CPY_GET_ATTR%s(%s, &%s, %d, %s, %s);' % (
+        self.emit_line('%s = CPY_GET_ATTR%s(%s, %s, %d, %s, %s);' % (
             dest,
             version,
             obj,
@@ -198,7 +198,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         rtype = op.class_type
         # TODO: Track errors
         version = '_TRAIT' if rtype.class_ir.is_trait else ''
-        self.emit_line('%s = CPY_SET_ATTR%s(%s, &%s, %d, %s, %s, %s);' % (
+        self.emit_line('%s = CPY_SET_ATTR%s(%s, %s, %d, %s, %s, %s);' % (
             dest,
             version,
             obj,
@@ -218,7 +218,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         prefix = self.PREFIX_MAP[op.namespace]
         name = self.emitter.static_name(op.identifier, op.module_name, prefix)
         if op.namespace == NAMESPACE_TYPE:
-            name = '(PyObject *)&%s' % name
+            name = '(PyObject *)%s' % name
         if is_int_rprimitive(op.type):
             self.emit_line('%s = CPyTagged_FromObject(%s);' % (dest, name))
         else:
@@ -253,7 +253,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         assert method is not None
         mtype = native_function_type(method, self.emitter)
         version = '_TRAIT' if rtype.class_ir.is_trait else ''
-        self.emit_line('{}CPY_GET_METHOD{}({}, &{}, {}, {}, {})({});'.format(
+        self.emit_line('{}CPY_GET_METHOD{}({}, {}, {}, {}, {})({});'.format(
             dest, version, obj, self.emitter.type_struct_name(rtype.class_ir),
             method_idx, rtype.struct_name(self.names), mtype, args))
 

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -199,12 +199,12 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
     def test_get_attr(self) -> None:
         self.assert_emit(
             GetAttr(self.r, 'y', 1),
-            """cpy_r_r0 = CPY_GET_ATTR(cpy_r_r, &CPyType_A, 2, AObject, CPyTagged);""")
+            """cpy_r_r0 = CPY_GET_ATTR(cpy_r_r, CPyType_A, 2, AObject, CPyTagged);""")
 
     def test_set_attr(self) -> None:
         self.assert_emit(
             SetAttr(self.r, 'y', self.m, 1),
-            """cpy_r_r0 = CPY_SET_ATTR(cpy_r_r, &CPyType_A, 3, cpy_r_m, AObject, CPyTagged);""")
+            """cpy_r_r0 = CPY_SET_ATTR(cpy_r_r, CPyType_A, 3, cpy_r_m, AObject, CPyTagged);""")
 
     def test_dict_get_item(self) -> None:
         self.assert_emit(PrimitiveOp([self.d, self.o2], dict_get_item_op, 1),

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -130,6 +130,11 @@ class TestRun(MypycDataSuite):
             lib_env = 'DYLD_LIBRARY_PATH' if sys.platform == 'darwin' else 'LD_LIBRARY_PATH'
             env[lib_env] = workdir
 
+            # XXX: This is an ugly hack.
+            if 'MYPYC_RUN_GDB' in os.environ:
+                subprocess.check_call(['gdb', '--args', 'python', driver_path], env=env)
+                assert False, "Test can't pass in gdb mode. (And remember to pass -s to pytest)"
+
             proc = subprocess.Popen(['python', driver_path], stdout=subprocess.PIPE,
                                     stderr=subprocess.STDOUT, env=env)
             output, _ = proc.communicate()

--- a/test-data/run-multimodule.test
+++ b/test-data/run-multimodule.test
@@ -293,15 +293,15 @@ class Base1:
     def __init__(self) -> None:
         self.x = 1
 
-class Deriv2(native.Base2):
-    pass
+def make_2() -> native.Base2:
+    return native.Base2()
 
 [file driver.py]
 from native import Deriv1
-from other import Deriv2
+from other import make_2
 a = Deriv1()
 assert a.x == 1
-b = Deriv2()
+b = make_2()
 assert b.y == 2
 
 [case testMultiModuleTraitInheritance]


### PR DESCRIPTION
This is to lay the groundwork for allocating our TypeObject's on the
heap, which we will unfortunately need to do to support a bunch of
behavior.

The main tricky thing here is in the initialization of trait vtables,
which can't be done fully statically. We take the approach of filling
out the initial vtable with pointers to the variable where the pointer
will be stored, and then patching them all up at module load
time. This is a bummer.

A side effect of these changes is that we no longer allow two modules
to both define classes that inherit from a class defined in the
other. This is fine, cpython doesn't support it either.