### PR TITLE
Allocate types on the heap

### DIFF
--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -133,8 +133,7 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
             {init_name},               /* tp_init */
             0,                         /* tp_alloc */
             {new_name},                /* tp_new */
-        }};
-        static PyTypeObject *{type_struct};\
+        }};\
         """).format(type_struct=emitter.type_struct_name(cl),
                     struct_name=cl.struct_name(emitter.names),
                     name=name,

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -26,7 +26,6 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
     """
     name = cl.name
     name_prefix = cl.name_prefix(emitter.names)
-    fullname = '{}.{}'.format(module, name)
 
     setup_name = new_name = clear_name = dealloc_name = '0'
     traverse_name = vtable_name = '0'
@@ -97,7 +96,7 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
     emitter.emit_line(textwrap.dedent("""\
         static PyTypeObject {type_struct}_template = {{
             PyVarObject_HEAD_INIT(&PyType_Type, 0)
-            "{fullname}",              /* tp_name */
+            "{name}",                  /* tp_name */
             sizeof({struct_name}),     /* tp_basicsize */
             0,                         /* tp_itemsize */
             (destructor){dealloc_name},  /* tp_dealloc */
@@ -115,7 +114,7 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
             0,                         /* tp_getattro */
             0,                         /* tp_setattro */
             0,                         /* tp_as_buffer */
-            Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC, /* tp_flags */
+            Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_HEAPTYPE, /* tp_flags */
             0,                         /* tp_doc */
             (traverseproc){traverse_name}, /* tp_traverse */
             (inquiry){clear_name},     /* tp_clear */
@@ -135,10 +134,10 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
             0,                         /* tp_alloc */
             {new_name},                /* tp_new */
         }};
-        static PyTypeObject *{type_struct} = &{type_struct}_template;\
+        static PyTypeObject *{type_struct};\
         """).format(type_struct=emitter.type_struct_name(cl),
                     struct_name=cl.struct_name(emitter.names),
-                    fullname=fullname,
+                    name=name,
                     traverse_name=traverse_name,
                     clear_name=clear_name,
                     dealloc_name=dealloc_name,

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -182,7 +182,6 @@ class ModuleGenerator:
                            '{}module_methods'.format(module_prefix),
                            '};')
         emitter.emit_line()
-
         # Emit module init function. If we are compiling just one module, this
         # will be the C API init function. If we are compiling 2+ modules, we
         # generate a shared library for the modules and shims that call into
@@ -203,6 +202,10 @@ class ModuleGenerator:
         emitter.emit_lines('{} = PyModule_Create(&{}module);'.format(module_static, module_prefix),
                            'if ({} == NULL)'.format(module_static),
                            '    return NULL;')
+        emitter.emit_line(
+            'PyObject *modname = PyObject_GetAttrString((PyObject *){}, "__name__");'.format(
+                module_static))
+
         module_globals = emitter.static_name('globals', module_name)
         emitter.emit_lines('{} = PyModule_GetDict({});'.format(module_globals, module_static),
                            'if ({} == NULL)'.format(module_globals),
@@ -221,19 +224,20 @@ class ModuleGenerator:
             real_base = cl.real_base()
             if real_base or cl.traits:
                 bases = ([real_base] if real_base else []) + cl.traits
-                emitter.emit_lines('{}->tp_bases = PyTuple_Pack({}, {});'.format(
+                emitter.emit_lines('{}_template.tp_bases = PyTuple_Pack({}, {});'.format(
                     type_struct,
                     len(bases),
                     ', '.join('{}'.format(emitter.type_struct_name(b)) for b in bases)))
 
-        for cl in module.classes:
+            emitter.emit_lines('{t} = CPyType_FromTemplate(&{t}_template, modname);'.format(
+                t=type_struct))
+            emitter.emit_lines('if (!{})'.format(type_struct),
+                               '    return NULL;')
+
             type_struct = emitter.type_struct_name(cl)
             if cl.trait_vtables and not cl.is_trait:
                 emitter.emit_lines('CPy_FixupTraitVtable({}_vtable, {});'.format(
                     cl.name_prefix(emitter.names), len(cl.trait_vtables)))
-
-            emitter.emit_lines('if (PyType_Ready({}) < 0)'.format(type_struct),
-                               '    return NULL;')
 
         for (_, literal), identifier in module.literals.items():
             symbol = emitter.static_name(identifier, None)
@@ -273,6 +277,8 @@ class ModuleGenerator:
                                                                        type_struct))
 
         self.generate_top_level_call(module, emitter)
+
+        emitter.emit_lines('Py_DECREF(modname);')
 
         emitter.emit_line('return {};'.format(module_static))
         emitter.emit_line('}')

--- a/test-data/module-output.test
+++ b/test-data/module-output.test
@@ -38,6 +38,7 @@ PyMODINIT_FUNC PyInit_prog(void)
     CPyStatic_module = PyModule_Create(&module);
     if (CPyStatic_module == NULL)
         return NULL;
+    PyObject *modname = PyObject_GetAttrString((PyObject *)CPyStatic_module, "__name__");
     CPyStatic_globals = PyModule_GetDict(CPyStatic_module);
     if (CPyStatic_globals == NULL)
         return NULL;
@@ -50,6 +51,7 @@ PyMODINIT_FUNC PyInit_prog(void)
     if (result == NULL)
         return NULL;
     Py_DECREF(result);
+    Py_DECREF(modname);
     return CPyStatic_module;
 }
 


### PR DESCRIPTION
CPython overloads `Py_TPFLAGS_HEAPTYPE` to mean essentially two different things:
1. The type object is literally allocated on the heap
   (and is a PyHeapTypeObject)
2. The type is not a "builtin" type and thus is allowed to support a number
   of operations that builtin types can not, such as allowing attributes of
   the type to be set.

We don't particularly care about #1, but do care about #2, so here we are.

The "correct" interface to use for creating heap types is
PyType_FromSpec(), but that has a *completely* different API and
doesn't exist at all in 2.7, which we still may want to support some
day.
Instead we manually create the type and fill in some fields ourselves.