### PR TITLE
Implement super()

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1398,13 +1398,23 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
 
         if isinstance(callee, MemberExpr):
             return self.translate_method_call(expr, callee)
+        elif isinstance(callee, SuperExpr):
+            return self.translate_super_method_call(expr, callee)
         else:
             return self.translate_call(expr, callee)
 
     def translate_call(self, expr: CallExpr, callee: Expression) -> Value:
-        """Translate a non-method call."""
-        assert isinstance(callee, RefExpr)  # TODO: Allow arbitrary callees
+        # The common case of calls is refexprs
+        if isinstance(callee, RefExpr):
+            return self.translate_refexpr_call(expr, callee)
 
+        function = self.accept(callee)
+        args = [self.accept(arg) for arg in expr.args]
+        return self.py_call(function, args, expr.line,
+                            arg_kinds=expr.arg_kinds, arg_names=expr.arg_names)
+
+    def translate_refexpr_call(self, expr: CallExpr, callee: RefExpr) -> Value:
+        """Translate a non-method call."""
         # Gen the argument values
         arg_values = [self.accept(arg) for arg in expr.args]
 
@@ -1501,6 +1511,19 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                                         expr.line,
                                         expr.arg_kinds,
                                         expr.arg_names)
+
+    def translate_super_method_call(self, expr: CallExpr, callee: SuperExpr) -> Value:
+        if callee.info is None or callee.call.args:
+            return self.translate_call(expr, callee)
+        ir = self.mapper.type_to_ir[callee.info]
+        if not ir or ir.base is None or not ir.base.has_method(callee.name):
+            return self.translate_call(expr, callee)
+
+        decl = ir.base.method_decl(callee.name)
+        vself = next(iter(self.environment.indexes))  # grab first argument
+        arg_values = [vself] + [self.accept(arg) for arg in expr.args]
+        arg_values = self.coerce_native_call_args(arg_values, decl.sig, expr.line)
+        return self.add(Call(decl, arg_values, expr.line))
 
     def gen_method_call(self,
                         base: Value,
@@ -2281,6 +2304,18 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         else:
             assert False, 'Unsupported del operation'
 
+    def visit_super_expr(self, o: SuperExpr) -> Value:
+        sup_val = self.load_module_attr_by_fullname('builtins.super', o.line)
+        if o.call.args:
+            args = [self.accept(arg) for arg in o.call.args]
+        else:
+            assert o.info is not None
+            typ = self.load_native_type_object(o.info.fullname())
+            vself = next(iter(self.environment.indexes))  # grab first argument
+            args = [typ, vself]
+        res = self.py_call(sup_val, args, o.line)
+        return self.py_get_attr(res, o.name, o.line)
+
     # Unimplemented constructs
     # TODO: some of these are actually things that should never show up,
     # so properly sort those out.
@@ -2328,9 +2363,6 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         raise NotImplementedError
 
     def visit_star_expr(self, o: StarExpr) -> Value:
-        raise NotImplementedError
-
-    def visit_super_expr(self, o: SuperExpr) -> Value:
         raise NotImplementedError
 
     def visit_temp_node(self, o: TempNode) -> Value:

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -735,6 +735,8 @@ class Call(RegisterOp):
         args = ', '.join(env.format('%r', arg) for arg in self.args)
         # TODO: Display long name?
         short_name = self.fn.name
+        if self.fn.class_name:
+            short_name = self.fn.class_name + '.' + short_name
         s = '%s(%s)' % (short_name, args)
         if not self.is_void:
             s = env.format('%r = ', self) + s

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -328,3 +328,33 @@ L1:
 L2:
     r3 = B()
     return r3
+
+[case testSuper]
+class A:
+    def __init__(self, x: int) -> None:
+        self.x = x
+class B(A):
+    def __init__(self, x: int, y: int) -> None:
+        super().__init__(x)
+        self.y = y
+[out]
+def A.__init__(self, x):
+    self :: A
+    x :: int
+    r0 :: bool
+    r1 :: None
+L0:
+    self.x = x; r0 = is_error
+    r1 = None
+    return r1
+def B.__init__(self, x, y):
+    self :: B
+    x, y :: int
+    r0 :: None
+    r1 :: bool
+    r2 :: None
+L0:
+    r0 = A.__init__(self, x)
+    self.y = y; r1 = is_error
+    r2 = None
+    return r2

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -412,3 +412,36 @@ Traceback (most recent call last):
   File "tmp/driver.py", line 4, in <module>
     A().x
 AttributeError: attribute 'x' of 'X' undefined
+
+[case testSuper]
+class A:
+    def __init__(self, x: int) -> None:
+        self.x = x
+class B(A):
+    def __init__(self, x: int, y: int) -> None:
+        super().__init__(x)
+        self.y = y
+class C(B):
+    def __init__(self, x: int, y: int) -> None:
+        init = super(C, self).__init__
+        init(x, y+1)
+
+class X:
+    def __init__(self, x: int) -> None:
+        self.x = x
+class Y(X):
+    pass
+class Z(Y):
+    def __init__(self, x: int, y: int) -> None:
+        super().__init__(x)
+        self.y = y
+
+[file driver.py]
+import traceback
+from native import *
+b = B(10, 20)
+assert b.x == 10 and b.y == 20
+c = C(10, 20)
+assert c.x == 10 and c.y == 21
+z = Z(10, 20)
+assert z.x == 10 and z.y == 20

--- a/test-data/run-multimodule.test
+++ b/test-data/run-multimodule.test
@@ -278,7 +278,8 @@ else:
 import other
 
 class Deriv1(other.Base1):
-    pass
+    def __init__(self) -> None:
+        super().__init__()
 
 class Base2:
     y: int

--- a/test-data/run-mypy-sim.test
+++ b/test-data/run-mypy-sim.test
@@ -38,8 +38,7 @@ class SymbolNode(Node):
 
 class FuncBase(Node):
     def __init__(self) -> None:
-        #super().__init__()
-        # you know whatever
+        super().__init__()
         self.is_static = False
 
 class Block(Statement):
@@ -62,8 +61,7 @@ class FuncItem(FuncBase):
 
 class FuncDef(FuncItem, SymbolNode, Statement):
     def __init__(self, name: str, body: Block) -> None:
-        #super().__init__(body)
-        FuncItem.__init__(self, body)
+        super().__init__(body)
         self._name = name
     def accept(self, visitor: visitor.StatementVisitor[T]) -> T:
         return visitor.visit_func_def(self)


### PR DESCRIPTION
This implements both a fast-path for making method calls of the form
`super().foo(...)` (which directly calls the function) and a slow-path
for other cases that just calls `builtins.super`.

Closes #141.