### PR TITLE
Generate better code when casting *from* optional

### DIFF
--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -270,7 +270,8 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         self.emitter.emit_box(self.reg(op.src), self.reg(op), op.src.type)
 
     def visit_cast(self, op: Cast) -> None:
-        self.emitter.emit_cast(self.reg(op.src), self.reg(op), op.type)
+        self.emitter.emit_cast(self.reg(op.src), self.reg(op), op.type,
+                               src_type=op.src.type)
 
     def visit_unbox(self, op: Unbox) -> None:
         self.emitter.emit_unbox(self.reg(op.src), self.reg(op), op.type)


### PR DESCRIPTION
Casts from optional don't need to do a real typecheck, often. They
just need to check that the value isn't `Py_None`.

This got like a 20% win on a modified version of the richards benchmark where we were doing two totally pointless `PyObject_TypeCheck` calls per loop iteration, with an abstract base as the type--so it was actually hitting `PyType_IsSubtype` every time. The checks against `Py_None` are still totally pointless, but at least they're cheap.