### PR TITLE
Better support for trait parents in super()

### DIFF
--- a/test-data/fixtures/ir.py
+++ b/test-data/fixtures/ir.py
@@ -71,7 +71,10 @@ class function: pass
 
 class list(Generic[T], Iterable[T], Sized):
     def __init__(self, i: Optional[Iterable[T]] = None) -> None: pass
-    def __getitem__(self, i: int) -> T: pass
+    @overload
+    def __getitem__(self, i: int) -> T: ...
+    @overload
+    def __getitem__(self, s: slice) -> List[T]: ...
     def __setitem__(self, i: int, o: T) -> None: pass
     def __delitem__(self, i: int) -> None: pass
     def __mul__(self, i: int) -> List[T]: pass

--- a/test-data/genops-any.test
+++ b/test-data/genops-any.test
@@ -100,30 +100,27 @@ def f2(a, n, l):
     a :: object
     n :: int
     l :: list
-    r0, r1, r2 :: object
-    r3 :: int
-    r4, r5 :: object
-    r6 :: bool
-    r7 :: object
-    r8, r9 :: bool
-    r10 :: object
-    r11 :: list
-    r12 :: None
+    r0, r1, r2, r3, r4 :: object
+    r5 :: bool
+    r6 :: object
+    r7, r8 :: bool
+    r9 :: object
+    r10 :: list
+    r11 :: None
 L0:
     r0 = box(int, n)
     r1 = a[r0] :: object
     r2 = l[a] :: object
-    r3 = unbox(int, r2)
+    r3 = box(int, n)
     r4 = box(int, n)
-    r5 = box(int, n)
-    r6 = a.__setitem__(r4, r5) :: object
-    r7 = box(int, n)
-    r8 = l.__setitem__(a, r7) :: object
-    r9 = l.__setitem__(n, a) :: list
-    r10 = box(int, n)
-    r11 = [a, r10]
-    r12 = None
-    return r12
+    r5 = a.__setitem__(r3, r4) :: object
+    r6 = box(int, n)
+    r7 = l.__setitem__(a, r6) :: object
+    r8 = l.__setitem__(n, a) :: list
+    r9 = box(int, n)
+    r10 = [a, r9]
+    r11 = None
+    return r11
 def f3(a, n):
     a :: object
     n :: int

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -359,7 +359,7 @@ L0:
     r2 = None
     return r2
 
-[case testSuper]
+[case testSuper1]
 class A:
     def __init__(self, x: int) -> None:
         self.x = x
@@ -388,6 +388,30 @@ L0:
     self.y = y; r1 = is_error
     r2 = None
     return r2
+
+[case testSuper2]
+from mypy_extensions import trait
+@trait
+class T:
+    def foo(self) -> None: pass
+
+class X(T):
+    def foo(self) -> None:
+        super().foo()
+[out]
+def T.foo(self):
+    self :: T
+    r0 :: None
+L0:
+    r0 = None
+    return r0
+def X.foo(self):
+    self :: X
+    r0, r1 :: None
+L0:
+    r0 = T.foo(self)
+    r1 = None
+    return r1
 
 [case testClassVariable]
 class A:

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -414,6 +414,9 @@ Traceback (most recent call last):
 AttributeError: attribute 'x' of 'X' undefined
 
 [case testSuper]
+from mypy_extensions import trait
+from typing import List
+
 class A:
     def __init__(self, x: int) -> None:
         self.x = x
@@ -436,6 +439,21 @@ class Z(Y):
         super().__init__(x)
         self.y = y
 
+@trait
+class T:
+    def v_int(self, x: int) -> None: pass
+    def v_list(self, x: List[int]) -> None:
+        if x:
+            self.v_int(x[0])
+            self.v_list(x[1:])
+
+class PrintList(T):
+    def v_int(self, x: int) -> None:
+        print(x)
+    def v_list(self, x: List[int]) -> None:
+        print('yo!')
+        super().v_list(x)
+
 [file driver.py]
 import traceback
 from native import *
@@ -445,6 +463,16 @@ c = C(10, 20)
 assert c.x == 10 and c.y == 21
 z = Z(10, 20)
 assert z.x == 10 and z.y == 20
+
+PrintList().v_list([1,2,3])
+[out]
+yo!
+1
+yo!
+2
+yo!
+3
+yo!
 
 [case testClassVariable]
 from typing import ClassVar


### PR DESCRIPTION
Trait parents did already work for `super()`, but there were no tests
for it and we fell back to calling `builtins.super()` even though we
didn't really need to.

Add some tests and and make some minor tweaks so we can find methods
in trait parents.