### PR TITLE
Implement a restricted form of attribute default values

### DIFF
--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -414,8 +414,9 @@ L0:
     return r1
 
 [case testClassVariable]
+from typing import ClassVar
 class A:
-    x = 10
+    x = 10  # type: ClassVar[int]
 
 def f() -> int:
     return A.x
@@ -446,3 +447,75 @@ L0:
     r4 = setattr r0, r2, r3
     r5 = None
     return r5
+
+[case testDefaultVars]
+from typing import ClassVar, Optional
+class A:
+    x = 10
+    def lol(self) -> None:
+        self.x = 100
+
+LOL = 'lol'
+class B(A):
+    y = LOL
+    z: Optional[str] = None
+    b = True
+    bogus = None  # type: int
+[out]
+def A.lol(self):
+    self :: A
+    r0 :: int
+    r1 :: bool
+    r2 :: None
+L0:
+    r0 = 100
+    self.x = r0; r1 = is_error
+    r2 = None
+    return r2
+def A.__mypyc_defaults_setup(self):
+    self :: A
+    r0 :: int
+    r1, r2 :: bool
+L0:
+    r0 = 10
+    self.x = r0; r1 = is_error
+    r2 = True
+    return r2
+def B.__mypyc_defaults_setup(self):
+    self :: B
+    r0 :: object
+    r1 :: str
+    r2 :: object
+    r3 :: str
+    r4 :: bool
+    r5 :: None
+    r6, r7, r8 :: bool
+    r9 :: int
+    r10, r11 :: bool
+L0:
+    r0 = __main__.globals :: static
+    r1 = unicode_1 :: static  ('LOL')
+    r2 = r0[r1] :: dict
+    r3 = cast(str, r2)
+    self.y = r3; r4 = is_error
+    r5 = None
+    self.z = r5; r6 = is_error
+    r7 = True
+    self.b = r7; r8 = is_error
+    r9 = 10
+    self.x = r9; r10 = is_error
+    r11 = True
+    return r11
+def __top_level__():
+    r0 :: str
+    r1 :: object
+    r2 :: str
+    r3 :: bool
+    r4 :: None
+L0:
+    r0 = unicode_0 :: static  ('lol')
+    r1 = __main__.globals :: static
+    r2 = unicode_1 :: static  ('LOL')
+    r3 = r1.__setitem__(r2, r0) :: object
+    r4 = None
+    return r4

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -488,3 +488,49 @@ from native import A, f
 assert f() == 10
 A.x = 200
 assert f() == 200
+
+[case testDefaultVars]
+from typing import ClassVar, Optional
+class A:
+    x = 10
+    def lol(self) -> None:
+        self.x = 100
+
+LOL = 'lol'
+class B(A):
+    y = LOL
+    z = None  # type: Optional[str]
+    b = True
+    bogus = None  # type: int
+
+def g() -> None:
+    a = A()
+    assert a.x == 10
+    a.x = 20
+    assert a.x == 20
+    b = B()
+    assert b.x == 10
+    b.x = 20
+    assert b.x == 20
+    assert b.y == 'lol'
+    b.y = 'rofl'
+    assert b.y == 'rofl'
+    assert b.z is None
+[file driver.py]
+from native import *
+g()
+
+a = A()
+assert a.x == 10
+a.x = 20
+assert a.x == 20
+b = B()
+assert b.x == 10
+b.x = 20
+assert b.x == 20
+assert b.y == 'lol'
+b.y = 'rofl'
+assert b.y == 'rofl'
+assert b.z is None
+# N.B: this doesn't match cpython
+assert not hasattr(b, 'bogus')


### PR DESCRIPTION
The necessity of interoperating properly via the C API makes it
difficult for us to faithfully implement class variables.

By default CPython relies on the interaction of instance `__dict__`s
and class `__dict__`s to provide the "default" behavior of falling
back to a class variable when the instance variable is missing. We
install data descriptors in the class dictionary, however, which
prevents taking advantage of this mechanism. Fully implementing the
cpython behavior would require a custom `__setattr__` on our class
types, which means using a metaclass for them.

So instead we implement a much more restricted form of class
variables.  Only class variables that are actually typed as `ClassVar`
are considered to be real class variables. They can be accessed
through the class. All other class variables are treated as simply
being default values for attributes. These default values can't be
accessed via the class, so they can't be changed.

When a non-Optional field is intialized to `None` in the class, we
simply ignore the default value. We could instead store an optional
type in the object and cast it away on attribute access, but this
would be extra work and increased code size with the only real benefit
being that access raises a `TypeError` instead of an `AttributeError`.

Closes #218.
Closes #186.