### PR TITLE
Implement @staticmethod and @classmethod

### DIFF
--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -9,7 +9,8 @@ from mypyc.emit import Emitter
 from mypyc.emitfunc import native_function_header
 from mypyc.ops import (
     ClassIR, FuncIR, FuncDecl, RType, RTuple, Environment, object_rprimitive, FuncSignature,
-    VTableMethod, VTableAttr, VTableEntries
+    VTableMethod, VTableAttr, VTableEntries,
+    FUNC_STATICMETHOD, FUNC_CLASSMETHOD,
 )
 from mypyc.sametype import is_same_type
 from mypyc.namegen import NameGenerator
@@ -390,7 +391,13 @@ def generate_methods_table(cl: ClassIR,
     for fn in cl.methods.values():
         emitter.emit_line('{{"{}",'.format(fn.name))
         emitter.emit_line(' (PyCFunction){}{},'.format(PREFIX, fn.cname(emitter.names)))
-        emitter.emit_line(' METH_VARARGS | METH_KEYWORDS, NULL},')
+        flags = ['METH_VARARGS', 'METH_KEYWORDS']
+        if fn.decl.kind == FUNC_STATICMETHOD:
+            flags.append('METH_STATIC')
+        elif fn.decl.kind == FUNC_CLASSMETHOD:
+            flags.append('METH_CLASS')
+
+        emitter.emit_line(' {}, NULL}},'.format(' | '.join(flags)))
     emitter.emit_line('{NULL}  /* Sentinel */')
     emitter.emit_line('};')
 

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -208,7 +208,7 @@ def compute_vtable(cls: ClassIR) -> None:
     for t in [cls] + cls.traits:
         for fn in itertools.chain(t.properties.values(), t.methods.values()):
             # TODO: don't generate a new entry when we overload without changing the type
-            if fn == cls.get_method(fn.name) and fn.decl.kind == FUNC_NORMAL:
+            if fn == cls.get_method(fn.name):
                 cls.vtable[fn.name] = len(entries)
                 entries.append(VTableMethod(t, fn.name, fn))
 
@@ -1594,11 +1594,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
 
         # If the base type is one of ours, do a MethodCall
         if isinstance(base.type, RInstance):
-            decl = (base.type.class_ir.method_decl(name)
-                    if base.type.class_ir.has_method(name) else None)
-            # We only do MethodCall to normal methods, not staticmethod/classmethods.
-            # This wouldn't be too hard to fix, though.
-            if decl and decl.kind == FUNC_NORMAL:
+            if base.type.class_ir.has_method(name):
+                decl = base.type.class_ir.method_decl(name)
                 if arg_kinds is None:
                     assert arg_names is None, "arg_kinds not present but arg_names is"
                     arg_kinds = [ARG_POS for _ in arg_values]

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1220,7 +1220,10 @@ class FuncDecl:
         if class_name is None:
             self.bound_sig = None  # type: Optional[FuncSignature]
         else:
-            self.bound_sig = FuncSignature(sig.args[1:], sig.ret_type)
+            if kind == FUNC_STATICMETHOD:
+                self.bound_sig = sig
+            else:
+                self.bound_sig = FuncSignature(sig.args[1:], sig.ret_type)
 
     def cname(self, names: NameGenerator) -> str:
         name = self.name

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1200,16 +1200,23 @@ class FuncSignature:
         return 'FuncSignature(args=%r, ret=%r)' % (self.args, self.ret_type)
 
 
+FUNC_NORMAL = 0
+FUNC_STATICMETHOD = 1
+FUNC_CLASSMETHOD = 2
+
+
 class FuncDecl:
     def __init__(self,
                  name: str,
                  class_name: Optional[str],
                  module_name: str,
-                 sig: FuncSignature) -> None:
+                 sig: FuncSignature,
+                 kind: int = FUNC_NORMAL) -> None:
         self.name = name
         self.class_name = class_name
         self.module_name = module_name
         self.sig = sig
+        self.kind = kind
         if class_name is None:
             self.bound_sig = None  # type: Optional[FuncSignature]
         else:

--- a/test-data/fixtures/ir.py
+++ b/test-data/fixtures/ir.py
@@ -148,3 +148,7 @@ def len(o: Sized) -> int: pass
 def print(*object) -> None: pass
 def range(x: int) -> Iterator[int]: pass
 def isinstance(x: object, t: object) -> bool: pass
+
+# Dummy definitions.
+class classmethod: pass
+class staticmethod: pass

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -359,6 +359,42 @@ L0:
     r2 = None
     return r2
 
+[case testClassMethod]
+class C:
+    @staticmethod
+    def foo(x: int) -> int: return 10 + x
+    @classmethod
+    def bar(cls, x: int) -> int: return 10 + x
+
+def lol() -> int:
+    return C.foo(1) + C.bar(2)
+[out]
+def C.foo(x):
+    x, r0, r1 :: int
+L0:
+    r0 = 10
+    r1 = r0 + x :: int
+    return r1
+def C.bar(cls, x):
+    cls :: object
+    x, r0, r1 :: int
+L0:
+    r0 = 10
+    r1 = r0 + x :: int
+    return r1
+def lol():
+    r0, r1 :: int
+    r2 :: object
+    r3, r4, r5 :: int
+L0:
+    r0 = 1
+    r1 = C.foo(r0)
+    r2 = __main__.C :: type
+    r3 = 2
+    r4 = C.bar(r2, r3)
+    r5 = r1 + r4 :: int
+    return r5
+
 [case testSuper1]
 class A:
     def __init__(self, x: int) -> None:

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -413,6 +413,31 @@ Traceback (most recent call last):
     A().x
 AttributeError: attribute 'x' of 'X' undefined
 
+[case testClassMethods]
+from typing import ClassVar
+class C:
+    lurr: ClassVar[int] = 9
+    @staticmethod
+    def foo(x: int) -> int: return 10 + x
+    @classmethod
+    def bar(cls, x: int) -> int: return cls.lurr + x
+
+def test1() -> int:
+    return C.foo(1) + C.bar(2)
+def test2() -> int:
+    c = C()
+    return c.foo(1) + c.bar(2)
+[file driver.py]
+from native import *
+assert C.foo(10) == 20
+assert C.bar(10) == 19
+c = C()
+assert c.foo(10) == 20
+assert c.bar(10) == 19
+
+assert test1() == 22
+assert test2() == 22
+
 [case testSuper]
 from mypy_extensions import trait
 from typing import List


### PR DESCRIPTION
We support direct calls to them via the class, and otherwise go
through the C API.  It will not be particularly difficult to add
wrappers to object vtables to dispatch to static methods, but it
doesn't seem important either.

Closes #177.
Closes #180.