### PR TITLE
Support subclassing python classes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@ Mypyc is licensed under the terms of the MIT license, reproduced below.
 
 The MIT License
 
-Copyright (c) 2017 Jukka Lehtosalo and contributors
+Copyright (c) 2017-2018 Jukka Lehtosalo and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -45,8 +45,9 @@ analyze, test, perform and/or display publicly, prepare derivative works,
 distribute, and otherwise use Python alone or in any derivative version,
 provided, however, that PSF's License Agreement and PSF's notice of copyright,
 i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
-2011, 2012 Python Software Foundation; All Rights Reserved" are retained in Python
-alone or in any derivative version prepared by Licensee.
+2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018 Python Software Foundation; All
+Rights Reserved" are retained in Python alone or in any derivative version
+prepared by Licensee.
 
 3. In the event Licensee prepares a derivative work that is based on
 or incorporates Python or any part thereof, and wants to make

--- a/LICENSE
+++ b/LICENSE
@@ -25,3 +25,203 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 = = = = =
+
+Portions of mypyc are licensed under different licenses.  The file
+lib-rt/pythonsupport.h is licensed under the PSF 2 License, reproduced below.
+
+= = = = =
+
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+--------------------------------------------
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+("PSF"), and the Individual or Organization ("Licensee") accessing and
+otherwise using this software ("Python") in source or binary form and
+its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF hereby
+grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+analyze, test, perform and/or display publicly, prepare derivative works,
+distribute, and otherwise use Python alone or in any derivative version,
+provided, however, that PSF's License Agreement and PSF's notice of copyright,
+i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+2011, 2012 Python Software Foundation; All Rights Reserved" are retained in Python
+alone or in any derivative version prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python.
+
+4. PSF is making Python available to Licensee on an "AS IS"
+basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between PSF and
+Licensee.  This License Agreement does not grant permission to use PSF
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.
+
+
+BEOPEN.COM LICENSE AGREEMENT FOR PYTHON 2.0
+-------------------------------------------
+
+BEOPEN PYTHON OPEN SOURCE LICENSE AGREEMENT VERSION 1
+
+1. This LICENSE AGREEMENT is between BeOpen.com ("BeOpen"), having an
+office at 160 Saratoga Avenue, Santa Clara, CA 95051, and the
+Individual or Organization ("Licensee") accessing and otherwise using
+this software in source or binary form and its associated
+documentation ("the Software").
+
+2. Subject to the terms and conditions of this BeOpen Python License
+Agreement, BeOpen hereby grants Licensee a non-exclusive,
+royalty-free, world-wide license to reproduce, analyze, test, perform
+and/or display publicly, prepare derivative works, distribute, and
+otherwise use the Software alone or in any derivative version,
+provided, however, that the BeOpen Python License is retained in the
+Software, alone or in any derivative version prepared by Licensee.
+
+3. BeOpen is making the Software available to Licensee on an "AS IS"
+basis.  BEOPEN MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, BEOPEN MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+4. BEOPEN SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF THE
+SOFTWARE FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS
+AS A RESULT OF USING, MODIFYING OR DISTRIBUTING THE SOFTWARE, OR ANY
+DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+5. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+6. This License Agreement shall be governed by and interpreted in all
+respects by the law of the State of California, excluding conflict of
+law provisions.  Nothing in this License Agreement shall be deemed to
+create any relationship of agency, partnership, or joint venture
+between BeOpen and Licensee.  This License Agreement does not grant
+permission to use BeOpen trademarks or trade names in a trademark
+sense to endorse or promote products or services of Licensee, or any
+third party.  As an exception, the "BeOpen Python" logos available at
+http://www.pythonlabs.com/logos.html may be used according to the
+permissions granted on that web page.
+
+7. By copying, installing or otherwise using the software, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.
+
+
+CNRI LICENSE AGREEMENT FOR PYTHON 1.6.1
+---------------------------------------
+
+1. This LICENSE AGREEMENT is between the Corporation for National
+Research Initiatives, having an office at 1895 Preston White Drive,
+Reston, VA 20191 ("CNRI"), and the Individual or Organization
+("Licensee") accessing and otherwise using Python 1.6.1 software in
+source or binary form and its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, CNRI
+hereby grants Licensee a nonexclusive, royalty-free, world-wide
+license to reproduce, analyze, test, perform and/or display publicly,
+prepare derivative works, distribute, and otherwise use Python 1.6.1
+alone or in any derivative version, provided, however, that CNRI's
+License Agreement and CNRI's notice of copyright, i.e., "Copyright (c)
+1995-2001 Corporation for National Research Initiatives; All Rights
+Reserved" are retained in Python 1.6.1 alone or in any derivative
+version prepared by Licensee.  Alternately, in lieu of CNRI's License
+Agreement, Licensee may substitute the following text (omitting the
+quotes): "Python 1.6.1 is made available subject to the terms and
+conditions in CNRI's License Agreement.  This Agreement together with
+Python 1.6.1 may be located on the Internet using the following
+unique, persistent identifier (known as a handle): 1895.22/1013.  This
+Agreement may also be obtained from a proxy server on the Internet
+using the following URL: http://hdl.handle.net/1895.22/1013".
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python 1.6.1 or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python 1.6.1.
+
+4. CNRI is making Python 1.6.1 available to Licensee on an "AS IS"
+basis.  CNRI MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, CNRI MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON 1.6.1 WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. CNRI SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+1.6.1 FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 1.6.1,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. This License Agreement shall be governed by the federal
+intellectual property law of the United States, including without
+limitation the federal copyright law, and, to the extent such
+U.S. federal law does not apply, by the law of the Commonwealth of
+Virginia, excluding Virginia's conflict of law provisions.
+Notwithstanding the foregoing, with regard to derivative works based
+on Python 1.6.1 that incorporate non-separable material that was
+previously distributed under the GNU General Public License (GPL), the
+law of the Commonwealth of Virginia shall govern this License
+Agreement only as to issues arising under or with respect to
+Paragraphs 4, 5, and 7 of this License Agreement.  Nothing in this
+License Agreement shall be deemed to create any relationship of
+agency, partnership, or joint venture between CNRI and Licensee.  This
+License Agreement does not grant permission to use CNRI trademarks or
+trade name in a trademark sense to endorse or promote products or
+services of Licensee, or any third party.
+
+8. By clicking on the "ACCEPT" button where indicated, or by copying,
+installing or otherwise using Python 1.6.1, Licensee agrees to be
+bound by the terms and conditions of this License Agreement.
+
+        ACCEPT
+
+
+CWI LICENSE AGREEMENT FOR PYTHON 0.9.0 THROUGH 1.2
+--------------------------------------------------
+
+Copyright (c) 1991 - 1995, Stichting Mathematisch Centrum Amsterdam,
+The Netherlands.  All rights reserved.
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted,
+provided that the above copyright notice appear in all copies and that
+both that copyright notice and this permission notice appear in
+supporting documentation, and that the name of Stichting Mathematisch
+Centrum or CWI not be used in advertising or publicity pertaining to
+distribution of the software without specific, written prior
+permission.
+
+STICHTING MATHEMATISCH CENTRUM DISCLAIMS ALL WARRANTIES WITH REGARD TO
+THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS, IN NO EVENT SHALL STICHTING MATHEMATISCH CENTRUM BE LIABLE
+FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+= = = = =

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -163,7 +163,6 @@ static inline PyObject *CPyType_FromTemplate(PyTypeObject *template_,
         // to the proxy.
         if (PyDict_SetItemString(t->ht_type.tp_dict, "_gorg", (PyObject *)t) < 0)
             goto error;
-        Py_DECREF(dummy_class);
     }
 
     if (PyObject_SetAttrString((PyObject *)t, "__module__", modname) < 0)
@@ -171,6 +170,8 @@ static inline PyObject *CPyType_FromTemplate(PyTypeObject *template_,
 
     if (init_subclass((PyTypeObject *)t, NULL))
         goto error;
+
+    Py_XDECREF(dummy_class);
 
     return (PyObject *)t;
 

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -131,11 +131,8 @@ static inline PyObject *CPyType_FromTemplate(PyTypeObject *template_,
         Py_INCREF(bases);
     }
 
-    // Allocate the type and then copy the main stuff in.  We create
-    // it with the type metaclass and then set the real metaclass
-    // later, since otherwise there are some extra strictness checks
-    // about the mro we fail.
-    t = (PyHeapTypeObject*)PyType_GenericAlloc(&PyType_Type, 0);
+    // Allocate the type and then copy the main stuff in.
+    t = (PyHeapTypeObject*)PyType_GenericAlloc(metaclass, 0);
     if (!t)
         goto error;
     memcpy((char *)t + sizeof(PyVarObject),
@@ -156,9 +153,6 @@ static inline PyObject *CPyType_FromTemplate(PyTypeObject *template_,
 
     if (PyType_Ready((PyTypeObject *)t) < 0)
         goto error;
-
-    Py_INCREF(metaclass);
-    Py_TYPE(t) = metaclass;
 
     if (dummy_class) {
         if (PyDict_Merge(t->ht_type.tp_dict, dummy_class->tp_dict, 0) != 0)

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -85,7 +85,6 @@ static inline PyObject *CPyType_FromTemplate(PyTypeObject *template_,
         ((PyObject *)t)->ob_type = metatype;
     }
 
-
     PyObject *name = PyUnicode_FromString(template_->tp_name);
     t->ht_name = name;
     Py_INCREF(name);

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -148,7 +148,8 @@ static inline PyObject *CPyType_FromTemplate(PyTypeObject *template_,
     }
 
     // Allocate the type and then copy the main stuff in.
-    t = (PyHeapTypeObject*)PyType_GenericAlloc(metaclass, 0);
+    // XXX: hack
+    t = (PyHeapTypeObject*)PyType_GenericAlloc(&PyType_Type, 0);
     if (!t)
         goto error;
     memcpy((char *)t + sizeof(PyVarObject),
@@ -169,6 +170,8 @@ static inline PyObject *CPyType_FromTemplate(PyTypeObject *template_,
 
     if (PyType_Ready((PyTypeObject *)t) < 0)
         goto error;
+
+    Py_TYPE(t) = metaclass;
 
     if (dummy_class) {
         if (PyDict_Merge(t->ht_type.tp_dict, dummy_class->tp_dict, 0) != 0)

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -81,7 +81,6 @@ static inline PyObject *CPyType_FromTemplate(PyTypeObject *template_,
 
     PyObject *old_bases = bases;
     if (bases) {
-        Py_INCREF(old_bases);
         bases = update_bases(old_bases);
 
         // Find the appropriate metaclass from our base classes. We
@@ -171,14 +170,12 @@ static inline PyObject *CPyType_FromTemplate(PyTypeObject *template_,
         goto error;
 
     Py_XDECREF(bases);
-    Py_XDECREF(old_bases);
 
     return (PyObject *)t;
 
 error:
     Py_XDECREF(t);
     Py_XDECREF(bases);
-    Py_XDECREF(old_bases);
     Py_XDECREF(dummy_class);
     return NULL;
 }

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -70,6 +70,8 @@ static inline void CPy_FixupTraitVtable(CPyVTableItem *vtable, int count) {
 
 // Create a heap type based on a template non-heap type.
 // This is super hacky and maybe we should suck it up and use PyType_FromSpec instead.
+// We allow bases to be NULL to represent just inheriting from object.
+// We don't support NULL bases and a non-type metaclass.
 static inline PyObject *CPyType_FromTemplate(PyTypeObject *template_,
                                              PyObject *bases,
                                              PyObject *modname) {
@@ -109,6 +111,8 @@ static inline PyObject *CPyType_FromTemplate(PyTypeObject *template_,
     // but for the case of GenericMeta setting a bunch of properties
     // on the class we should be fine.
     if (metaclass != &PyType_Type) {
+        assert(bases && "non-type metaclasses require non-NULL bases");
+
         PyObject *ns = PyDict_New();
         if (!ns) goto error;
 

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -5,7 +5,7 @@
 #include <Python.h>
 #include <frameobject.h>
 #include <assert.h>
-#include <pythonsupport.h>
+#include "pythonsupport.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -75,6 +75,7 @@ static inline PyObject *CPyType_FromTemplate(PyTypeObject *template_,
                                              PyObject *modname) {
     PyHeapTypeObject *t = NULL;
     PyTypeObject *dummy_class = NULL;
+    PyObject *name;
 
     PyTypeObject *metaclass = Py_TYPE(template_);
 
@@ -104,7 +105,7 @@ static inline PyObject *CPyType_FromTemplate(PyTypeObject *template_,
             goto error;
     }
 
-    PyObject *name = PyUnicode_FromString(template_->tp_name);
+    name = PyUnicode_FromString(template_->tp_name);
     if (!name)
         goto error;
     t->ht_name = name;

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -118,7 +118,8 @@ static inline PyObject *CPyType_FromTemplate(PyTypeObject *template_,
         assert(bases && "non-type metaclasses require non-NULL bases");
 
         PyObject *ns = PyDict_New();
-        if (!ns) goto error;
+        if (!ns)
+            goto error;
 
         dummy_class = (PyTypeObject *)PyObject_CallFunctionObjArgs(
             (PyObject *)metaclass, name, bases, ns, NULL);

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -77,7 +77,7 @@ static inline PyObject *CPyType_FromTemplate(PyTypeObject *template_,
                                              PyObject *modname) {
     PyHeapTypeObject *t = NULL;
     PyTypeObject *dummy_class = NULL;
-    PyObject *name;
+    PyObject *name = NULL;
 
     PyTypeObject *metaclass = Py_TYPE(template_);
 
@@ -146,6 +146,7 @@ static inline PyObject *CPyType_FromTemplate(PyTypeObject *template_,
     t->ht_name = name;
     Py_INCREF(name);
     t->ht_qualname = name;
+    name = NULL;  // last ref to name stolen by ht_qualname, so NULL it out
     Py_XINCREF(bases);
     t->ht_type.tp_bases = bases;
 
@@ -181,6 +182,7 @@ error:
     Py_XDECREF(t);
     Py_XDECREF(bases);
     Py_XDECREF(dummy_class);
+    Py_XDECREF(name);
     return NULL;
 }
 

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -81,7 +81,7 @@ static inline PyObject *CPyType_FromTemplate(PyTypeObject *template_,
 
     PyObject *old_bases = bases;
     if (bases) {
-        Py_INCREF(bases);
+        Py_INCREF(old_bases);
         bases = update_bases(old_bases);
 
         // Find the appropriate metaclass from our base classes. We
@@ -146,6 +146,7 @@ static inline PyObject *CPyType_FromTemplate(PyTypeObject *template_,
     if (PyType_Ready((PyTypeObject *)t) < 0)
         goto error;
 
+    Py_INCREF(metaclass);
     Py_TYPE(t) = metaclass;
 
     if (dummy_class) {

--- a/lib-rt/pythonsupport.h
+++ b/lib-rt/pythonsupport.h
@@ -89,9 +89,17 @@ error:
     Py_XDECREF(new_bases);
     return NULL;
 }
+#else
+static PyObject*
+update_bases(PyObject *bases)
+{
+    return bases;
+}
+#endif
 
-_Py_IDENTIFIER(__init_subclass__);
 // From Python 3.7's typeobject.c
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 6
+_Py_IDENTIFIER(__init_subclass__);
 static int
 init_subclass(PyTypeObject *type, PyObject *kwds)
 {
@@ -120,12 +128,6 @@ init_subclass(PyTypeObject *type, PyObject *kwds)
 }
 
 #else
-static PyObject*
-update_bases(PyObject *bases)
-{
-    return bases;
-}
-
 static int
 init_subclass(PyTypeObject *type, PyObject *kwds)
 {

--- a/lib-rt/pythonsupport.h
+++ b/lib-rt/pythonsupport.h
@@ -1,0 +1,138 @@
+#ifndef CPY_PYTHONSUPPORT_H
+#define CPY_PYTHONSUPPORT_H
+
+#include <stdbool.h>
+#include <Python.h>
+#include <frameobject.h>
+#include <assert.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if 0
+} // why isn't emacs smart enough to not indent this
+#endif
+
+/////////////////////////////////////////
+// Adapted from bltinmodule.c in Python 3.7.0
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 7
+_Py_IDENTIFIER(__mro_entries__);
+static PyObject*
+update_bases(PyObject *bases)
+{
+    Py_ssize_t i, j;
+    PyObject *base, *meth, *new_base, *result, *new_bases = NULL;
+    PyObject *stack[1] = {bases};
+    assert(PyTuple_Check(bases));
+
+    Py_ssize_t nargs = PyTuple_GET_SIZE(bases);
+    for (i = 0; i < nargs; i++) {
+        base = PyTuple_GET_ITEM(bases, i);
+        if (PyType_Check(base)) {
+            if (new_bases) {
+                /* If we already have made a replacement, then we append every normal base,
+                   otherwise just skip it. */
+                if (PyList_Append(new_bases, base) < 0) {
+                    goto error;
+                }
+            }
+            continue;
+        }
+        if (_PyObject_LookupAttrId(base, &PyId___mro_entries__, &meth) < 0) {
+            goto error;
+        }
+        if (!meth) {
+            if (new_bases) {
+                if (PyList_Append(new_bases, base) < 0) {
+                    goto error;
+                }
+            }
+            continue;
+        }
+        new_base = _PyObject_FastCall(meth, stack, 1);
+        Py_DECREF(meth);
+        if (!new_base) {
+            goto error;
+        }
+        if (!PyTuple_Check(new_base)) {
+            PyErr_SetString(PyExc_TypeError,
+                            "__mro_entries__ must return a tuple");
+            Py_DECREF(new_base);
+            goto error;
+        }
+        if (!new_bases) {
+            /* If this is a first successful replacement, create new_bases list and
+               copy previously encountered bases. */
+            if (!(new_bases = PyList_New(i))) {
+                goto error;
+            }
+            for (j = 0; j < i; j++) {
+                base = PyTuple_GET_ITEM(bases, j);
+                PyList_SET_ITEM(new_bases, j, base);
+                Py_INCREF(base);
+            }
+        }
+        j = PyList_GET_SIZE(new_bases);
+        if (PyList_SetSlice(new_bases, j, j, new_base) < 0) {
+            goto error;
+        }
+        Py_DECREF(new_base);
+    }
+    if (!new_bases) {
+        return bases;
+    }
+    result = PyList_AsTuple(new_bases);
+    Py_DECREF(new_bases);
+    return result;
+
+error:
+    Py_XDECREF(new_bases);
+    return NULL;
+}
+
+_Py_IDENTIFIER(__init_subclass__);
+// From Python 3.7's typeobject.c
+static int
+init_subclass(PyTypeObject *type, PyObject *kwds)
+{
+    PyObject *super, *func, *result;
+    PyObject *args[2] = {(PyObject *)type, (PyObject *)type};
+
+    super = _PyObject_FastCall((PyObject *)&PySuper_Type, args, 2);
+    if (super == NULL) {
+        return -1;
+    }
+
+    func = _PyObject_GetAttrId(super, &PyId___init_subclass__);
+    Py_DECREF(super);
+    if (func == NULL) {
+        return -1;
+    }
+
+    result = _PyObject_FastCallDict(func, NULL, 0, kwds);
+    Py_DECREF(func);
+    if (result == NULL) {
+        return -1;
+    }
+
+    Py_DECREF(result);
+    return 0;
+}
+
+#else
+static PyObject*
+update_bases(PyObject *bases)
+{
+    Py_INCREF(bases);
+    return bases;
+}
+
+static int
+init_subclass(PyTypeObject *type, PyObject *kwds)
+{
+    return 0;
+}
+#endif
+
+
+#endif

--- a/lib-rt/pythonsupport.h
+++ b/lib-rt/pythonsupport.h
@@ -134,5 +134,8 @@ init_subclass(PyTypeObject *type, PyObject *kwds)
 }
 #endif
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib-rt/pythonsupport.h
+++ b/lib-rt/pythonsupport.h
@@ -123,7 +123,6 @@ init_subclass(PyTypeObject *type, PyObject *kwds)
 static PyObject*
 update_bases(PyObject *bases)
 {
-    Py_INCREF(bases);
     return bases;
 }
 

--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -9,7 +9,7 @@ from mypyc.ops import (
     ControlOp,
     BasicBlock, OpVisitor, Assign, LoadInt, LoadErrorValue, RegisterOp, Goto, Branch, Return, Call,
     Environment, Box, Unbox, Cast, Op, Unreachable, TupleGet, TupleSet, GetAttr, SetAttr,
-    LoadStatic, PrimitiveOp, MethodCall, RaiseStandardError,
+    LoadStatic, InitStatic, PrimitiveOp, MethodCall, RaiseStandardError,
 )
 
 
@@ -120,6 +120,9 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill]):
         return self.visit_register_op(op)
 
     def visit_load_static(self, op: LoadStatic) -> GenAndKill:
+        return self.visit_register_op(op)
+
+    def visit_init_static(self, op: InitStatic) -> GenAndKill:
         return self.visit_register_op(op)
 
     def visit_tuple_get(self, op: TupleGet) -> GenAndKill:

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -77,6 +77,16 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
     else:
         as_mapping_name = '0'
 
+    # If the class inherits from python, make space for a __dict__
+    struct_name = cl.struct_name(emitter.names)
+    if cl.inherits_python:
+        tp_basicsize = 'sizeof({}) + 2*sizeof(PyObject *)'.format(struct_name)
+        tp_dictoffset = 'sizeof({})'.format(struct_name)
+        tp_weaklistoffset = 'sizeof({}) + sizeof(PyObject *)'.format(struct_name)
+    else:
+        tp_basicsize = 'sizeof({})'.format(struct_name)
+        tp_weaklistoffset = tp_dictoffset = '0'
+
     if not cl.is_trait:
         emitter.emit_line('static PyObject *{}(void);'.format(setup_name))
         # TODO: Use RInstance
@@ -106,7 +116,7 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
         static PyTypeObject {type_struct}_template_ = {{
             PyVarObject_HEAD_INIT(&PyType_Type, 0)
             "{name}",                  /* tp_name */
-            sizeof({struct_name}),     /* tp_basicsize */
+            {tp_basicsize},            /* tp_basicsize */
             0,                         /* tp_itemsize */
             (destructor){dealloc_name},  /* tp_dealloc */
             0,                         /* tp_print */
@@ -128,7 +138,7 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
             (traverseproc){traverse_name}, /* tp_traverse */
             (inquiry){clear_name},     /* tp_clear */
             0,                         /* tp_richcompare */
-            0,                         /* tp_weaklistoffset */
+            {tp_weaklistoffset},       /* tp_weaklistoffset */
             {iter_name},               /* tp_iter */
             {next_name},               /* tp_iternext */
             {methods_name},            /* tp_methods */
@@ -138,14 +148,13 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
             0,                         /* tp_dict */
             0,                         /* tp_descr_get */
             0,                         /* tp_descr_set */
-            0,                         /* tp_dictoffset */
+            {tp_dictoffset},           /* tp_dictoffset */
             {init_name},               /* tp_init */
             0,                         /* tp_alloc */
             {new_name},                /* tp_new */
         }};
         static PyTypeObject *{type_struct}_template = &{type_struct}_template_;\
         """).format(type_struct=emitter.type_struct_name(cl),
-                    struct_name=cl.struct_name(emitter.names),
                     name=name,
                     traverse_name=traverse_name,
                     clear_name=clear_name,
@@ -158,6 +167,9 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
                     getseters_name=getseters_name,
                     as_mapping_name=as_mapping_name,
                     init_name=init_name,
+                    tp_basicsize=tp_basicsize,
+                    tp_dictoffset=tp_dictoffset,
+                    tp_weaklistoffset=tp_weaklistoffset,
                     ))
     emitter.emit_line()
     if not cl.is_trait:

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -113,6 +113,10 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
     generate_methods_table(cl, methods_name, emitter)
     emit_line()
 
+    flags = ['Py_TPFLAGS_DEFAULT', 'Py_TPFLAGS_HAVE_GC', 'Py_TPFLAGS_HEAPTYPE',
+             'Py_TPFLAGS_BASETYPE']
+    tp_flags = ' | '.join(flags)
+
     emitter.emit_line(textwrap.dedent("""\
         static PyTypeObject {type_struct}_template_ = {{
             PyVarObject_HEAD_INIT(&PyType_Type, 0)
@@ -134,7 +138,7 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
             0,                         /* tp_getattro */
             0,                         /* tp_setattro */
             0,                         /* tp_as_buffer */
-            Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_HEAPTYPE, /* tp_flags */
+            {tp_flags},                /* tp_flags */
             0,                         /* tp_doc */
             (traverseproc){traverse_name}, /* tp_traverse */
             (inquiry){clear_name},     /* tp_clear */
@@ -168,6 +172,7 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
                     getseters_name=getseters_name,
                     as_mapping_name=as_mapping_name,
                     init_name=init_name,
+                    tp_flags=tp_flags,
                     tp_basicsize=tp_basicsize,
                     tp_dictoffset=tp_dictoffset,
                     tp_weaklistoffset=tp_weaklistoffset,

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -80,12 +80,16 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
 
     # If the class inherits from python, make space for a __dict__
     struct_name = cl.struct_name(emitter.names)
-    if cl.inherits_python:
-        tp_basicsize = 'sizeof({}) + 2*sizeof(PyObject *)'.format(struct_name)
-        tp_dictoffset = 'sizeof({})'.format(struct_name)
-        tp_weaklistoffset = 'sizeof({}) + sizeof(PyObject *)'.format(struct_name)
+    if cl.is_trait:
+        base_size = 'sizeof(PyObject)'
     else:
-        tp_basicsize = 'sizeof({})'.format(struct_name)
+        base_size = 'sizeof({})'.format(struct_name)
+    if cl.inherits_python:
+        tp_basicsize = '{} + 2*sizeof(PyObject *)'.format(base_size)
+        tp_dictoffset = base_size
+        tp_weaklistoffset = '{} + sizeof(PyObject *)'.format(base_size)
+    else:
+        tp_basicsize = base_size
         tp_weaklistoffset = tp_dictoffset = '0'
 
     if not cl.is_trait:

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -40,7 +40,7 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
 
     getseters_name = '{}_getseters'.format(name_prefix)
     methods_name = '{}_methods'.format(name_prefix)
-    vtable_setup_name = '{}__trait_vtable_setup'.format(name_prefix)
+    vtable_setup_name = '{}_trait_vtable_setup'.format(name_prefix)
 
     def emit_line() -> None:
         emitter.emit_line()

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -103,7 +103,7 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
     emit_line()
 
     emitter.emit_line(textwrap.dedent("""\
-        static PyTypeObject {type_struct}_template = {{
+        static PyTypeObject {type_struct}_template_ = {{
             PyVarObject_HEAD_INIT(&PyType_Type, 0)
             "{name}",                  /* tp_name */
             sizeof({struct_name}),     /* tp_basicsize */
@@ -142,7 +142,8 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
             {init_name},               /* tp_init */
             0,                         /* tp_alloc */
             {new_name},                /* tp_new */
-        }};\
+        }};
+        static PyTypeObject *{type_struct}_template = &{type_struct}_template_;\
         """).format(type_struct=emitter.type_struct_name(cl),
                     struct_name=cl.struct_name(emitter.names),
                     name=name,

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -257,23 +257,14 @@ class ModuleGenerator:
                 assert False, ('Literals must be integers, floating point numbers, or strings,',
                                'but the provided literal is of type {}'.format(type(literal)))
 
-        # for cl in module.classes:
-        #     name = cl.name
-        #     type_struct = emitter.type_struct_name(cl)
-        #     emitter.emit_lines(
-        #         'Py_INCREF({});'.format(type_struct),
-        #         'PyModule_AddObject({}, "{}", (PyObject *){});'.format(module_static, name,
-        #                                                                type_struct))
-
         self.generate_top_level_call(module, emitter)
 
+        # TODO: This needs to be done right after the trait allocation
         for cl in module.classes:
             type_struct = emitter.type_struct_name(cl)
             if cl.trait_vtables and not cl.is_trait:
                 emitter.emit_lines('CPy_FixupTraitVtable({}_vtable, {});'.format(
                     cl.name_prefix(emitter.names), len(cl.trait_vtables)))
-
-
 
         emitter.emit_lines('Py_DECREF(modname);')
 

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -218,26 +218,15 @@ class ModuleGenerator:
             emitter,
         )
 
+        # HACK: Manually instantiate generated classes here
         for cl in module.classes:
-            type_struct = emitter.type_struct_name(cl)
-            # FIXME: This ought to be driven by emitclass, maybe?
-            real_base = cl.real_base()
-            if real_base or cl.traits:
-                bases = ([real_base] if real_base else []) + cl.traits
-                emitter.emit_lines('{}_template.tp_bases = PyTuple_Pack({}, {});'.format(
-                    type_struct,
-                    len(bases),
-                    ', '.join('{}'.format(emitter.type_struct_name(b)) for b in bases)))
-
-            emitter.emit_lines('{t} = CPyType_FromTemplate(&{t}_template, modname);'.format(
-                t=type_struct))
-            emitter.emit_lines('if (!{})'.format(type_struct),
-                               '    return NULL;')
-
-            type_struct = emitter.type_struct_name(cl)
-            if cl.trait_vtables and not cl.is_trait:
-                emitter.emit_lines('CPy_FixupTraitVtable({}_vtable, {});'.format(
-                    cl.name_prefix(emitter.names), len(cl.trait_vtables)))
+            if cl.is_generated:
+                type_struct = emitter.type_struct_name(cl)
+                emitter.emit_lines(
+                    '{t} = (PyTypeObject *)CPyType_FromTemplate({t}_template, NULL, modname);'.
+                    format(t=type_struct))
+                emitter.emit_lines('if (!{})'.format(type_struct),
+                                   '    return NULL;')
 
         for (_, literal), identifier in module.literals.items():
             symbol = emitter.static_name(identifier, None)
@@ -268,15 +257,23 @@ class ModuleGenerator:
                 assert False, ('Literals must be integers, floating point numbers, or strings,',
                                'but the provided literal is of type {}'.format(type(literal)))
 
-        for cl in module.classes:
-            name = cl.name
-            type_struct = emitter.type_struct_name(cl)
-            emitter.emit_lines(
-                'Py_INCREF({});'.format(type_struct),
-                'PyModule_AddObject({}, "{}", (PyObject *){});'.format(module_static, name,
-                                                                       type_struct))
+        # for cl in module.classes:
+        #     name = cl.name
+        #     type_struct = emitter.type_struct_name(cl)
+        #     emitter.emit_lines(
+        #         'Py_INCREF({});'.format(type_struct),
+        #         'PyModule_AddObject({}, "{}", (PyObject *){});'.format(module_static, name,
+        #                                                                type_struct))
 
         self.generate_top_level_call(module, emitter)
+
+        for cl in module.classes:
+            type_struct = emitter.type_struct_name(cl)
+            if cl.trait_vtables and not cl.is_trait:
+                emitter.emit_lines('CPy_FixupTraitVtable({}_vtable, {});'.format(
+                    cl.name_prefix(emitter.names), len(cl.trait_vtables)))
+
+
 
         emitter.emit_lines('Py_DECREF(modname);')
 

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -259,13 +259,6 @@ class ModuleGenerator:
 
         self.generate_top_level_call(module, emitter)
 
-        # TODO: This needs to be done right after the trait allocation
-        for cl in module.classes:
-            type_struct = emitter.type_struct_name(cl)
-            if cl.trait_vtables and not cl.is_trait:
-                emitter.emit_lines('CPy_FixupTraitVtable({}_vtable, {});'.format(
-                    cl.name_prefix(emitter.names), len(cl.trait_vtables)))
-
         emitter.emit_lines('Py_DECREF(modname);')
 
         emitter.emit_line('return {};'.format(module_static))

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -847,8 +847,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                           [self.load_globals_dict(), self.load_static_unicode(cdef.name),
                            tp], cdef.line)
 
-        # XXX: *WE* need to do the trait patchup!
-
+        # TODO: *WE* need to do the trait patchup here because something could try to
+        # use it right away.
 
     def visit_import(self, node: Import) -> None:
         if node.is_unreachable or node.is_mypy_only:

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -365,7 +365,10 @@ def prepare_class_def(module_name: str, cdef: ClassDef, mapper: Mapper) -> None:
     mro = []
     base_mro = []
     for cls in info.mro:
-        if cls not in mapper.type_to_ir: continue
+        if cls not in mapper.type_to_ir:
+            if cls.name != 'builtins.object':
+                ir.inherits_python = True
+            continue
         base_ir = mapper.type_to_ir[cls]
         if not base_ir.is_trait:
             base_mro.append(base_ir)
@@ -1687,7 +1690,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             return self.load_module_attr(expr)
         else:
             obj = self.accept(expr.expr)
-            if isinstance(obj.type, RInstance):
+            if isinstance(obj.type, RInstance) and obj.type.class_ir.has_attr(expr.name):
                 return self.add(GetAttr(obj, expr.name, expr.line))
             else:
                 return self.py_get_attr(obj, expr.name, expr.line)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -51,14 +51,18 @@ from mypyc.ops import (
     BasicBlock, AssignmentTarget, AssignmentTargetRegister, AssignmentTargetIndex,
     AssignmentTargetAttr, AssignmentTargetTuple, Environment, Op, LoadInt, RType, Value, Register,
     Return, FuncIR, Assign, Branch, Goto, RuntimeArg, Call, Box, Unbox, Cast, RTuple, Unreachable,
-    TupleGet, TupleSet, ClassIR, RInstance, ModuleIR, GetAttr, SetAttr, LoadStatic, ROptional,
-    MethodCall, INVALID_FUNC_DEF, int_rprimitive, float_rprimitive, bool_rprimitive,
-    list_rprimitive, is_list_rprimitive, dict_rprimitive, set_rprimitive, str_rprimitive,
-    tuple_rprimitive, none_rprimitive, is_none_rprimitive, object_rprimitive, exc_rtuple,
-    PrimitiveOp, ControlOp, LoadErrorValue, ERR_FALSE, OpDescription, RegisterOp,
-    is_object_rprimitive, LiteralsMap, FuncSignature, VTableAttr, VTableMethod, VTableEntries,
-    NAMESPACE_TYPE, RaiseStandardError, LoadErrorValue, NO_TRACEBACK_LINE_NO, FuncDecl,
-    FUNC_NORMAL, FUNC_STATICMETHOD, FUNC_CLASSMETHOD,
+    TupleGet, TupleSet, ClassIR, RInstance, ModuleIR, GetAttr, SetAttr, LoadStatic, InitStatic,
+    ROptional,
+    MethodCall, INVALID_FUNC_DEF, int_rprimitive, float_rprimitive,
+    bool_rprimitive, list_rprimitive, is_list_rprimitive, dict_rprimitive, set_rprimitive,
+    str_rprimitive, tuple_rprimitive, none_rprimitive, is_none_rprimitive, object_rprimitive,
+    exc_rtuple,
+    PrimitiveOp, ControlOp, LoadErrorValue,
+    ERR_FALSE, OpDescription, RegisterOp, is_object_rprimitive, LiteralsMap, FuncSignature,
+    VTableAttr, VTableMethod, VTableEntries,
+    NAMESPACE_TYPE, RaiseStandardError, LoadErrorValue,
+    NO_TRACEBACK_LINE_NO,
+    FuncDecl, FUNC_NORMAL, FUNC_STATICMETHOD, FUNC_CLASSMETHOD,
 )
 from mypyc.ops_primitive import binary_ops, unary_ops, func_ops, method_ops, name_ref_ops
 from mypyc.ops_list import (
@@ -72,6 +76,7 @@ from mypyc.ops_misc import (
     py_call_op, py_call_with_kwargs_op, py_method_call_op,
     fast_isinstance_op, bool_op, new_slice_op,
     is_none_op, type_op,
+    pytype_from_template_op,
 )
 from mypyc.ops_exc import (
     no_err_occurred_op, raise_exception_op, reraise_exception_op,
@@ -352,18 +357,15 @@ def prepare_class_def(module_name: str, cdef: ClassDef, mapper: Mapper) -> None:
         mapper.func_to_decl[cdef.info] = ir.ctor
 
     # Set up the parent class
-    assert all(base.type in mapper.type_to_ir for base in info.bases
-               if base.type.fullname() != 'builtins.object'), (
-        "Can't subclass cpython types")
     bases = [mapper.type_to_ir[base.type] for base in info.bases
-             if base.type.fullname() != 'builtins.object']
+             if base.type in mapper.type_to_ir]
     assert all(c.is_trait for c in bases[1:]), "Non trait bases must be first"
     ir.traits = [c for c in bases if c.is_trait]
 
     mro = []
     base_mro = []
     for cls in info.mro:
-        if cls.fullname() == 'builtins.object': continue
+        if cls not in mapper.type_to_ir: continue
         base_ir = mapper.type_to_ir[cls]
         if not base_ir.is_trait:
             base_mro.append(base_ir)
@@ -789,6 +791,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         cls.methods[ir.name] = ir
 
     def visit_class_def(self, cdef: ClassDef) -> None:
+        self.allocate_class(cdef)
+
         for stmt in cdef.defs.body:
             if isinstance(stmt, FuncDef):
                 self.visit_method(cdef, stmt)
@@ -818,6 +822,30 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                 assert False, "Unsupported statement in class body"
 
         self.generate_attr_defaults(cdef)
+
+    def allocate_class(self, cdef: ClassDef) -> None:
+        # OK AND NOW THE FUN PART
+        base_exprs = cdef.base_type_exprs + cdef.removed_base_type_exprs
+        if base_exprs:
+            bases = [self.accept(x) for x in base_exprs]
+            tp_bases = self.box(self.add(TupleSet(bases, cdef.line)))
+        else:
+            tp_bases = self.add(LoadErrorValue(object_rprimitive, is_borrowed=True))
+        modname = self.load_static_unicode(self.module_name)
+        template = self.add(LoadStatic(object_rprimitive, cdef.name + "_template",
+                                       self.module_name, NAMESPACE_TYPE))
+        # Create the class and assign it to whatever
+        tp = self.primitive_op(pytype_from_template_op,
+                               [template, tp_bases, modname], cdef.line)
+        self.add(InitStatic(tp, cdef.name, self.module_name, NAMESPACE_TYPE))
+
+        # Add it to the dict
+        self.primitive_op(dict_set_item_op,
+                          [self.load_globals_dict(), self.load_static_unicode(cdef.name),
+                           tp], cdef.line)
+
+        # XXX: *WE* need to do the trait patchup!
+
 
     def visit_import(self, node: Import) -> None:
         if node.is_unreachable or node.is_mypy_only:
@@ -1112,11 +1140,6 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
     def visit_assignment_stmt(self, stmt: AssignmentStmt) -> None:
         assert len(stmt.lvalues) >= 1
         self.disallow_class_assignments(stmt.lvalues)
-        if isinstance(stmt.rvalue, CallExpr) and isinstance(stmt.rvalue.analyzed, TypeVarExpr):
-            # Just ignore type variable declarations -- they are a compile-time only thing.
-            # TODO: It would be nice to actually construct TypeVar objects to match Python
-            #       semantics.
-            return
         lvalue = stmt.lvalues[0]
         if stmt.type and isinstance(stmt.rvalue, TempNode):
             # This is actually a variable annotation without initializer. Don't generate
@@ -1843,9 +1866,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         ret_args = []  # type: List[Value]
         for reg, arg in zip(args, sig.args):
             if reg is None:
-                reg = LoadErrorValue(arg.type)
-                reg.is_borrowed = True
-                self.add(reg)
+                reg = self.add(LoadErrorValue(arg.type, is_borrowed=True))
             ret_args.append(reg)
         return ret_args
 
@@ -3069,7 +3090,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
 
         # Define the actual callable class ClassIR, and set its environment to point at the
         # previously defined environment class.
-        callable_class_ir = ClassIR(name, self.module_name)
+        callable_class_ir = ClassIR(name, self.module_name, is_generated=True)
         callable_class_ir.attributes[ENV_ATTR_NAME] = RInstance(self.fn_infos[-2].env_class)
         callable_class_ir.mro = [callable_class_ir]
         self.fn_info.callable_class = CallableClass(callable_class_ir)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -833,7 +833,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                                [template, tp_bases, modname], cdef.line)
         # Immediately fix up the trait vtables, before doing anything with the class.
         self.add(Call(
-            FuncDecl(cdef.name + '__trait_vtable_setup',
+            FuncDecl(cdef.name + '_trait_vtable_setup',
                      None, self.module_name,
                      FuncSignature([], bool_rprimitive)), [], -1))
         # Save the class

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -908,9 +908,10 @@ class LoadErrorValue(RegisterOp):
 
     error_kind = ERR_NEVER
 
-    def __init__(self, rtype: RType, line: int = -1) -> None:
+    def __init__(self, rtype: RType, line: int = -1, is_borrowed: bool = False) -> None:
         super().__init__(line)
         self.type = rtype
+        self.is_borrowed = is_borrowed
 
     def sources(self) -> List[Value]:
         return []
@@ -1015,6 +1016,39 @@ class LoadStatic(RegisterOp):
 
     def accept(self, visitor: 'OpVisitor[T]') -> T:
         return visitor.visit_load_static(self)
+
+
+class InitStatic(RegisterOp):
+    """static = value :: static
+
+    Initialize a C static variable/pointer. See everything in LoadStatic.
+    """
+
+    error_kind = ERR_NEVER
+
+    def __init__(self,
+                 value: Value,
+                 identifier: str,
+                 module_name: Optional[str] = None,
+                 namespace: str = NAMESPACE_STATIC,
+                 line: int = -1) -> None:
+        super().__init__(line)
+        self.identifier = identifier
+        self.module_name = module_name
+        self.namespace = namespace
+        self.value = value
+
+    def sources(self) -> List[Value]:
+        return [self.value]
+
+    def to_str(self, env: Environment) -> str:
+        name = self.identifier
+        if self.module_name is not None:
+            name = '{}.{}'.format(self.module_name, name)
+        return env.format('%s = %r :: %s', name, self.value, self.namespace)
+
+    def accept(self, visitor: 'OpVisitor[T]') -> T:
+        return visitor.visit_init_static(self)
 
 
 class TupleSet(RegisterOp):
@@ -1340,10 +1374,12 @@ class ClassIR:
 
     This also describes the runtime structure of native instances.
     """
-    def __init__(self, name: str, module_name: str, is_trait: bool = False) -> None:
+    def __init__(self, name: str, module_name: str, is_trait: bool = False,
+                 is_generated: bool = True) -> None:
         self.name = name
         self.module_name = module_name
         self.is_trait = is_trait
+        self.is_generated = is_generated
         # Default empty ctor
         self.ctor = FuncDecl(name, None, module_name, FuncSignature([], RInstance(self)))
         # Properties are accessed like attributes, but have behaivor like method calls.
@@ -1491,6 +1527,10 @@ class OpVisitor(Generic[T]):
 
     @abstractmethod
     def visit_load_static(self, op: LoadStatic) -> T:
+        raise NotImplementedError
+
+    @abstractmethod
+    def visit_init_static(self, op: InitStatic) -> T:
         raise NotImplementedError
 
     @abstractmethod

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -21,7 +21,6 @@ from collections import OrderedDict
 from mypy.nodes import Block, SymbolNode, Var, FuncDef, ARG_POS, ARG_OPT, ARG_NAMED_OPT
 
 from mypyc.namegen import NameGenerator
-from mypyc.common import TOP_LEVEL_NAME
 
 
 T = TypeVar('T')
@@ -1625,10 +1624,6 @@ def format_func(fn: FuncIR) -> List[str]:
     code = format_blocks(fn.blocks, fn.env)
     lines.extend(code)
     return lines
-
-
-def is_empty_module_top_level(fn: FuncIR) -> bool:
-    return fn.name == TOP_LEVEL_NAME and len(fn.blocks) == 1 and len(fn.blocks[0].ops) == 2
 
 
 class RTypeVisitor(Generic[T]):

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1380,6 +1380,7 @@ class ClassIR:
         self.module_name = module_name
         self.is_trait = is_trait
         self.is_generated = is_generated
+        self.inherits_python = False
         # Default empty ctor
         self.ctor = FuncDecl(name, None, module_name, FuncSignature([], RInstance(self)))
         # Properties are accessed like attributes, but have behaivor like method calls.
@@ -1443,6 +1444,13 @@ class ClassIR:
     def has_method(self, name: str) -> bool:
         try:
             self.method_decl(name)
+        except KeyError:
+            return False
+        return True
+
+    def has_attr(self, name: str) -> bool:
+        try:
+            self.attr_type(name)
         except KeyError:
             return False
         return True

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -275,7 +275,7 @@ type_op = func_op(
 pytype_from_template_op = custom_op(
     arg_types=[object_rprimitive, object_rprimitive, str_rprimitive],
     result_type=object_rprimitive,
-    error_kind=ERR_NEVER,
+    error_kind=ERR_MAGIC,
     format_str='{dest} = pytype_from_template({comma_args})',
     emit=simple_emit(
         '{dest} = CPyType_FromTemplate((PyTypeObject *){args[0]}, {args[1]}, {args[2]});'))

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -3,8 +3,9 @@
 from typing import List
 
 from mypyc.ops import (
-    EmitterInterface, PrimitiveOp, none_rprimitive, bool_rprimitive, object_rprimitive, ERR_NEVER,
-    ERR_MAGIC, ERR_FALSE
+    EmitterInterface, PrimitiveOp,
+    none_rprimitive, bool_rprimitive, object_rprimitive, tuple_rprimitive, str_rprimitive,
+    ERR_NEVER, ERR_MAGIC, ERR_FALSE
 )
 from mypyc.ops_primitive import (
     name_ref_op, simple_emit, binary_op, unary_op, func_op, method_op, custom_op,
@@ -270,3 +271,11 @@ type_op = func_op(
     result_type=object_rprimitive,
     error_kind=ERR_NEVER,
     emit=simple_emit('{dest} = PyObject_Type({args[0]});'))
+
+pytype_from_template_op = custom_op(
+    arg_types=[object_rprimitive, object_rprimitive, str_rprimitive],
+    result_type=object_rprimitive,
+    error_kind=ERR_NEVER,
+    format_str='{dest} = pytype_from_template({comma_args})',
+    emit=simple_emit(
+        '{dest} = CPyType_FromTemplate((PyTypeObject *){args[0]}, {args[1]}, {args[2]});'))

--- a/mypyc/test/test_genops.py
+++ b/mypyc/test/test_genops.py
@@ -13,7 +13,8 @@ from mypy.options import Options
 from mypy import experiments
 
 from mypyc import genops
-from mypyc.ops import format_func, FuncIR, is_empty_module_top_level
+from mypyc.ops import format_func, FuncIR
+from mypyc.common import TOP_LEVEL_NAME
 
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, assert_test_output
@@ -72,7 +73,9 @@ class TestGenOps(MypycDataSuite):
                     module = modules[0][1]
                     actual = []
                     for fn in module.functions:
-                        if is_empty_module_top_level(fn):
+
+                        if (fn.name == fn.name == TOP_LEVEL_NAME
+                                and not testcase.name.endswith('_toplevel')):
                             # Skip trivial module top levels that only return.
                             continue
                         actual.extend(format_func(fn))

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -150,10 +150,10 @@ class TestRun(MypycDataSuite):
             output = output.decode('utf8')
             outlines = output.splitlines()
 
-            heading('Generated C')
-            with open(cpath) as f:
-                print(f.read().rstrip())
-            heading('End C')
+            # heading('Generated C')
+            # with open(cpath) as f:
+            #     print(f.read().rstrip())
+            # heading('End C')
             if proc.returncode != 0:
                 print()
                 print('*** Exit status: %d' % proc.returncode)

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -150,10 +150,10 @@ class TestRun(MypycDataSuite):
             output = output.decode('utf8')
             outlines = output.splitlines()
 
-            # heading('Generated C')
-            # with open(cpath) as f:
-            #     print(f.read().rstrip())
-            # heading('End C')
+            heading('Generated C')
+            with open(cpath) as f:
+                print(f.read().rstrip())
+            heading('End C')
             if proc.returncode != 0:
                 print()
                 print('*** Exit status: %d' % proc.returncode)

--- a/test-data/genops-any.test
+++ b/test-data/genops-any.test
@@ -62,11 +62,31 @@ L0:
     a = r4
     r5 = unbox(int, a)
     n = r5
-    r6 = unicode_0 :: static  ('a')
+    r6 = unicode_2 :: static  ('a')
     r7 = box(int, n)
     r8 = setattr a, r6, r7
     r9 = None
     return r9
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.C_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.C = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('C')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = None
+    return r8
 
 [case testCoerceAnyInOps]
 from typing import Any, List

--- a/test-data/genops-any.test
+++ b/test-data/genops-any.test
@@ -67,26 +67,6 @@ L0:
     r8 = setattr a, r6, r7
     r9 = None
     return r9
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.C_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.C = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('C')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = None
-    return r8
 
 [case testCoerceAnyInOps]
 from typing import Any, List

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -764,6 +764,26 @@ L0:
     o = r4
     r5 = None
     return r5
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = None
+    return r8
 
 [case testDownCast]
 from typing import cast, List, Tuple
@@ -796,6 +816,26 @@ L0:
     t = r4
     r5 = None
     return r5
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = None
+    return r8
 
 [case testDownCastSpecialCases]
 from typing import cast, Optional, Tuple
@@ -826,6 +866,26 @@ L0:
     t = r3
     r4 = None
     return r4
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = None
+    return r8
 
 [case testSuccessfulCast]
 from typing import cast, Optional, Tuple, List, Dict
@@ -878,6 +938,26 @@ L0:
     d2 = d
     r1 = None
     return r1
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = None
+    return r8
 
 [case testGenericSetItem]
 from typing import Any
@@ -1279,6 +1359,26 @@ L3:
     return r5
 L4:
     unreachable
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = None
+    return r8
 
 [case testRaise]
 def foo() -> None:
@@ -1459,14 +1559,34 @@ def g(a):
     r4 :: str
     r5, r6 :: None
 L0:
-    r0 = unicode_0 :: static  ('a')
+    r0 = unicode_2 :: static  ('a')
     r1 = 0
     r2 = a.f(r1, r0)
     r3 = 1
-    r4 = unicode_1 :: static  ('b')
+    r4 = unicode_3 :: static  ('b')
     r5 = a.f(r3, r4)
     r6 = None
     return r6
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = None
+    return r8
 
 [case testStarArgs]
 from typing import Tuple
@@ -1713,7 +1833,7 @@ L1:
 L2:
     if is_error(z) goto L3 else goto L4
 L3:
-    r1 = unicode_0 :: static  ('test')
+    r1 = unicode_2 :: static  ('test')
     z = r1
 L4:
     r2 = None
@@ -1739,6 +1859,26 @@ L0:
     r8 = a.f(r6, r5, r7)
     r9 = None
     return r9
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = None
+    return r8
 
 [case testListComprehension]
 from typing import List
@@ -1994,6 +2134,26 @@ L0:
     r1 = self.value
     r2 = r0 * r1 :: int
     return r2
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.PropertyHolder_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.PropertyHolder = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('PropertyHolder')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = None
+    return r8
 
 [case testPropertyDerivedGen]
 from typing import Callable
@@ -2108,7 +2268,7 @@ def DerivedProperty.next(self):
 L0:
     r0 = self._incr_func
     r1 = self.value
-    r2 = unicode_0 :: static  ('_incr_func')
+    r2 = unicode_3 :: static  ('_incr_func')
     r3 = box(int, r1)
     r4 = py_method_call(self, r2, r3)
     r5 = unbox(int, r4)
@@ -2145,11 +2305,11 @@ def AgainProperty.next(self):
 L0:
     r0 = self._incr_func
     r1 = self.value
-    r2 = unicode_0 :: static  ('_incr_func')
+    r2 = unicode_3 :: static  ('_incr_func')
     r3 = box(int, r1)
     r4 = py_method_call(self, r2, r3)
     r5 = unbox(int, r4)
-    r6 = unicode_0 :: static  ('_incr_func')
+    r6 = unicode_3 :: static  ('_incr_func')
     r7 = box(int, r5)
     r8 = py_method_call(self, r6, r7)
     r9 = unbox(int, r8)
@@ -2187,6 +2347,64 @@ L0:
     r0 = self.bad_value
     r1 = box(int, r0)
     return r1
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: object
+    r9 :: tuple[object]
+    r10 :: object
+    r11 :: str
+    r12, r13, r14 :: object
+    r15 :: str
+    r16 :: dict
+    r17 :: bool
+    r18 :: object
+    r19 :: tuple[object]
+    r20 :: object
+    r21 :: str
+    r22, r23, r24 :: object
+    r25 :: str
+    r26 :: dict
+    r27 :: bool
+    r28 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.BaseProperty_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.BaseProperty = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('BaseProperty')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = __main__.BaseProperty :: type
+    r9 = (r8)
+    r10 = box(tuple[object], r9)
+    r11 = unicode_0 :: static  ('__main__')
+    r12 = __main__.DerivedProperty_template :: type
+    r13 = pytype_from_template(r12, r10, r11)
+    __main__.DerivedProperty = r13 :: type
+    r14 = __main__.globals :: static
+    r15 = unicode_2 :: static  ('DerivedProperty')
+    r16 = cast(dict, r14)
+    r17 = r16.__setitem__(r15, r13) :: dict
+    r18 = __main__.DerivedProperty :: type
+    r19 = (r18)
+    r20 = box(tuple[object], r19)
+    r21 = unicode_0 :: static  ('__main__')
+    r22 = __main__.AgainProperty_template :: type
+    r23 = pytype_from_template(r22, r20, r21)
+    __main__.AgainProperty = r23 :: type
+    r24 = __main__.globals :: static
+    r25 = unicode_4 :: static  ('AgainProperty')
+    r26 = cast(dict, r24)
+    r27 = r26.__setitem__(r25, r23) :: dict
+    r28 = None
+    return r28
 
 [case testPropertyTraitSubclassing]
 from mypy_extensions import trait
@@ -2244,6 +2462,45 @@ L0:
     r0 = self.boxed
     r1 = box(int, r0)
     return r1
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: object
+    r9 :: tuple[object]
+    r10 :: object
+    r11 :: str
+    r12, r13, r14 :: object
+    r15 :: str
+    r16 :: dict
+    r17 :: bool
+    r18 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.SubclassedTrait_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.SubclassedTrait = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('SubclassedTrait')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = __main__.SubclassedTrait :: type
+    r9 = (r8)
+    r10 = box(tuple[object], r9)
+    r11 = unicode_0 :: static  ('__main__')
+    r12 = __main__.DerivingObject_template :: type
+    r13 = pytype_from_template(r12, r10, r11)
+    __main__.DerivingObject = r13 :: type
+    r14 = __main__.globals :: static
+    r15 = unicode_2 :: static  ('DerivingObject')
+    r16 = cast(dict, r14)
+    r17 = r16.__setitem__(r15, r13) :: dict
+    r18 = None
+    return r18
 
 [case testNativeIndex]
 from typing import List
@@ -2270,6 +2527,26 @@ L0:
     r2 = unbox(int, r1)
     r3 = r0 + r2 :: int
     return r3
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = None
+    return r8
 
 [case testTypeAlias]
 from typing import List, NewType, NamedTuple

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -764,26 +764,6 @@ L0:
     o = r4
     r5 = None
     return r5
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = None
-    return r8
 
 [case testDownCast]
 from typing import cast, List, Tuple
@@ -816,26 +796,6 @@ L0:
     t = r4
     r5 = None
     return r5
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = None
-    return r8
 
 [case testDownCastSpecialCases]
 from typing import cast, Optional, Tuple
@@ -866,26 +826,6 @@ L0:
     t = r3
     r4 = None
     return r4
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = None
-    return r8
 
 [case testSuccessfulCast]
 from typing import cast, Optional, Tuple, List, Dict
@@ -938,26 +878,6 @@ L0:
     d2 = d
     r1 = None
     return r1
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = None
-    return r8
 
 [case testGenericSetItem]
 from typing import Any
@@ -1359,26 +1279,6 @@ L3:
     return r5
 L4:
     unreachable
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = None
-    return r8
 
 [case testRaise]
 def foo() -> None:
@@ -1413,7 +1313,7 @@ L0:
     raise_exception(r2, r3); r4 = 0
     unreachable
 
-[case testModuleTopLevel]
+[case testModuleTopLevel_toplevel]
 x = 1
 print(x)
 
@@ -1567,26 +1467,6 @@ L0:
     r5 = a.f(r3, r4)
     r6 = None
     return r6
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = None
-    return r8
 
 [case testStarArgs]
 from typing import Tuple
@@ -1859,26 +1739,6 @@ L0:
     r8 = a.f(r6, r5, r7)
     r9 = None
     return r9
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = None
-    return r8
 
 [case testListComprehension]
 from typing import List
@@ -2134,26 +1994,6 @@ L0:
     r1 = self.value
     r2 = r0 * r1 :: int
     return r2
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.PropertyHolder_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.PropertyHolder = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('PropertyHolder')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = None
-    return r8
 
 [case testPropertyDerivedGen]
 from typing import Callable
@@ -2347,64 +2187,6 @@ L0:
     r0 = self.bad_value
     r1 = box(int, r0)
     return r1
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: object
-    r9 :: tuple[object]
-    r10 :: object
-    r11 :: str
-    r12, r13, r14 :: object
-    r15 :: str
-    r16 :: dict
-    r17 :: bool
-    r18 :: object
-    r19 :: tuple[object]
-    r20 :: object
-    r21 :: str
-    r22, r23, r24 :: object
-    r25 :: str
-    r26 :: dict
-    r27 :: bool
-    r28 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.BaseProperty_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.BaseProperty = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('BaseProperty')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = __main__.BaseProperty :: type
-    r9 = (r8)
-    r10 = box(tuple[object], r9)
-    r11 = unicode_0 :: static  ('__main__')
-    r12 = __main__.DerivedProperty_template :: type
-    r13 = pytype_from_template(r12, r10, r11)
-    __main__.DerivedProperty = r13 :: type
-    r14 = __main__.globals :: static
-    r15 = unicode_2 :: static  ('DerivedProperty')
-    r16 = cast(dict, r14)
-    r17 = r16.__setitem__(r15, r13) :: dict
-    r18 = __main__.DerivedProperty :: type
-    r19 = (r18)
-    r20 = box(tuple[object], r19)
-    r21 = unicode_0 :: static  ('__main__')
-    r22 = __main__.AgainProperty_template :: type
-    r23 = pytype_from_template(r22, r20, r21)
-    __main__.AgainProperty = r23 :: type
-    r24 = __main__.globals :: static
-    r25 = unicode_4 :: static  ('AgainProperty')
-    r26 = cast(dict, r24)
-    r27 = r26.__setitem__(r25, r23) :: dict
-    r28 = None
-    return r28
 
 [case testPropertyTraitSubclassing]
 from mypy_extensions import trait
@@ -2462,45 +2244,6 @@ L0:
     r0 = self.boxed
     r1 = box(int, r0)
     return r1
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: object
-    r9 :: tuple[object]
-    r10 :: object
-    r11 :: str
-    r12, r13, r14 :: object
-    r15 :: str
-    r16 :: dict
-    r17 :: bool
-    r18 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.SubclassedTrait_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.SubclassedTrait = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('SubclassedTrait')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = __main__.SubclassedTrait :: type
-    r9 = (r8)
-    r10 = box(tuple[object], r9)
-    r11 = unicode_0 :: static  ('__main__')
-    r12 = __main__.DerivingObject_template :: type
-    r13 = pytype_from_template(r12, r10, r11)
-    __main__.DerivingObject = r13 :: type
-    r14 = __main__.globals :: static
-    r15 = unicode_2 :: static  ('DerivingObject')
-    r16 = cast(dict, r14)
-    r17 = r16.__setitem__(r15, r13) :: dict
-    r18 = None
-    return r18
 
 [case testNativeIndex]
 from typing import List
@@ -2527,26 +2270,6 @@ L0:
     r2 = unbox(int, r1)
     r3 = r0 + r2 :: int
     return r3
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = None
-    return r8
 
 [case testTypeAlias]
 from typing import List, NewType, NamedTuple
@@ -2556,126 +2279,3 @@ Foo = List[int]
 Bar = NewType('Bar', Foo)
 y = Bar([1,2,3])
 [out]
-def __top_level__():
-    r0, r1 :: str
-    r2 :: object
-    r3 :: str
-    r4 :: object
-    r5 :: tuple[str, object]
-    r6 :: object
-    r7 :: str
-    r8 :: object
-    r9 :: str
-    r10 :: object
-    r11 :: tuple[str, object]
-    r12 :: object
-    r13 :: tuple[object, object]
-    r14, r15 :: object
-    r16 :: str
-    r17, r18, r19 :: object
-    r20 :: str
-    r21 :: bool
-    r22 :: int
-    r23 :: str
-    r24 :: object
-    r25 :: str
-    r26, r27, r28 :: object
-    r29 :: tuple
-    r30 :: object
-    r31 :: str
-    r32 :: bool
-    r33 :: object
-    r34 :: str
-    r35, r36 :: object
-    r37 :: str
-    r38, r39, r40 :: object
-    r41 :: str
-    r42 :: bool
-    r43 :: str
-    r44 :: object
-    r45 :: str
-    r46, r47 :: object
-    r48 :: str
-    r49, r50, r51 :: object
-    r52 :: str
-    r53 :: bool
-    r54, r55, r56 :: int
-    r57, r58, r59 :: object
-    r60 :: list
-    r61 :: object
-    r62 :: str
-    r63, r64, r65 :: object
-    r66 :: str
-    r67 :: bool
-    r68 :: None
-L0:
-    r0 = unicode_0 :: static  ('Lol')
-    r1 = unicode_1 :: static  ('a')
-    r2 = builtins.module :: static
-    r3 = unicode_2 :: static  ('int')
-    r4 = getattr r2, r3
-    r5 = (r1, r4)
-    r6 = box(tuple[str, object], r5)
-    r7 = unicode_3 :: static  ('b')
-    r8 = builtins.module :: static
-    r9 = unicode_4 :: static  ('str')
-    r10 = getattr r8, r9
-    r11 = (r7, r10)
-    r12 = box(tuple[str, object], r11)
-    r13 = (r6, r12)
-    r14 = box(tuple[object, object], r13)
-    r15 = __main__.globals :: static
-    r16 = unicode_5 :: static  ('NamedTuple')
-    r17 = r15[r16] :: dict
-    r18 = py_call(r17, r0, r14)
-    r19 = __main__.globals :: static
-    r20 = unicode_0 :: static  ('Lol')
-    r21 = r19.__setitem__(r20, r18) :: object
-    r22 = 1
-    r23 = unicode_6 :: static
-    r24 = __main__.globals :: static
-    r25 = unicode_0 :: static  ('Lol')
-    r26 = r24[r25] :: dict
-    r27 = box(int, r22)
-    r28 = py_call(r26, r27, r23)
-    r29 = cast(tuple, r28)
-    r30 = __main__.globals :: static
-    r31 = unicode_7 :: static  ('x')
-    r32 = r30.__setitem__(r31, r29) :: object
-    r33 = __main__.globals :: static
-    r34 = unicode_8 :: static  ('List')
-    r35 = r33[r34] :: dict
-    r36 = builtins.module :: static
-    r37 = unicode_2 :: static  ('int')
-    r38 = getattr r36, r37
-    r39 = r35[r38] :: object
-    r40 = __main__.globals :: static
-    r41 = unicode_9 :: static  ('Foo')
-    r42 = r40.__setitem__(r41, r39) :: object
-    r43 = unicode_10 :: static  ('Bar')
-    r44 = __main__.globals :: static
-    r45 = unicode_9 :: static  ('Foo')
-    r46 = r44[r45] :: dict
-    r47 = __main__.globals :: static
-    r48 = unicode_11 :: static  ('NewType')
-    r49 = r47[r48] :: dict
-    r50 = py_call(r49, r43, r46)
-    r51 = __main__.globals :: static
-    r52 = unicode_10 :: static  ('Bar')
-    r53 = r51.__setitem__(r52, r50) :: object
-    r54 = 1
-    r55 = 2
-    r56 = 3
-    r57 = box(int, r54)
-    r58 = box(int, r55)
-    r59 = box(int, r56)
-    r60 = [r57, r58, r59]
-    r61 = __main__.globals :: static
-    r62 = unicode_10 :: static  ('Bar')
-    r63 = r61[r62] :: dict
-    r64 = py_call(r63, r60)
-    r65 = __main__.globals :: static
-    r66 = unicode_12 :: static  ('y')
-    r67 = r65.__setitem__(r66, r64) :: object
-    r68 = None
-    return r68

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -2271,7 +2271,7 @@ L0:
     r3 = r0 + r2 :: int
     return r3
 
-[case testTypeAlias]
+[case testTypeAlias_toplevel]
 from typing import List, NewType, NamedTuple
 Lol = NamedTuple('Lol', (('a', int), ('b', str)))
 x = Lol(1, '')
@@ -2279,3 +2279,126 @@ Foo = List[int]
 Bar = NewType('Bar', Foo)
 y = Bar([1,2,3])
 [out]
+def __top_level__():
+    r0, r1 :: str
+    r2 :: object
+    r3 :: str
+    r4 :: object
+    r5 :: tuple[str, object]
+    r6 :: object
+    r7 :: str
+    r8 :: object
+    r9 :: str
+    r10 :: object
+    r11 :: tuple[str, object]
+    r12 :: object
+    r13 :: tuple[object, object]
+    r14, r15 :: object
+    r16 :: str
+    r17, r18, r19 :: object
+    r20 :: str
+    r21 :: bool
+    r22 :: int
+    r23 :: str
+    r24 :: object
+    r25 :: str
+    r26, r27, r28 :: object
+    r29 :: tuple
+    r30 :: object
+    r31 :: str
+    r32 :: bool
+    r33 :: object
+    r34 :: str
+    r35, r36 :: object
+    r37 :: str
+    r38, r39, r40 :: object
+    r41 :: str
+    r42 :: bool
+    r43 :: str
+    r44 :: object
+    r45 :: str
+    r46, r47 :: object
+    r48 :: str
+    r49, r50, r51 :: object
+    r52 :: str
+    r53 :: bool
+    r54, r55, r56 :: int
+    r57, r58, r59 :: object
+    r60 :: list
+    r61 :: object
+    r62 :: str
+    r63, r64, r65 :: object
+    r66 :: str
+    r67 :: bool
+    r68 :: None
+L0:
+    r0 = unicode_0 :: static  ('Lol')
+    r1 = unicode_1 :: static  ('a')
+    r2 = builtins.module :: static
+    r3 = unicode_2 :: static  ('int')
+    r4 = getattr r2, r3
+    r5 = (r1, r4)
+    r6 = box(tuple[str, object], r5)
+    r7 = unicode_3 :: static  ('b')
+    r8 = builtins.module :: static
+    r9 = unicode_4 :: static  ('str')
+    r10 = getattr r8, r9
+    r11 = (r7, r10)
+    r12 = box(tuple[str, object], r11)
+    r13 = (r6, r12)
+    r14 = box(tuple[object, object], r13)
+    r15 = __main__.globals :: static
+    r16 = unicode_5 :: static  ('NamedTuple')
+    r17 = r15[r16] :: dict
+    r18 = py_call(r17, r0, r14)
+    r19 = __main__.globals :: static
+    r20 = unicode_0 :: static  ('Lol')
+    r21 = r19.__setitem__(r20, r18) :: object
+    r22 = 1
+    r23 = unicode_6 :: static
+    r24 = __main__.globals :: static
+    r25 = unicode_0 :: static  ('Lol')
+    r26 = r24[r25] :: dict
+    r27 = box(int, r22)
+    r28 = py_call(r26, r27, r23)
+    r29 = cast(tuple, r28)
+    r30 = __main__.globals :: static
+    r31 = unicode_7 :: static  ('x')
+    r32 = r30.__setitem__(r31, r29) :: object
+    r33 = __main__.globals :: static
+    r34 = unicode_8 :: static  ('List')
+    r35 = r33[r34] :: dict
+    r36 = builtins.module :: static
+    r37 = unicode_2 :: static  ('int')
+    r38 = getattr r36, r37
+    r39 = r35[r38] :: object
+    r40 = __main__.globals :: static
+    r41 = unicode_9 :: static  ('Foo')
+    r42 = r40.__setitem__(r41, r39) :: object
+    r43 = unicode_10 :: static  ('Bar')
+    r44 = __main__.globals :: static
+    r45 = unicode_9 :: static  ('Foo')
+    r46 = r44[r45] :: dict
+    r47 = __main__.globals :: static
+    r48 = unicode_11 :: static  ('NewType')
+    r49 = r47[r48] :: dict
+    r50 = py_call(r49, r43, r46)
+    r51 = __main__.globals :: static
+    r52 = unicode_10 :: static  ('Bar')
+    r53 = r51.__setitem__(r52, r50) :: object
+    r54 = 1
+    r55 = 2
+    r56 = 3
+    r57 = box(int, r54)
+    r58 = box(int, r55)
+    r59 = box(int, r56)
+    r60 = [r57, r58, r59]
+    r61 = __main__.globals :: static
+    r62 = unicode_10 :: static  ('Bar')
+    r63 = r61[r62] :: dict
+    r64 = py_call(r63, r60)
+    r65 = __main__.globals :: static
+    r66 = unicode_12 :: static  ('y')
+    r67 = r65.__setitem__(r66, r64) :: object
+    r68 = None
+    return r68

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -11,6 +11,26 @@ def f(a):
 L0:
     r0 = a.x
     return r0
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = None
+    return r8
 
 [case testSetAttribute]
 class A:
@@ -29,6 +49,26 @@ L0:
     a.x = r0; r1 = is_error
     r2 = None
     return r2
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = None
+    return r8
 
 [case testUserClassInList]
 class C:
@@ -65,6 +105,26 @@ L0:
     r8 = 1
     r9 = r7 + r8 :: int
     return r9
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.C_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.C = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('C')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = None
+    return r8
 
 [case testMethodCall]
 class A:
@@ -91,10 +151,30 @@ def g(a):
     r3 :: None
 L0:
     r0 = 1
-    r1 = unicode_0 :: static  ('hi')
+    r1 = unicode_2 :: static  ('hi')
     r2 = a.f(r0, r1)
     r3 = None
     return r3
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = None
+    return r8
 
 [case testForwardUse]
 def g(a: A) -> int:
@@ -110,6 +190,26 @@ def g(a):
 L0:
     r0 = a.n
     return r0
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = None
+    return r8
 
 [case testOptionalMember]
 from typing import Optional
@@ -142,6 +242,26 @@ L1:
     return r7
 L2:
     r8 = 1
+    return r8
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.Node_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.Node = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('Node')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = None
     return r8
 
 [case testSubclass]
@@ -177,6 +297,45 @@ L0:
     self.y = r2; r3 = is_error
     r4 = None
     return r4
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: object
+    r9 :: tuple[object]
+    r10 :: object
+    r11 :: str
+    r12, r13, r14 :: object
+    r15 :: str
+    r16 :: dict
+    r17 :: bool
+    r18 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = __main__.A :: type
+    r9 = (r8)
+    r10 = box(tuple[object], r9)
+    r11 = unicode_0 :: static  ('__main__')
+    r12 = __main__.B_template :: type
+    r13 = pytype_from_template(r12, r10, r11)
+    __main__.B = r13 :: type
+    r14 = __main__.globals :: static
+    r15 = unicode_2 :: static  ('B')
+    r16 = cast(dict, r14)
+    r17 = r16.__setitem__(r15, r13) :: dict
+    r18 = None
+    return r18
 
 [case testAttrLvalue]
 class O(object):
@@ -207,6 +366,34 @@ L0:
     r2 = r0 += r1 :: int
     o.x = r2; r3 = is_error
     return o
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2 :: object
+    r3 :: tuple[object]
+    r4 :: object
+    r5 :: str
+    r6, r7, r8 :: object
+    r9 :: str
+    r10 :: dict
+    r11 :: bool
+    r12 :: None
+L0:
+    r0 = builtins.module :: static
+    r1 = unicode_0 :: static  ('object')
+    r2 = getattr r0, r1
+    r3 = (r2)
+    r4 = box(tuple[object], r3)
+    r5 = unicode_1 :: static  ('__main__')
+    r6 = __main__.O_template :: type
+    r7 = pytype_from_template(r6, r4, r5)
+    __main__.O = r7 :: type
+    r8 = __main__.globals :: static
+    r9 = unicode_2 :: static  ('O')
+    r10 = cast(dict, r8)
+    r11 = r10.__setitem__(r9, r7) :: dict
+    r12 = None
+    return r12
 
 [case testSubclassSpecialize2]
 class A:
@@ -258,7 +445,7 @@ def C.foo(self, x):
     r4 :: int
 L0:
     r0 = builtins.module :: static
-    r1 = unicode_0 :: static  ('id')
+    r1 = unicode_4 :: static  ('id')
     r2 = getattr r0, r1
     r3 = py_call(r2, x)
     r4 = unbox(int, r3)
@@ -303,6 +490,64 @@ def use_c(x, y):
 L0:
     r0 = x.foo(y)
     return r0
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: object
+    r9 :: tuple[object]
+    r10 :: object
+    r11 :: str
+    r12, r13, r14 :: object
+    r15 :: str
+    r16 :: dict
+    r17 :: bool
+    r18 :: object
+    r19 :: tuple[object]
+    r20 :: object
+    r21 :: str
+    r22, r23, r24 :: object
+    r25 :: str
+    r26 :: dict
+    r27 :: bool
+    r28 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = __main__.A :: type
+    r9 = (r8)
+    r10 = box(tuple[object], r9)
+    r11 = unicode_0 :: static  ('__main__')
+    r12 = __main__.B_template :: type
+    r13 = pytype_from_template(r12, r10, r11)
+    __main__.B = r13 :: type
+    r14 = __main__.globals :: static
+    r15 = unicode_2 :: static  ('B')
+    r16 = cast(dict, r14)
+    r17 = r16.__setitem__(r15, r13) :: dict
+    r18 = __main__.B :: type
+    r19 = (r18)
+    r20 = box(tuple[object], r19)
+    r21 = unicode_0 :: static  ('__main__')
+    r22 = __main__.C_template :: type
+    r23 = pytype_from_template(r22, r20, r21)
+    __main__.C = r23 :: type
+    r24 = __main__.globals :: static
+    r25 = unicode_3 :: static  ('C')
+    r26 = cast(dict, r24)
+    r27 = r26.__setitem__(r25, r23) :: dict
+    r28 = None
+    return r28
 
 [case testIsInstance]
 class A: pass
@@ -328,6 +573,45 @@ L1:
 L2:
     r3 = B()
     return r3
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: object
+    r9 :: tuple[object]
+    r10 :: object
+    r11 :: str
+    r12, r13, r14 :: object
+    r15 :: str
+    r16 :: dict
+    r17 :: bool
+    r18 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = __main__.A :: type
+    r9 = (r8)
+    r10 = box(tuple[object], r9)
+    r11 = unicode_0 :: static  ('__main__')
+    r12 = __main__.B_template :: type
+    r13 = pytype_from_template(r12, r10, r11)
+    __main__.B = r13 :: type
+    r14 = __main__.globals :: static
+    r15 = unicode_2 :: static  ('B')
+    r16 = cast(dict, r14)
+    r17 = r16.__setitem__(r15, r13) :: dict
+    r18 = None
+    return r18
 
 [case testFakeSuper]
 class A:
@@ -358,6 +642,45 @@ L0:
     self.y = y; r1 = is_error
     r2 = None
     return r2
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: object
+    r9 :: tuple[object]
+    r10 :: object
+    r11 :: str
+    r12, r13, r14 :: object
+    r15 :: str
+    r16 :: dict
+    r17 :: bool
+    r18 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = __main__.A :: type
+    r9 = (r8)
+    r10 = box(tuple[object], r9)
+    r11 = unicode_0 :: static  ('__main__')
+    r12 = __main__.B_template :: type
+    r13 = pytype_from_template(r12, r10, r11)
+    __main__.B = r13 :: type
+    r14 = __main__.globals :: static
+    r15 = unicode_2 :: static  ('B')
+    r16 = cast(dict, r14)
+    r17 = r16.__setitem__(r15, r13) :: dict
+    r18 = None
+    return r18
 
 [case testClassMethod]
 class C:
@@ -424,6 +747,45 @@ L0:
     self.y = y; r1 = is_error
     r2 = None
     return r2
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: object
+    r9 :: tuple[object]
+    r10 :: object
+    r11 :: str
+    r12, r13, r14 :: object
+    r15 :: str
+    r16 :: dict
+    r17 :: bool
+    r18 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = __main__.A :: type
+    r9 = (r8)
+    r10 = box(tuple[object], r9)
+    r11 = unicode_0 :: static  ('__main__')
+    r12 = __main__.B_template :: type
+    r13 = pytype_from_template(r12, r10, r11)
+    __main__.B = r13 :: type
+    r14 = __main__.globals :: static
+    r15 = unicode_2 :: static  ('B')
+    r16 = cast(dict, r14)
+    r17 = r16.__setitem__(r15, r13) :: dict
+    r18 = None
+    return r18
 
 [case testSuper2]
 from mypy_extensions import trait
@@ -448,6 +810,45 @@ L0:
     r0 = T.foo(self)
     r1 = None
     return r1
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: object
+    r9 :: tuple[object]
+    r10 :: object
+    r11 :: str
+    r12, r13, r14 :: object
+    r15 :: str
+    r16 :: dict
+    r17 :: bool
+    r18 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.T_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.T = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('T')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = __main__.T :: type
+    r9 = (r8)
+    r10 = box(tuple[object], r9)
+    r11 = unicode_0 :: static  ('__main__')
+    r12 = __main__.X_template :: type
+    r13 = pytype_from_template(r12, r10, r11)
+    __main__.X = r13 :: type
+    r14 = __main__.globals :: static
+    r15 = unicode_2 :: static  ('X')
+    r16 = cast(dict, r14)
+    r17 = r16.__setitem__(r15, r13) :: dict
+    r18 = None
+    return r18
 
 [case testClassVariable]
 from typing import ClassVar
@@ -464,25 +865,40 @@ def f():
     r3 :: int
 L0:
     r0 = __main__.A :: type
-    r1 = unicode_0 :: static  ('x')
+    r1 = unicode_2 :: static  ('x')
     r2 = getattr r0, r1
     r3 = unbox(int, r2)
     return r3
 def __top_level__():
     r0 :: object
-    r1 :: int
-    r2 :: str
-    r3 :: object
-    r4 :: bool
-    r5 :: None
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: object
+    r9 :: int
+    r10 :: str
+    r11 :: object
+    r12 :: bool
+    r13 :: None
 L0:
-    r0 = __main__.A :: type
-    r1 = 10
-    r2 = unicode_0 :: static  ('x')
-    r3 = box(int, r1)
-    r4 = setattr r0, r2, r3
-    r5 = None
-    return r5
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = __main__.A :: type
+    r9 = 10
+    r10 = unicode_2 :: static  ('x')
+    r11 = box(int, r9)
+    r12 = setattr r8, r10, r11
+    r13 = None
+    return r13
 
 [case testDefaultVars]
 from typing import ClassVar, Optional
@@ -597,3 +1013,51 @@ class C(Generic[T]):
     pass
 
 [out]
+def __top_level__():
+    r0 :: str
+    r1 :: object
+    r2 :: str
+    r3, r4, r5 :: object
+    r6 :: str
+    r7 :: bool
+    r8 :: object
+    r9 :: str
+    r10, r11 :: object
+    r12 :: str
+    r13, r14 :: object
+    r15 :: tuple[object]
+    r16 :: object
+    r17 :: str
+    r18, r19, r20 :: object
+    r21 :: str
+    r22 :: dict
+    r23 :: bool
+    r24 :: None
+L0:
+    r0 = unicode_0 :: static  ('T')
+    r1 = __main__.globals :: static
+    r2 = unicode_1 :: static  ('TypeVar')
+    r3 = r1[r2] :: dict
+    r4 = py_call(r3, r0)
+    r5 = __main__.globals :: static
+    r6 = unicode_0 :: static  ('T')
+    r7 = r5.__setitem__(r6, r4) :: object
+    r8 = __main__.globals :: static
+    r9 = unicode_2 :: static  ('Generic')
+    r10 = r8[r9] :: dict
+    r11 = __main__.globals :: static
+    r12 = unicode_0 :: static  ('T')
+    r13 = r11[r12] :: dict
+    r14 = r10[r13] :: object
+    r15 = (r14)
+    r16 = box(tuple[object], r15)
+    r17 = unicode_3 :: static  ('__main__')
+    r18 = __main__.C_template :: type
+    r19 = pytype_from_template(r18, r16, r17)
+    __main__.C = r19 :: type
+    r20 = __main__.globals :: static
+    r21 = unicode_4 :: static  ('C')
+    r22 = cast(dict, r20)
+    r23 = r22.__setitem__(r21, r19) :: dict
+    r24 = None
+    return r24

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -530,7 +530,7 @@ def B.__mypyc_defaults_setup(self):
     r10, r11 :: bool
 L0:
     r0 = __main__.globals :: static
-    r1 = unicode_1 :: static  ('LOL')
+    r1 = unicode_3 :: static  ('LOL')
     r2 = r0[r1] :: dict
     r3 = cast(str, r2)
     self.y = r3; r4 = is_error
@@ -543,15 +543,57 @@ L0:
     r11 = True
     return r11
 def __top_level__():
-    r0 :: str
-    r1 :: object
-    r2 :: str
-    r3 :: bool
-    r4 :: None
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: str
+    r9 :: object
+    r10 :: str
+    r11 :: bool
+    r12 :: object
+    r13 :: tuple[object]
+    r14 :: object
+    r15 :: str
+    r16, r17, r18 :: object
+    r19 :: str
+    r20 :: dict
+    r21 :: bool
+    r22 :: None
 L0:
-    r0 = unicode_0 :: static  ('lol')
-    r1 = __main__.globals :: static
-    r2 = unicode_1 :: static  ('LOL')
-    r3 = r1.__setitem__(r2, r0) :: object
-    r4 = None
-    return r4
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = unicode_2 :: static  ('lol')
+    r9 = __main__.globals :: static
+    r10 = unicode_3 :: static  ('LOL')
+    r11 = r9.__setitem__(r10, r8) :: object
+    r12 = __main__.A :: type
+    r13 = (r12)
+    r14 = box(tuple[object], r13)
+    r15 = unicode_0 :: static  ('__main__')
+    r16 = __main__.B_template :: type
+    r17 = pytype_from_template(r16, r14, r15)
+    __main__.B = r17 :: type
+    r18 = __main__.globals :: static
+    r19 = unicode_4 :: static  ('B')
+    r20 = cast(dict, r18)
+    r21 = r20.__setitem__(r19, r17) :: dict
+    r22 = None
+    return r22
+
+[case testGenericTrivial]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class C(Generic[T]):
+    pass
+
+[out]

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -304,6 +304,102 @@ L0:
     r0 = x.foo(y)
     return r0
 
+[case testSubclass_toplevel]
+from typing import TypeVar, Generic
+from mypy_extensions import trait
+T = TypeVar('T')
+class C:
+    pass
+
+@trait
+class S:
+    pass
+
+class D(C, S, Generic[T]):
+    pass
+
+[out]
+def __top_level__():
+    r0 :: str
+    r1 :: object
+    r2 :: str
+    r3, r4, r5 :: object
+    r6 :: str
+    r7 :: bool
+    r8 :: object
+    r9 :: str
+    r10, r11, r12 :: object
+    r13 :: str
+    r14 :: dict
+    r15 :: bool
+    r16 :: object
+    r17 :: str
+    r18, r19, r20 :: object
+    r21 :: str
+    r22 :: dict
+    r23 :: bool
+    r24, r25, r26 :: object
+    r27 :: str
+    r28, r29 :: object
+    r30 :: str
+    r31, r32 :: object
+    r33 :: tuple[object, object, object]
+    r34 :: object
+    r35 :: str
+    r36, r37, r38 :: object
+    r39 :: str
+    r40 :: dict
+    r41 :: bool
+    r42 :: None
+L0:
+    r0 = unicode_0 :: static  ('T')
+    r1 = __main__.globals :: static
+    r2 = unicode_1 :: static  ('TypeVar')
+    r3 = r1[r2] :: dict
+    r4 = py_call(r3, r0)
+    r5 = __main__.globals :: static
+    r6 = unicode_0 :: static  ('T')
+    r7 = r5.__setitem__(r6, r4) :: object
+    r8 = <error> :: object
+    r9 = unicode_2 :: static  ('__main__')
+    r10 = __main__.C_template :: type
+    r11 = pytype_from_template(r10, r8, r9)
+    __main__.C = r11 :: type
+    r12 = __main__.globals :: static
+    r13 = unicode_3 :: static  ('C')
+    r14 = cast(dict, r12)
+    r15 = r14.__setitem__(r13, r11) :: dict
+    r16 = <error> :: object
+    r17 = unicode_2 :: static  ('__main__')
+    r18 = __main__.S_template :: type
+    r19 = pytype_from_template(r18, r16, r17)
+    __main__.S = r19 :: type
+    r20 = __main__.globals :: static
+    r21 = unicode_4 :: static  ('S')
+    r22 = cast(dict, r20)
+    r23 = r22.__setitem__(r21, r19) :: dict
+    r24 = __main__.C :: type
+    r25 = __main__.S :: type
+    r26 = __main__.globals :: static
+    r27 = unicode_5 :: static  ('Generic')
+    r28 = r26[r27] :: dict
+    r29 = __main__.globals :: static
+    r30 = unicode_0 :: static  ('T')
+    r31 = r29[r30] :: dict
+    r32 = r28[r31] :: object
+    r33 = (r24, r25, r32)
+    r34 = box(tuple[object, object, object], r33)
+    r35 = unicode_2 :: static  ('__main__')
+    r36 = __main__.D_template :: type
+    r37 = pytype_from_template(r36, r34, r35)
+    __main__.D = r37 :: type
+    r38 = __main__.globals :: static
+    r39 = unicode_6 :: static  ('D')
+    r40 = cast(dict, r38)
+    r41 = r40.__setitem__(r39, r37) :: dict
+    r42 = None
+    return r42
+
 [case testIsInstance]
 class A: pass
 class B(A): pass
@@ -527,11 +623,3 @@ L0:
     self.x = r9; r10 = is_error
     r11 = True
     return r11
-
-[case testGenericTrivial]
-from typing import TypeVar, Generic
-T = TypeVar('T')
-class C(Generic[T]):
-    pass
-
-[out]

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -11,26 +11,6 @@ def f(a):
 L0:
     r0 = a.x
     return r0
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = None
-    return r8
 
 [case testSetAttribute]
 class A:
@@ -49,26 +29,6 @@ L0:
     a.x = r0; r1 = is_error
     r2 = None
     return r2
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = None
-    return r8
 
 [case testUserClassInList]
 class C:
@@ -105,26 +65,6 @@ L0:
     r8 = 1
     r9 = r7 + r8 :: int
     return r9
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.C_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.C = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('C')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = None
-    return r8
 
 [case testMethodCall]
 class A:
@@ -155,26 +95,6 @@ L0:
     r2 = a.f(r0, r1)
     r3 = None
     return r3
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = None
-    return r8
 
 [case testForwardUse]
 def g(a: A) -> int:
@@ -190,26 +110,6 @@ def g(a):
 L0:
     r0 = a.n
     return r0
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = None
-    return r8
 
 [case testOptionalMember]
 from typing import Optional
@@ -242,26 +142,6 @@ L1:
     return r7
 L2:
     r8 = 1
-    return r8
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.Node_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.Node = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('Node')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = None
     return r8
 
 [case testSubclass]
@@ -297,45 +177,6 @@ L0:
     self.y = r2; r3 = is_error
     r4 = None
     return r4
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: object
-    r9 :: tuple[object]
-    r10 :: object
-    r11 :: str
-    r12, r13, r14 :: object
-    r15 :: str
-    r16 :: dict
-    r17 :: bool
-    r18 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = __main__.A :: type
-    r9 = (r8)
-    r10 = box(tuple[object], r9)
-    r11 = unicode_0 :: static  ('__main__')
-    r12 = __main__.B_template :: type
-    r13 = pytype_from_template(r12, r10, r11)
-    __main__.B = r13 :: type
-    r14 = __main__.globals :: static
-    r15 = unicode_2 :: static  ('B')
-    r16 = cast(dict, r14)
-    r17 = r16.__setitem__(r15, r13) :: dict
-    r18 = None
-    return r18
 
 [case testAttrLvalue]
 class O(object):
@@ -366,34 +207,6 @@ L0:
     r2 = r0 += r1 :: int
     o.x = r2; r3 = is_error
     return o
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2 :: object
-    r3 :: tuple[object]
-    r4 :: object
-    r5 :: str
-    r6, r7, r8 :: object
-    r9 :: str
-    r10 :: dict
-    r11 :: bool
-    r12 :: None
-L0:
-    r0 = builtins.module :: static
-    r1 = unicode_0 :: static  ('object')
-    r2 = getattr r0, r1
-    r3 = (r2)
-    r4 = box(tuple[object], r3)
-    r5 = unicode_1 :: static  ('__main__')
-    r6 = __main__.O_template :: type
-    r7 = pytype_from_template(r6, r4, r5)
-    __main__.O = r7 :: type
-    r8 = __main__.globals :: static
-    r9 = unicode_2 :: static  ('O')
-    r10 = cast(dict, r8)
-    r11 = r10.__setitem__(r9, r7) :: dict
-    r12 = None
-    return r12
 
 [case testSubclassSpecialize2]
 class A:
@@ -490,64 +303,6 @@ def use_c(x, y):
 L0:
     r0 = x.foo(y)
     return r0
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: object
-    r9 :: tuple[object]
-    r10 :: object
-    r11 :: str
-    r12, r13, r14 :: object
-    r15 :: str
-    r16 :: dict
-    r17 :: bool
-    r18 :: object
-    r19 :: tuple[object]
-    r20 :: object
-    r21 :: str
-    r22, r23, r24 :: object
-    r25 :: str
-    r26 :: dict
-    r27 :: bool
-    r28 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = __main__.A :: type
-    r9 = (r8)
-    r10 = box(tuple[object], r9)
-    r11 = unicode_0 :: static  ('__main__')
-    r12 = __main__.B_template :: type
-    r13 = pytype_from_template(r12, r10, r11)
-    __main__.B = r13 :: type
-    r14 = __main__.globals :: static
-    r15 = unicode_2 :: static  ('B')
-    r16 = cast(dict, r14)
-    r17 = r16.__setitem__(r15, r13) :: dict
-    r18 = __main__.B :: type
-    r19 = (r18)
-    r20 = box(tuple[object], r19)
-    r21 = unicode_0 :: static  ('__main__')
-    r22 = __main__.C_template :: type
-    r23 = pytype_from_template(r22, r20, r21)
-    __main__.C = r23 :: type
-    r24 = __main__.globals :: static
-    r25 = unicode_3 :: static  ('C')
-    r26 = cast(dict, r24)
-    r27 = r26.__setitem__(r25, r23) :: dict
-    r28 = None
-    return r28
 
 [case testIsInstance]
 class A: pass
@@ -573,45 +328,6 @@ L1:
 L2:
     r3 = B()
     return r3
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: object
-    r9 :: tuple[object]
-    r10 :: object
-    r11 :: str
-    r12, r13, r14 :: object
-    r15 :: str
-    r16 :: dict
-    r17 :: bool
-    r18 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = __main__.A :: type
-    r9 = (r8)
-    r10 = box(tuple[object], r9)
-    r11 = unicode_0 :: static  ('__main__')
-    r12 = __main__.B_template :: type
-    r13 = pytype_from_template(r12, r10, r11)
-    __main__.B = r13 :: type
-    r14 = __main__.globals :: static
-    r15 = unicode_2 :: static  ('B')
-    r16 = cast(dict, r14)
-    r17 = r16.__setitem__(r15, r13) :: dict
-    r18 = None
-    return r18
 
 [case testFakeSuper]
 class A:
@@ -642,45 +358,6 @@ L0:
     self.y = y; r1 = is_error
     r2 = None
     return r2
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: object
-    r9 :: tuple[object]
-    r10 :: object
-    r11 :: str
-    r12, r13, r14 :: object
-    r15 :: str
-    r16 :: dict
-    r17 :: bool
-    r18 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = __main__.A :: type
-    r9 = (r8)
-    r10 = box(tuple[object], r9)
-    r11 = unicode_0 :: static  ('__main__')
-    r12 = __main__.B_template :: type
-    r13 = pytype_from_template(r12, r10, r11)
-    __main__.B = r13 :: type
-    r14 = __main__.globals :: static
-    r15 = unicode_2 :: static  ('B')
-    r16 = cast(dict, r14)
-    r17 = r16.__setitem__(r15, r13) :: dict
-    r18 = None
-    return r18
 
 [case testClassMethod]
 class C:
@@ -747,45 +424,6 @@ L0:
     self.y = y; r1 = is_error
     r2 = None
     return r2
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: object
-    r9 :: tuple[object]
-    r10 :: object
-    r11 :: str
-    r12, r13, r14 :: object
-    r15 :: str
-    r16 :: dict
-    r17 :: bool
-    r18 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = __main__.A :: type
-    r9 = (r8)
-    r10 = box(tuple[object], r9)
-    r11 = unicode_0 :: static  ('__main__')
-    r12 = __main__.B_template :: type
-    r13 = pytype_from_template(r12, r10, r11)
-    __main__.B = r13 :: type
-    r14 = __main__.globals :: static
-    r15 = unicode_2 :: static  ('B')
-    r16 = cast(dict, r14)
-    r17 = r16.__setitem__(r15, r13) :: dict
-    r18 = None
-    return r18
 
 [case testSuper2]
 from mypy_extensions import trait
@@ -810,45 +448,6 @@ L0:
     r0 = T.foo(self)
     r1 = None
     return r1
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: object
-    r9 :: tuple[object]
-    r10 :: object
-    r11 :: str
-    r12, r13, r14 :: object
-    r15 :: str
-    r16 :: dict
-    r17 :: bool
-    r18 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.T_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.T = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('T')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = __main__.T :: type
-    r9 = (r8)
-    r10 = box(tuple[object], r9)
-    r11 = unicode_0 :: static  ('__main__')
-    r12 = __main__.X_template :: type
-    r13 = pytype_from_template(r12, r10, r11)
-    __main__.X = r13 :: type
-    r14 = __main__.globals :: static
-    r15 = unicode_2 :: static  ('X')
-    r16 = cast(dict, r14)
-    r17 = r16.__setitem__(r15, r13) :: dict
-    r18 = None
-    return r18
 
 [case testClassVariable]
 from typing import ClassVar
@@ -869,36 +468,6 @@ L0:
     r2 = getattr r0, r1
     r3 = unbox(int, r2)
     return r3
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: object
-    r9 :: int
-    r10 :: str
-    r11 :: object
-    r12 :: bool
-    r13 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = __main__.A :: type
-    r9 = 10
-    r10 = unicode_2 :: static  ('x')
-    r11 = box(int, r9)
-    r12 = setattr r8, r10, r11
-    r13 = None
-    return r13
 
 [case testDefaultVars]
 from typing import ClassVar, Optional
@@ -958,53 +527,6 @@ L0:
     self.x = r9; r10 = is_error
     r11 = True
     return r11
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: str
-    r9 :: object
-    r10 :: str
-    r11 :: bool
-    r12 :: object
-    r13 :: tuple[object]
-    r14 :: object
-    r15 :: str
-    r16, r17, r18 :: object
-    r19 :: str
-    r20 :: dict
-    r21 :: bool
-    r22 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = unicode_2 :: static  ('lol')
-    r9 = __main__.globals :: static
-    r10 = unicode_3 :: static  ('LOL')
-    r11 = r9.__setitem__(r10, r8) :: object
-    r12 = __main__.A :: type
-    r13 = (r12)
-    r14 = box(tuple[object], r13)
-    r15 = unicode_0 :: static  ('__main__')
-    r16 = __main__.B_template :: type
-    r17 = pytype_from_template(r16, r14, r15)
-    __main__.B = r17 :: type
-    r18 = __main__.globals :: static
-    r19 = unicode_4 :: static  ('B')
-    r20 = cast(dict, r18)
-    r21 = r20.__setitem__(r19, r17) :: dict
-    r22 = None
-    return r22
 
 [case testGenericTrivial]
 from typing import TypeVar, Generic
@@ -1013,51 +535,3 @@ class C(Generic[T]):
     pass
 
 [out]
-def __top_level__():
-    r0 :: str
-    r1 :: object
-    r2 :: str
-    r3, r4, r5 :: object
-    r6 :: str
-    r7 :: bool
-    r8 :: object
-    r9 :: str
-    r10, r11 :: object
-    r12 :: str
-    r13, r14 :: object
-    r15 :: tuple[object]
-    r16 :: object
-    r17 :: str
-    r18, r19, r20 :: object
-    r21 :: str
-    r22 :: dict
-    r23 :: bool
-    r24 :: None
-L0:
-    r0 = unicode_0 :: static  ('T')
-    r1 = __main__.globals :: static
-    r2 = unicode_1 :: static  ('TypeVar')
-    r3 = r1[r2] :: dict
-    r4 = py_call(r3, r0)
-    r5 = __main__.globals :: static
-    r6 = unicode_0 :: static  ('T')
-    r7 = r5.__setitem__(r6, r4) :: object
-    r8 = __main__.globals :: static
-    r9 = unicode_2 :: static  ('Generic')
-    r10 = r8[r9] :: dict
-    r11 = __main__.globals :: static
-    r12 = unicode_0 :: static  ('T')
-    r13 = r11[r12] :: dict
-    r14 = r10[r13] :: object
-    r15 = (r14)
-    r16 = box(tuple[object], r15)
-    r17 = unicode_3 :: static  ('__main__')
-    r18 = __main__.C_template :: type
-    r19 = pytype_from_template(r18, r16, r17)
-    __main__.C = r19 :: type
-    r20 = __main__.globals :: static
-    r21 = unicode_4 :: static  ('C')
-    r22 = cast(dict, r20)
-    r23 = r22.__setitem__(r21, r19) :: dict
-    r24 = None
-    return r24

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -328,29 +328,35 @@ def __top_level__():
     r7 :: bool
     r8 :: object
     r9 :: str
-    r10, r11, r12 :: object
-    r13 :: str
-    r14 :: dict
-    r15 :: bool
-    r16 :: object
-    r17 :: str
-    r18, r19, r20 :: object
-    r21 :: str
-    r22 :: dict
-    r23 :: bool
-    r24, r25, r26 :: object
-    r27 :: str
-    r28, r29 :: object
-    r30 :: str
-    r31, r32 :: object
-    r33 :: tuple[object, object, object]
-    r34 :: object
-    r35 :: str
-    r36, r37, r38 :: object
-    r39 :: str
-    r40 :: dict
-    r41 :: bool
-    r42 :: None
+    r10, r11 :: object
+    r12 :: bool
+    r13 :: object
+    r14 :: str
+    r15 :: dict
+    r16 :: bool
+    r17 :: object
+    r18 :: str
+    r19, r20 :: object
+    r21 :: bool
+    r22 :: object
+    r23 :: str
+    r24 :: dict
+    r25 :: bool
+    r26, r27, r28 :: object
+    r29 :: str
+    r30, r31 :: object
+    r32 :: str
+    r33, r34 :: object
+    r35 :: tuple[object, object, object]
+    r36 :: object
+    r37 :: str
+    r38, r39 :: object
+    r40 :: bool
+    r41 :: object
+    r42 :: str
+    r43 :: dict
+    r44 :: bool
+    r45 :: None
 L0:
     r0 = unicode_0 :: static  ('T')
     r1 = __main__.globals :: static
@@ -364,41 +370,44 @@ L0:
     r9 = unicode_2 :: static  ('__main__')
     r10 = __main__.C_template :: type
     r11 = pytype_from_template(r10, r8, r9)
+    r12 = C__trait_vtable_setup()
     __main__.C = r11 :: type
-    r12 = __main__.globals :: static
-    r13 = unicode_3 :: static  ('C')
-    r14 = cast(dict, r12)
-    r15 = r14.__setitem__(r13, r11) :: dict
-    r16 = <error> :: object
-    r17 = unicode_2 :: static  ('__main__')
-    r18 = __main__.S_template :: type
-    r19 = pytype_from_template(r18, r16, r17)
-    __main__.S = r19 :: type
-    r20 = __main__.globals :: static
-    r21 = unicode_4 :: static  ('S')
-    r22 = cast(dict, r20)
-    r23 = r22.__setitem__(r21, r19) :: dict
-    r24 = __main__.C :: type
-    r25 = __main__.S :: type
-    r26 = __main__.globals :: static
-    r27 = unicode_5 :: static  ('Generic')
-    r28 = r26[r27] :: dict
-    r29 = __main__.globals :: static
-    r30 = unicode_0 :: static  ('T')
-    r31 = r29[r30] :: dict
-    r32 = r28[r31] :: object
-    r33 = (r24, r25, r32)
-    r34 = box(tuple[object, object, object], r33)
-    r35 = unicode_2 :: static  ('__main__')
-    r36 = __main__.D_template :: type
-    r37 = pytype_from_template(r36, r34, r35)
-    __main__.D = r37 :: type
-    r38 = __main__.globals :: static
-    r39 = unicode_6 :: static  ('D')
-    r40 = cast(dict, r38)
-    r41 = r40.__setitem__(r39, r37) :: dict
-    r42 = None
-    return r42
+    r13 = __main__.globals :: static
+    r14 = unicode_3 :: static  ('C')
+    r15 = cast(dict, r13)
+    r16 = r15.__setitem__(r14, r11) :: dict
+    r17 = <error> :: object
+    r18 = unicode_2 :: static  ('__main__')
+    r19 = __main__.S_template :: type
+    r20 = pytype_from_template(r19, r17, r18)
+    r21 = S__trait_vtable_setup()
+    __main__.S = r20 :: type
+    r22 = __main__.globals :: static
+    r23 = unicode_4 :: static  ('S')
+    r24 = cast(dict, r22)
+    r25 = r24.__setitem__(r23, r20) :: dict
+    r26 = __main__.C :: type
+    r27 = __main__.S :: type
+    r28 = __main__.globals :: static
+    r29 = unicode_5 :: static  ('Generic')
+    r30 = r28[r29] :: dict
+    r31 = __main__.globals :: static
+    r32 = unicode_0 :: static  ('T')
+    r33 = r31[r32] :: dict
+    r34 = r30[r33] :: object
+    r35 = (r26, r27, r34)
+    r36 = box(tuple[object, object, object], r35)
+    r37 = unicode_2 :: static  ('__main__')
+    r38 = __main__.D_template :: type
+    r39 = pytype_from_template(r38, r36, r37)
+    r40 = D__trait_vtable_setup()
+    __main__.D = r39 :: type
+    r41 = __main__.globals :: static
+    r42 = unicode_6 :: static  ('D')
+    r43 = cast(dict, r41)
+    r44 = r43.__setitem__(r42, r39) :: dict
+    r45 = None
+    return r45
 
 [case testIsInstance]
 class A: pass

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -372,7 +372,7 @@ L0:
     r9 = unicode_2 :: static  ('__main__')
     r10 = __main__.C_template :: type
     r11 = pytype_from_template(r10, r8, r9)
-    r12 = C__trait_vtable_setup()
+    r12 = C_trait_vtable_setup()
     __main__.C = r11 :: type
     r13 = __main__.globals :: static
     r14 = unicode_3 :: static  ('C')
@@ -382,7 +382,7 @@ L0:
     r18 = unicode_2 :: static  ('__main__')
     r19 = __main__.S_template :: type
     r20 = pytype_from_template(r19, r17, r18)
-    r21 = S__trait_vtable_setup()
+    r21 = S_trait_vtable_setup()
     __main__.S = r20 :: type
     r22 = __main__.globals :: static
     r23 = unicode_4 :: static  ('S')
@@ -402,7 +402,7 @@ L0:
     r37 = unicode_2 :: static  ('__main__')
     r38 = __main__.D_template :: type
     r39 = pytype_from_template(r38, r36, r37)
-    r40 = D__trait_vtable_setup()
+    r40 = D_trait_vtable_setup()
     __main__.D = r39 :: type
     r41 = __main__.globals :: static
     r42 = unicode_6 :: static  ('D')

--- a/test-data/genops-generics.test
+++ b/test-data/genops-generics.test
@@ -39,25 +39,6 @@ L0:
     y = r3
     r4 = None
     return r4
-def __top_level__():
-    r0 :: str
-    r1 :: object
-    r2 :: str
-    r3, r4, r5 :: object
-    r6 :: str
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = unicode_0 :: static  ('T')
-    r1 = __main__.globals :: static
-    r2 = unicode_1 :: static  ('TypeVar')
-    r3 = r1[r2] :: dict
-    r4 = py_call(r3, r0)
-    r5 = __main__.globals :: static
-    r6 = unicode_0 :: static  ('T')
-    r7 = r5.__setitem__(r6, r4) :: object
-    r8 = None
-    return r8
 
 [case testGenericAttrAndTypeApplication]
 from typing import TypeVar, Generic
@@ -90,54 +71,6 @@ L0:
     r7 = r4 + r6 :: int
     r8 = None
     return r8
-def __top_level__():
-    r0 :: str
-    r1 :: object
-    r2 :: str
-    r3, r4, r5 :: object
-    r6 :: str
-    r7 :: bool
-    r8 :: object
-    r9 :: str
-    r10, r11 :: object
-    r12 :: str
-    r13, r14 :: object
-    r15 :: tuple[object]
-    r16 :: object
-    r17 :: str
-    r18, r19, r20 :: object
-    r21 :: str
-    r22 :: dict
-    r23 :: bool
-    r24 :: None
-L0:
-    r0 = unicode_0 :: static  ('T')
-    r1 = __main__.globals :: static
-    r2 = unicode_1 :: static  ('TypeVar')
-    r3 = r1[r2] :: dict
-    r4 = py_call(r3, r0)
-    r5 = __main__.globals :: static
-    r6 = unicode_0 :: static  ('T')
-    r7 = r5.__setitem__(r6, r4) :: object
-    r8 = __main__.globals :: static
-    r9 = unicode_2 :: static  ('Generic')
-    r10 = r8[r9] :: dict
-    r11 = __main__.globals :: static
-    r12 = unicode_0 :: static  ('T')
-    r13 = r11[r12] :: dict
-    r14 = r10[r13] :: object
-    r15 = (r14)
-    r16 = box(tuple[object], r15)
-    r17 = unicode_3 :: static  ('__main__')
-    r18 = __main__.C_template :: type
-    r19 = pytype_from_template(r18, r16, r17)
-    __main__.C = r19 :: type
-    r20 = __main__.globals :: static
-    r21 = unicode_4 :: static  ('C')
-    r22 = cast(dict, r20)
-    r23 = r22.__setitem__(r21, r19) :: dict
-    r24 = None
-    return r24
 
 [case testGenericMethod]
 from typing import TypeVar, Generic
@@ -203,51 +136,3 @@ L0:
     x = r8
     r9 = None
     return r9
-def __top_level__():
-    r0 :: str
-    r1 :: object
-    r2 :: str
-    r3, r4, r5 :: object
-    r6 :: str
-    r7 :: bool
-    r8 :: object
-    r9 :: str
-    r10, r11 :: object
-    r12 :: str
-    r13, r14 :: object
-    r15 :: tuple[object]
-    r16 :: object
-    r17 :: str
-    r18, r19, r20 :: object
-    r21 :: str
-    r22 :: dict
-    r23 :: bool
-    r24 :: None
-L0:
-    r0 = unicode_0 :: static  ('T')
-    r1 = __main__.globals :: static
-    r2 = unicode_1 :: static  ('TypeVar')
-    r3 = r1[r2] :: dict
-    r4 = py_call(r3, r0)
-    r5 = __main__.globals :: static
-    r6 = unicode_0 :: static  ('T')
-    r7 = r5.__setitem__(r6, r4) :: object
-    r8 = __main__.globals :: static
-    r9 = unicode_2 :: static  ('Generic')
-    r10 = r8[r9] :: dict
-    r11 = __main__.globals :: static
-    r12 = unicode_0 :: static  ('T')
-    r13 = r11[r12] :: dict
-    r14 = r10[r13] :: object
-    r15 = (r14)
-    r16 = box(tuple[object], r15)
-    r17 = unicode_3 :: static  ('__main__')
-    r18 = __main__.C_template :: type
-    r19 = pytype_from_template(r18, r16, r17)
-    __main__.C = r19 :: type
-    r20 = __main__.globals :: static
-    r21 = unicode_4 :: static  ('C')
-    r22 = cast(dict, r20)
-    r23 = r22.__setitem__(r21, r19) :: dict
-    r24 = None
-    return r24

--- a/test-data/genops-generics.test
+++ b/test-data/genops-generics.test
@@ -39,6 +39,25 @@ L0:
     y = r3
     r4 = None
     return r4
+def __top_level__():
+    r0 :: str
+    r1 :: object
+    r2 :: str
+    r3, r4, r5 :: object
+    r6 :: str
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = unicode_0 :: static  ('T')
+    r1 = __main__.globals :: static
+    r2 = unicode_1 :: static  ('TypeVar')
+    r3 = r1[r2] :: dict
+    r4 = py_call(r3, r0)
+    r5 = __main__.globals :: static
+    r6 = unicode_0 :: static  ('T')
+    r7 = r5.__setitem__(r6, r4) :: object
+    r8 = None
+    return r8
 
 [case testGenericAttrAndTypeApplication]
 from typing import TypeVar, Generic
@@ -71,6 +90,54 @@ L0:
     r7 = r4 + r6 :: int
     r8 = None
     return r8
+def __top_level__():
+    r0 :: str
+    r1 :: object
+    r2 :: str
+    r3, r4, r5 :: object
+    r6 :: str
+    r7 :: bool
+    r8 :: object
+    r9 :: str
+    r10, r11 :: object
+    r12 :: str
+    r13, r14 :: object
+    r15 :: tuple[object]
+    r16 :: object
+    r17 :: str
+    r18, r19, r20 :: object
+    r21 :: str
+    r22 :: dict
+    r23 :: bool
+    r24 :: None
+L0:
+    r0 = unicode_0 :: static  ('T')
+    r1 = __main__.globals :: static
+    r2 = unicode_1 :: static  ('TypeVar')
+    r3 = r1[r2] :: dict
+    r4 = py_call(r3, r0)
+    r5 = __main__.globals :: static
+    r6 = unicode_0 :: static  ('T')
+    r7 = r5.__setitem__(r6, r4) :: object
+    r8 = __main__.globals :: static
+    r9 = unicode_2 :: static  ('Generic')
+    r10 = r8[r9] :: dict
+    r11 = __main__.globals :: static
+    r12 = unicode_0 :: static  ('T')
+    r13 = r11[r12] :: dict
+    r14 = r10[r13] :: object
+    r15 = (r14)
+    r16 = box(tuple[object], r15)
+    r17 = unicode_3 :: static  ('__main__')
+    r18 = __main__.C_template :: type
+    r19 = pytype_from_template(r18, r16, r17)
+    __main__.C = r19 :: type
+    r20 = __main__.globals :: static
+    r21 = unicode_4 :: static  ('C')
+    r22 = cast(dict, r20)
+    r23 = r22.__setitem__(r21, r19) :: dict
+    r24 = None
+    return r24
 
 [case testGenericMethod]
 from typing import TypeVar, Generic
@@ -136,3 +203,51 @@ L0:
     x = r8
     r9 = None
     return r9
+def __top_level__():
+    r0 :: str
+    r1 :: object
+    r2 :: str
+    r3, r4, r5 :: object
+    r6 :: str
+    r7 :: bool
+    r8 :: object
+    r9 :: str
+    r10, r11 :: object
+    r12 :: str
+    r13, r14 :: object
+    r15 :: tuple[object]
+    r16 :: object
+    r17 :: str
+    r18, r19, r20 :: object
+    r21 :: str
+    r22 :: dict
+    r23 :: bool
+    r24 :: None
+L0:
+    r0 = unicode_0 :: static  ('T')
+    r1 = __main__.globals :: static
+    r2 = unicode_1 :: static  ('TypeVar')
+    r3 = r1[r2] :: dict
+    r4 = py_call(r3, r0)
+    r5 = __main__.globals :: static
+    r6 = unicode_0 :: static  ('T')
+    r7 = r5.__setitem__(r6, r4) :: object
+    r8 = __main__.globals :: static
+    r9 = unicode_2 :: static  ('Generic')
+    r10 = r8[r9] :: dict
+    r11 = __main__.globals :: static
+    r12 = unicode_0 :: static  ('T')
+    r13 = r11[r12] :: dict
+    r14 = r10[r13] :: object
+    r15 = (r14)
+    r16 = box(tuple[object], r15)
+    r17 = unicode_3 :: static  ('__main__')
+    r18 = __main__.C_template :: type
+    r19 = pytype_from_template(r18, r16, r17)
+    __main__.C = r19 :: type
+    r20 = __main__.globals :: static
+    r21 = unicode_4 :: static  ('C')
+    r22 = cast(dict, r20)
+    r23 = r22.__setitem__(r21, r19) :: dict
+    r24 = None
+    return r24

--- a/test-data/genops-optional.test
+++ b/test-data/genops-optional.test
@@ -214,7 +214,7 @@ def f(x):
     r8 :: int
 L0:
     r0 = builtins.module :: static
-    r1 = unicode_0 :: static  ('int')
+    r1 = unicode_2 :: static  ('int')
     r2 = getattr r0, r1
     r3 = isinstance x, r2
     if r3 goto L1 else goto L2 :: bool
@@ -293,7 +293,7 @@ def set(o, s):
     r1 :: bool
     r2 :: None
 L0:
-    r0 = unicode_0 :: static  ('a')
+    r0 = unicode_3 :: static  ('a')
     r1 = setattr o, r0, s
     r2 = None
     return r2
@@ -419,7 +419,7 @@ L1:
     goto L3
 L2:
     r5 = o
-    r6 = unicode_0 :: static  ('x')
+    r6 = unicode_2 :: static  ('x')
     r7 = getattr r5, r6
     r8 = unbox(int, r7)
     r0 = r8
@@ -449,7 +449,7 @@ L1:
     goto L3
 L2:
     r5 = o
-    r6 = unicode_0 :: static  ('x')
+    r6 = unicode_2 :: static  ('x')
     r7 = getattr r5, r6
     r8 = unbox(int, r7)
     r0 = r8

--- a/test-data/genops-optional.test
+++ b/test-data/genops-optional.test
@@ -21,6 +21,26 @@ L1:
 L2:
     r2 = 2
     return r2
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = None
+    return r8
 
 [case testIsNotNone]
 from typing import Optional
@@ -46,6 +66,26 @@ L1:
 L2:
     r3 = 2
     return r3
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = None
+    return r8
 
 [case testAssignToOptional]
 from typing import Optional
@@ -94,6 +134,26 @@ L0:
     a.a = r8; r9 = is_error
     r10 = None
     return r10
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = None
+    return r8
 
 [case testBoxOptionalListItem]
 from typing import List, Optional
@@ -152,6 +212,26 @@ L1:
     return r4
 L2:
     return y
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = None
+    return r8
 
 [case testPartialOptionalType]
 def f(y: int) -> None:

--- a/test-data/genops-optional.test
+++ b/test-data/genops-optional.test
@@ -21,26 +21,6 @@ L1:
 L2:
     r2 = 2
     return r2
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = None
-    return r8
 
 [case testIsNotNone]
 from typing import Optional
@@ -66,26 +46,6 @@ L1:
 L2:
     r3 = 2
     return r3
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = None
-    return r8
 
 [case testAssignToOptional]
 from typing import Optional
@@ -134,26 +94,6 @@ L0:
     a.a = r8; r9 = is_error
     r10 = None
     return r10
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = None
-    return r8
 
 [case testBoxOptionalListItem]
 from typing import List, Optional
@@ -212,26 +152,6 @@ L1:
     return r4
 L2:
     return y
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = None
-    return r8
 
 [case testPartialOptionalType]
 def f(y: int) -> None:

--- a/test-data/genops-statements.test
+++ b/test-data/genops-statements.test
@@ -476,6 +476,26 @@ L0:
     z = r7
     r8 = None
     return r8
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_0 :: static  ('__main__')
+    r2 = __main__.A_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.A = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_1 :: static  ('A')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = None
+    return r8
 
 [case testAssert]
 from typing import Optional
@@ -731,7 +751,7 @@ L0:
     r1 = 2
     r2 = Dummy(r0, r1)
     dummy = r2
-    r3 = unicode_4 :: static  ('x')
+    r3 = unicode_6 :: static  ('x')
     r4 = delattr dummy, r3
     r5 = None
     return r5
@@ -748,9 +768,29 @@ L0:
     r1 = 2
     r2 = Dummy(r0, r1)
     dummy = r2
-    r3 = unicode_4 :: static  ('x')
+    r3 = unicode_6 :: static  ('x')
     r4 = delattr dummy, r3
-    r5 = unicode_5 :: static  ('y')
+    r5 = unicode_7 :: static  ('y')
     r6 = delattr dummy, r5
     r7 = None
     return r7
+def __top_level__():
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: str
+    r6 :: dict
+    r7 :: bool
+    r8 :: None
+L0:
+    r0 = <error> :: object
+    r1 = unicode_4 :: static  ('__main__')
+    r2 = __main__.Dummy_template :: type
+    r3 = pytype_from_template(r2, r0, r1)
+    __main__.Dummy = r3 :: type
+    r4 = __main__.globals :: static
+    r5 = unicode_5 :: static  ('Dummy')
+    r6 = cast(dict, r4)
+    r7 = r6.__setitem__(r5, r3) :: dict
+    r8 = None
+    return r8

--- a/test-data/genops-statements.test
+++ b/test-data/genops-statements.test
@@ -476,26 +476,6 @@ L0:
     z = r7
     r8 = None
     return r8
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_0 :: static  ('__main__')
-    r2 = __main__.A_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.A = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_1 :: static  ('A')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = None
-    return r8
 
 [case testAssert]
 from typing import Optional
@@ -774,23 +754,3 @@ L0:
     r6 = delattr dummy, r5
     r7 = None
     return r7
-def __top_level__():
-    r0 :: object
-    r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6 :: dict
-    r7 :: bool
-    r8 :: None
-L0:
-    r0 = <error> :: object
-    r1 = unicode_4 :: static  ('__main__')
-    r2 = __main__.Dummy_template :: type
-    r3 = pytype_from_template(r2, r0, r1)
-    __main__.Dummy = r3 :: type
-    r4 = __main__.globals :: static
-    r5 = unicode_5 :: static  ('Dummy')
-    r6 = cast(dict, r4)
-    r7 = r6.__setitem__(r5, r3) :: dict
-    r8 = None
-    return r8

--- a/test-data/run-bench.test
+++ b/test-data/run-bench.test
@@ -148,6 +148,9 @@ import interpreted
 print(interpreted.SumVisitor.mro())
 import native
 print(native.SumVisitor.mro())
+print(native.TreeVisitor.__name__)
+print(native.SumVisitor.__name__)
+print(native.TreeVisitor[int])
 from timeit import timeit
 from time import time
 import os
@@ -166,6 +169,9 @@ def basic_test(m):
     assert m.sum_tree(tree) == 57
     assert m.equal(tree, tree)
     assert not m.equal(tree, tree2)
+
+    assert isinstance(native.SumVisitor(), native.TreeVisitor)
+
     return tree
 
 def test(m):

--- a/test-data/run-bench.test
+++ b/test-data/run-bench.test
@@ -155,7 +155,7 @@ print(tuple(x.__name__ for x in interpreted.SumVisitor.mro()))
 print(tuple(x.__name__ for x in native.SumVisitor.mro()))
 print(native.TreeVisitor.__name__)
 print(native.SumVisitor.__name__)
-print(native.TreeVisitor[int])
+print(native.TreeVisitor[native.T])
 
 def dumb_time(f):
     t0 = time()
@@ -196,4 +196,4 @@ if os.environ.get('MYPYC_RUN_BENCH') == '1':
 ('SumVisitor', 'TreeVisitor', 'Generic', 'object')
 TreeVisitor
 SumVisitor
-native.TreeVisitor[int]
+native.TreeVisitor[~T]

--- a/test-data/run-bench.test
+++ b/test-data/run-bench.test
@@ -151,8 +151,8 @@ from time import time
 import os
 
 # Side test: some stuff about MROs and generics
-print(tuple(interpreted.SumVisitor.mro()))
-print(tuple(native.SumVisitor.mro()))
+print(tuple(x.__name__ for x in interpreted.SumVisitor.mro()))
+print(tuple(x.__name__ for x in native.SumVisitor.mro()))
 print(native.TreeVisitor.__name__)
 print(native.SumVisitor.__name__)
 print(native.TreeVisitor[int])
@@ -192,8 +192,8 @@ if os.environ.get('MYPYC_RUN_BENCH') == '1':
     print("Sum speedup:", ifsum/nfsum)
     print("Equal speedup:", ifeq/nfeq)
 [out]
-(interpreted.SumVisitor, interpreted.TreeVisitor, typing.Generic, <class 'object'>)
-(native.SumVisitor, native.TreeVisitor, typing.Generic, <class 'object'>)
+('SumVisitor', 'TreeVisitor', 'Generic', 'object')
+('SumVisitor', 'TreeVisitor', 'Generic', 'object')
 TreeVisitor
 SumVisitor
 native.TreeVisitor[int]

--- a/test-data/run-bench.test
+++ b/test-data/run-bench.test
@@ -79,7 +79,7 @@ if os.environ.get('MYPYC_RUN_BENCH') == '1':
 
 [case testBenchmarkVisitorTree]
 from mypy_extensions import trait
-from typing import cast, Generic, TypeVar
+from typing import cast, Generic, TypeVar, Any
 
 T = TypeVar('T')
 class Tree:
@@ -144,11 +144,14 @@ def bench_equal_tree(x: Tree, y: Tree) -> None:
 
 [file driver.py]
 from typing import Optional
-import native
 import interpreted
+print(interpreted.SumVisitor.mro())
+import native
+print(native.SumVisitor.mro())
 from timeit import timeit
 from time import time
 import os
+
 
 def dumb_time(f):
     t0 = time()

--- a/test-data/run-bench.test
+++ b/test-data/run-bench.test
@@ -145,16 +145,17 @@ def bench_equal_tree(x: Tree, y: Tree) -> None:
 [file driver.py]
 from typing import Optional
 import interpreted
-print(interpreted.SumVisitor.mro())
 import native
-print(native.SumVisitor.mro())
-print(native.TreeVisitor.__name__)
-print(native.SumVisitor.__name__)
-print(native.TreeVisitor[int])
 from timeit import timeit
 from time import time
 import os
 
+# Side test: some stuff about MROs and generics
+print(tuple(interpreted.SumVisitor.mro()))
+print(tuple(native.SumVisitor.mro()))
+print(native.TreeVisitor.__name__)
+print(native.SumVisitor.__name__)
+print(native.TreeVisitor[int])
 
 def dumb_time(f):
     t0 = time()
@@ -190,3 +191,9 @@ if os.environ.get('MYPYC_RUN_BENCH') == '1':
     print(nfsum)
     print("Sum speedup:", ifsum/nfsum)
     print("Equal speedup:", ifeq/nfeq)
+[out]
+(interpreted.SumVisitor, interpreted.TreeVisitor, typing.Generic, <class 'object'>)
+(native.SumVisitor, native.TreeVisitor, typing.Generic, <class 'object'>)
+TreeVisitor
+SumVisitor
+native.TreeVisitor[int]

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -615,10 +615,18 @@ assert not hasattr(b, 'bogus')
 [case testGenericTrivial]
 from typing import TypeVar, Generic
 T = TypeVar('T')
+print('yo')
 class C(Generic[T]):
     pass
-class D(C[int]):
-    pass
+# class D(C[int]):
+#     pass
 
 [file driver.py]
-import native
+from native import C#, D
+print(C.__dict__)
+print(C.mro())
+print(type(C))
+# print(D.__dict__)
+# print(D.mro())
+# print(type(D))
+# D()

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -499,6 +499,41 @@ yo!
 3
 yo!
 
+-- broken - we need to handle the layout conflicts for it to work
+[case testSubclassException-skip]
+class Failure(Exception):
+    pass
+
+def foo() -> None:
+    raise Failure
+
+[file driver.py]
+import native
+native.Failure()
+native.foo()
+
+[case testSubclassPy-skip]
+from b import B
+class A(B):
+    x: int
+    def foo(self, x: int) -> int:
+        print("hi", x)
+        return x+1
+[file b.py]
+class B:
+    def foo(self, x: int) -> int:
+        print("parent!")
+        return x-1
+    def bar(self) -> None:
+        self.z = 10
+        print("hello!")
+[file driver.py]
+import native
+a = native.A()
+a.foo(10)
+a.bar(10)
+assert False
+
 [case testClassVariable]
 from typing import ClassVar
 class A:
@@ -559,3 +594,14 @@ assert b.y == 'rofl'
 assert b.z is None
 # N.B: this doesn't match cpython
 assert not hasattr(b, 'bogus')
+
+[case testGenericTrivial]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class C(Generic[T]):
+    pass
+class D(C[int]):
+    pass
+
+[file driver.py]
+import native

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -512,27 +512,44 @@ import native
 native.Failure()
 native.foo()
 
-[case testSubclassPy-skip]
+[case testSubclassPy]
 from b import B
 class A(B):
-    x: int
+    def __init__(self, x: int, y: int) -> None:
+        super().__init__(y)
+        self.x = x
+
     def foo(self, x: int) -> int:
         print("hi", x)
         return x+1
+
+def f(x: A) -> None:
+    print(x.x)
+    print(x.y)
+    print(x.foo(20))
+
 [file b.py]
 class B:
+    def __init__(self, y: int) -> None:
+        self.y = y
     def foo(self, x: int) -> int:
         print("parent!")
-        return x-1
+        return x + self.y
     def bar(self) -> None:
-        self.z = 10
-        print("hello!")
+        print("hello!", self.y)
 [file driver.py]
 import native
-a = native.A()
+a = native.A(10, 20)
 a.foo(10)
-a.bar(10)
-assert False
+a.bar()
+native.f(a)
+[out]
+hi 10
+hello! 20
+10
+20
+hi 20
+21
 
 [case testClassVariable]
 from typing import ClassVar

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -611,22 +611,3 @@ assert b.y == 'rofl'
 assert b.z is None
 # N.B: this doesn't match cpython
 assert not hasattr(b, 'bogus')
-
-[case testGenericTrivial]
-from typing import TypeVar, Generic
-T = TypeVar('T')
-print('yo')
-class C(Generic[T]):
-    pass
-# class D(C[int]):
-#     pass
-
-[file driver.py]
-from native import C#, D
-print(C.__dict__)
-print(C.mro())
-print(type(C))
-# print(D.__dict__)
-# print(D.mro())
-# print(type(D))
-# D()

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -513,7 +513,7 @@ native.Failure()
 native.foo()
 
 [case testSubclassPy]
-from b import B
+from b import B, V
 class A(B):
     def __init__(self, x: int, y: int) -> None:
         super().__init__(y)
@@ -523,12 +523,20 @@ class A(B):
         print("hi", x)
         return x+1
 
+class C(V[int]):
+    def f(self) -> int: return 10
+
+assert isinstance(C(), V)
+
 def f(x: A) -> None:
     print(x.x)
     print(x.y)
     print(x.foo(20))
 
 [file b.py]
+from typing import Generic, TypeVar
+T = TypeVar('T')
+
 class B:
     def __init__(self, y: int) -> None:
         self.y = y
@@ -537,6 +545,10 @@ class B:
         return x + self.y
     def bar(self) -> None:
         print("hello!", self.y)
+
+class V(Generic[T]):
+    def f(self) -> T:
+        raise Exception('unimplemented')
 [file driver.py]
 import native
 a = native.A(10, 20)

--- a/test-data/run-traits.test
+++ b/test-data/run-traits.test
@@ -27,6 +27,8 @@ def use_c(c: C) -> int:
     c.bar()
     return c.baz()
 
+use_t(C())
+
 [file driver.py]
 from native import A, T, C, use_c, use_t
 c = C()
@@ -36,6 +38,7 @@ assert c.baz() == 10
 assert use_c(c) == 10
 assert use_t(c) == 10
 [out]
+bar
 foo
 bar
 bar

--- a/test-data/run-traits.test
+++ b/test-data/run-traits.test
@@ -125,3 +125,19 @@ foo
 bar 13
 bar 13
 1337
+
+[case testTrait3]
+from mypy_extensions import trait
+from typing import Generic, TypeVar
+
+@trait
+class T1: pass
+@trait
+class T2: pass
+
+T = TypeVar('T')
+
+class C(Generic[T], T1, T2):
+    pass
+[file driver.py]
+import native


### PR DESCRIPTION
I think we are going to want to support both options in #296, and so this is
work on option 1 of it.
This is not fully finished code, but I wanted to ask for thoughts on it now.

In addition to supporting subclassing python classes during the migration,
we also probably want to be able to subclass `Generic[T]`.

My approach for this is moving class creation into genops, evaluating the base 
classes, calling a prim to create the class, and saving it with a newly added
`InitStatic` op. This requires https://github.com/python/mypy/pull/5410 to support it.

This all works but it feels kind of ugly.