### PR TITLE
Make `none_op` return a borrowed value

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -72,7 +72,7 @@ from mypyc.ops_misc import (
     none_op, true_op, false_op, iter_op, next_op, py_getattr_op, py_setattr_op, py_delattr_op,
     py_call_op, py_call_with_kwargs_op, py_method_call_op,
     fast_isinstance_op, bool_op, new_slice_op,
-    is_none_op, type_op,
+    type_op,
 )
 from mypyc.ops_exc import (
     no_err_occurred_op, raise_exception_op, reraise_exception_op,
@@ -2186,16 +2186,9 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         elif op == 'not in':
             op, negate = 'in', True
 
-        rhs = e.operands[1]
-        if (op == 'is' and isinstance(rhs, NameExpr) and rhs.node
-                and rhs.node.fullname() == 'builtins.None'):
-            # Special case 'is None' checks.
-            left = self.accept(e.operands[0])
-            target = self.add(PrimitiveOp([left], is_none_op, e.line))
-        else:
-            left = self.accept(e.operands[0])
-            right = self.accept(e.operands[1])
-            target = self.binary_op(left, right, op, e.line)
+        left = self.accept(e.operands[0])
+        right = self.accept(e.operands[1])
+        target = self.binary_op(left, right, op, e.line)
 
         if negate:
             target = self.unary_op(target, 'not', e.line)

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -856,6 +856,12 @@ class PrimitiveOp(RegisterOp):
         else:
             self.type = desc.result_type
 
+        # This is a kind of awful hack: none_op produces a borrowed
+        # value. There are basically zero other primitive ops where we
+        # want a borrowed value, so we just special case it.
+        if desc is mypyc.ops_misc.none_op:
+            self.is_borrowed = True
+
     def sources(self) -> List[Value]:
         return list(self.args)
 

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -12,15 +12,11 @@ from mypyc.ops_primitive import (
 )
 
 
-def emit_none(emitter: EmitterInterface, args: List[str], dest: str) -> None:
-    emitter.emit_lines('{} = Py_None;'.format(dest),
-                       'Py_INCREF({});'.format(dest))
-
-
+# N.B: none_op is special cased as borrowed by PrimitiveOp
 none_op = name_ref_op('builtins.None',
                       result_type=none_rprimitive,
                       error_kind=ERR_NEVER,
-                      emit=emit_none)
+                      emit=simple_emit('{dest} = Py_None;'))
 
 true_op = name_ref_op('builtins.True',
                       result_type=bool_rprimitive,
@@ -128,14 +124,6 @@ binary_op('is not',
           error_kind=ERR_NEVER,
           emit=negative_int_emit('{dest} = {args[0]} != {args[1]};'),
           priority=0)
-
-is_none_op = custom_op(
-    arg_types=[object_rprimitive],
-    result_type=bool_rprimitive,
-    error_kind=ERR_NEVER,
-    format_str = '{dest} = {args[0]} is None',
-    emit=simple_emit('{dest} = {args[0]} == Py_None;'))
-
 
 for op, funcname in [('-', 'PyNumber_Negative'),
                      ('+', 'PyNumber_Positive'),

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -69,10 +69,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.assert_emit(TupleGet(self.t, 1, 0), 'cpy_r_r0 = cpy_r_t.f1;')
 
     def test_load_None(self) -> None:
-        self.assert_emit(PrimitiveOp([], none_op, 0),
-                         """cpy_r_r0 = Py_None;
-                            Py_INCREF(cpy_r_r0);
-                         """)
+        self.assert_emit(PrimitiveOp([], none_op, 0), "cpy_r_r0 = Py_None;")
 
     def test_load_True(self) -> None:
         self.assert_emit(PrimitiveOp([], true_op, 0), "cpy_r_r0 = 1;")

--- a/test-data/exceptions.test
+++ b/test-data/exceptions.test
@@ -36,7 +36,6 @@ L0:
     if not r1 goto L3 (error at f:3) else goto L1 :: bool
 L1:
     r2 = None
-    dec_ref r2
     inc_ref z :: int
     r3 = box(int, z)
     r4 = x.__setitem__(y, r3) :: list
@@ -44,6 +43,7 @@ L1:
     if not r4 goto L3 (error at f:4) else goto L2 :: bool
 L2:
     r5 = None
+    inc_ref r5
     return r5
 L3:
     r6 = <error> :: None
@@ -62,29 +62,31 @@ def f(x: Optional[A]) -> int:
     return 3
 [out]
 L0:
-    r0 = x is None
-    if r0 goto L1 else goto L2 :: bool
+    r0 = None
+    r1 = x is r0
+    if r1 goto L1 else goto L2 :: bool
 L1:
-    r1 = 1
-    return r1
+    r2 = 1
+    return r2
 L2:
     inc_ref x
-    r2 = cast(A, x)
-    if is_error(r2) goto L6 (error at f:8) else goto L3
+    r3 = cast(A, x)
+    if is_error(r3) goto L6 (error at f:8) else goto L3
 L3:
-    r3 = r2 is None
-    dec_ref r2
-    r4 = !r3
-    if r4 goto L4 else goto L5 :: bool
+    r4 = None
+    r5 = r3 is r4
+    dec_ref r3
+    r6 = !r5
+    if r6 goto L4 else goto L5 :: bool
 L4:
-    r5 = 2
-    return r5
-L5:
-    r6 = 3
-    return r6
-L6:
-    r7 = <error> :: int
+    r7 = 2
     return r7
+L5:
+    r8 = 3
+    return r8
+L6:
+    r9 = <error> :: int
+    return r9
 
 [case testListSum]
 from typing import List
@@ -182,6 +184,7 @@ L10:
     unreachable
 L11:
     r12 = None
+    inc_ref r12
     return r12
 L12:
     r13 = <error> :: None
@@ -296,6 +299,7 @@ def lol() -> None:
 L0:
     r0 = unicode_0 :: static  ('Hello')
     r1 = None
+    inc_ref r1
     return r1
 
 [case testExceptUndefined]

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -123,26 +123,28 @@ class Node:
 def Node.length(self):
     self :: Node
     r0 :: union[Node, None]
-    r1, r2 :: bool
-    r3 :: int
-    r4 :: union[Node, None]
-    r5 :: Node
-    r6, r7, r8 :: int
+    r1 :: None
+    r2, r3 :: bool
+    r4 :: int
+    r5 :: union[Node, None]
+    r6 :: Node
+    r7, r8, r9 :: int
 L0:
     r0 = self.next
-    r1 = r0 is None
-    r2 = !r1
-    if r2 goto L1 else goto L2 :: bool
+    r1 = None
+    r2 = r0 is r1
+    r3 = !r2
+    if r3 goto L1 else goto L2 :: bool
 L1:
-    r3 = 1
-    r4 = self.next
-    r5 = cast(Node, r4)
-    r6 = r5.length()
-    r7 = r3 + r6 :: int
-    return r7
-L2:
-    r8 = 1
+    r4 = 1
+    r5 = self.next
+    r6 = cast(Node, r5)
+    r7 = r6.length()
+    r8 = r4 + r7 :: int
     return r8
+L2:
+    r9 = 1
+    return r9
 
 [case testSubclass]
 class A:

--- a/test-data/genops-optional.test
+++ b/test-data/genops-optional.test
@@ -10,17 +10,19 @@ def f(x: Optional[A]) -> int:
 [out]
 def f(x):
     x :: union[A, None]
-    r0 :: bool
-    r1, r2 :: int
+    r0 :: None
+    r1 :: bool
+    r2, r3 :: int
 L0:
-    r0 = x is None
-    if r0 goto L1 else goto L2 :: bool
+    r0 = None
+    r1 = x is r0
+    if r1 goto L1 else goto L2 :: bool
 L1:
-    r1 = 1
-    return r1
-L2:
-    r2 = 2
+    r2 = 1
     return r2
+L2:
+    r3 = 2
+    return r3
 
 [case testIsNotNone]
 from typing import Optional
@@ -34,18 +36,20 @@ def f(x: Optional[A]) -> int:
 [out]
 def f(x):
     x :: union[A, None]
-    r0, r1 :: bool
-    r2, r3 :: int
+    r0 :: None
+    r1, r2 :: bool
+    r3, r4 :: int
 L0:
-    r0 = x is None
-    r1 = !r0
-    if r1 goto L1 else goto L2 :: bool
+    r0 = None
+    r1 = x is r0
+    r2 = !r1
+    if r2 goto L1 else goto L2 :: bool
 L1:
-    r2 = 1
-    return r2
-L2:
-    r3 = 2
+    r3 = 1
     return r3
+L2:
+    r4 = 2
+    return r4
 
 [case testAssignToOptional]
 from typing import Optional
@@ -137,19 +141,21 @@ def f(x: Optional[A]) -> A:
 def f(x):
     x :: union[A, None]
     r0, y :: A
-    r1, r2 :: bool
-    r3, r4 :: A
+    r1 :: None
+    r2, r3 :: bool
+    r4, r5 :: A
 L0:
     r0 = A()
     y = r0
-    r1 = x is None
-    r2 = !r1
-    if r2 goto L1 else goto L2 :: bool
+    r1 = None
+    r2 = x is r1
+    r3 = !r2
+    if r3 goto L1 else goto L2 :: bool
 L1:
-    r3 = cast(A, x)
-    y = r3
     r4 = cast(A, x)
-    return r4
+    y = r4
+    r5 = cast(A, x)
+    return r5
 L2:
     return y
 
@@ -168,9 +174,10 @@ def f(y):
     r1 :: int
     r2 :: bool
     r3 :: object
-    r4, r5 :: bool
-    r6 :: int
-    r7 :: None
+    r4 :: None
+    r5, r6 :: bool
+    r7 :: int
+    r8 :: None
 L0:
     r0 = None
     x = r0
@@ -181,15 +188,16 @@ L1:
     r3 = box(int, y)
     x = r3
 L2:
-    r4 = x is None
-    r5 = !r4
-    if r5 goto L3 else goto L4 :: bool
+    r4 = None
+    r5 = x is r4
+    r6 = !r5
+    if r6 goto L3 else goto L4 :: bool
 L3:
-    r6 = unbox(int, x)
-    y = r6
+    r7 = unbox(int, x)
+    y = r7
 L4:
-    r7 = None
-    return r7
+    r8 = None
+    return r8
 
 [case testUnionType]
 from typing import Union

--- a/test-data/module-output.test
+++ b/test-data/module-output.test
@@ -86,7 +86,7 @@ static PyObject *CPyDef___top_level__(void) {
     PyObject *cpy_r_r0;
 CPyL0: ;
     cpy_r_r0 = Py_None;
-    Py_INCREF(cpy_r_r0);
+    CPy_INCREF(cpy_r_r0);
     return cpy_r_r0;
 }
 [case testError]

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -309,6 +309,7 @@ L0:
     x = r2
     dec_ref x :: int
     r3 = None
+    inc_ref r3
     return r3
 
 [case testAdd1]
@@ -326,6 +327,7 @@ L0:
     x = r2
     dec_ref x :: int
     r3 = None
+    inc_ref r3
     return r3
 
 [case testAdd2]
@@ -375,6 +377,7 @@ L0:
     z = r2
     dec_ref z :: int
     r3 = None
+    inc_ref r3
     return r3
 
 [case testAdd5]
@@ -394,6 +397,7 @@ L0:
     x = r2
     dec_ref x :: int
     r3 = None
+    inc_ref r3
     return r3
 
 [case testReturnInMiddleOfFunction]
@@ -530,6 +534,7 @@ L0:
     dec_ref r3 :: int
     dec_ref r4
     r6 = None
+    inc_ref r6
     return r6
 
 [case testTupleRefcount]
@@ -558,6 +563,7 @@ L0:
     dec_ref c
     dec_ref r1
     r3 = None
+    inc_ref r3
     return r3
 
 [case testCastRefCount]
@@ -580,6 +586,7 @@ L0:
     d = r4
     dec_ref d
     r5 = None
+    inc_ref r5
     return r5
 
 [case testUnaryBranchSpecialCase]
@@ -641,8 +648,8 @@ L0:
     r1 = a.append(r0) :: list
     dec_ref r0
     r2 = None
-    dec_ref r2
     r3 = None
+    inc_ref r3
     return r3
 
 [case testForDict]
@@ -672,6 +679,7 @@ L3:
     r6 = no_err_occurred
 L4:
     r7 = None
+    inc_ref r7
     return r7
 L5:
     dec_ref r0


### PR DESCRIPTION
This is done through a somewhat tasteless special case in PrimitiveOp.

The point of all of this is to allow removing the `is_none` special
case in `visit_comparision_expr` without incurring extra reference
count traffic. We want to do that because it will simplify
implementation of many-operand comparisons.