### PR TITLE
Support defining __bool__

### DIFF
--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1431,6 +1431,9 @@ class ClassIR:
         # base_mro is the chain of concrete (non-trait) ancestors
         self.base_mro = [self]  # type: List[ClassIR]
 
+        # Does this class or any subclass have a __bool__method
+        self.has_bool = False
+
     def real_base(self) -> Optional['ClassIR']:
         """Return the actual concrete base class, if there is one."""
         if len(self.mro) > 1 and not self.mro[1].is_trait:

--- a/test-data/fixtures/ir.py
+++ b/test-data/fixtures/ir.py
@@ -64,7 +64,9 @@ class bytes:
     def __ne__(self, x: object) -> bool: pass
     def join(self, x: Iterable[object]) -> bytes: pass
 
-class bool: pass
+class bool:
+    def __init__(self, o: object = ...) -> None: ...
+
 
 class tuple(Generic[T], Sized):
     def __init__(self, i: Iterable[T]) -> None: pass

--- a/test-data/genops-optional.test
+++ b/test-data/genops-optional.test
@@ -24,6 +24,49 @@ L2:
     r3 = 2
     return r3
 
+[case testIsTruthyOverride]
+from typing import Optional
+
+class A: pass
+
+class B(A):
+    def __bool__(self) -> bool:
+        return False
+
+
+def f(x: Optional[A]) -> int:
+    if x:
+        return 1
+    return 2
+[out]
+def B.__bool__(self):
+    self :: B
+    r0 :: bool
+L0:
+    r0 = False
+    return r0
+def f(x):
+    x :: union[A, None]
+    r0 :: None
+    r1 :: bool
+    r2 :: A
+    r3 :: bool
+    r4, r5 :: int
+L0:
+    r0 = None
+    r1 = x is not r0
+    if r1 goto L1 else goto L3 :: bool
+L1:
+    r2 = cast(A, x)
+    r3 = bool r2 :: object
+    if r3 goto L2 else goto L3 :: bool
+L2:
+    r4 = 1
+    return r4
+L3:
+    r5 = 2
+    return r5
+
 [case testIsNotNone]
 from typing import Optional
 

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -2377,7 +2377,8 @@ class Item:
         return self.value < x.value
 
 class Subclass1(Item):
-    pass
+    def __bool__(self) -> bool:
+        return bool(self.value)
 
 class NonBoxedThing:
     def __getitem__(self, index: Item) -> Item:
@@ -2399,6 +2400,9 @@ def internal_index_into() -> None:
     y = NonBoxedThing()
     z = Item("3")
     print(y[z].value)
+
+def is_truthy(x: Item) -> bool:
+    return True if x else False
 
 [file driver.py]
 from native import *
@@ -2426,6 +2430,11 @@ assert i1 != i3
 assert i2 < i3
 assert not i1 < i2
 assert i1 == Subclass1('lolol')
+
+assert is_truthy(Item(''))
+assert is_truthy(Item('a'))
+assert not is_truthy(Subclass1(''))
+assert is_truthy(Subclass1('a'))
 
 internal_index_into()
 [out]


### PR DESCRIPTION
To support this, refactor emitclass dunder handling to be even *more*
data driven.
The main reason I am not throwing in support for ~all of the other
dunder methods is that I think we should add tests for them when we
add support.

Supporting __bool__ without always deoptimizing truthiness checks
against Optional types requires adding a very simple "whole-program
analysis" for whether a subclass defines __bool__.