### PR TITLE
Special case any() and all()

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1545,7 +1545,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             assert s.else_body is not None
             self.accept(s.else_body)
 
-        self.for_loop_helper(s.index, s.expr, body, else_block if s.else_body else None, s.line)
+        self.for_loop_helper(s.index, s.expr, body,
+                             else_block if s.else_body else None, None, s.line)
 
     def spill(self, value: Value) -> AssignmentTarget:
         """Moves a given Value instance into the generator class' environment class."""
@@ -1588,16 +1589,20 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         return reg
 
     def for_loop_helper(self, index: Lvalue, expr: Expression,
-                        body_insts: GenFunc, else_insts: Optional[GenFunc], line: int) -> None:
+                        body_insts: GenFunc, else_insts: Optional[GenFunc],
+                        exit_block: Optional[BasicBlock], line: int) -> None:
         """Generate IR for a loop.
 
         "index" is the loop index Lvalue
         "expr" is the expression to iterate over
         "body_insts" is a function to generate the body of the loop.
         """
-        body_block, exit_block, increment_block = BasicBlock(), BasicBlock(), BasicBlock()
+        body_block, increment_block = BasicBlock(), BasicBlock()
         # Block for the else clause, if we need it.
         else_block = BasicBlock()
+
+        if exit_block is None:
+            exit_block = BasicBlock()
 
         # Determine where we want to exit, if our condition check fails.
         normal_loop_exit = else_block if else_insts is not None else exit_block
@@ -1732,6 +1737,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             self.activate_block(else_block)
             else_insts()
             self.goto(exit_block)
+
         self.activate_block(exit_block)
 
     def visit_break_stmt(self, node: BreakStmt) -> None:
@@ -2073,6 +2079,27 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         return self.py_call(function, args, expr.line,
                             arg_kinds=expr.arg_kinds, arg_names=expr.arg_names)
 
+    def any_all_helper(self,
+                       gen: GeneratorExpr,
+                       initial_value_op: OpDescription,
+                       modify: Callable[[Value], Value],
+                       new_value_op: OpDescription) -> Value:
+        retval = self.alloc_temp(bool_rprimitive)
+        self.assign(retval, self.primitive_op(initial_value_op, [], -1), -1)
+        loop_params = list(zip(gen.indices, gen.sequences, gen.condlists))
+        true_block, false_block, exit_block = BasicBlock(), BasicBlock(), BasicBlock()
+
+        def gen_inner_stmts() -> None:
+            comparison = modify(self.accept(gen.left_expr))
+            self.add_bool_branch(comparison, true_block, false_block)
+            self.activate_block(true_block)
+            self.assign(retval, self.primitive_op(new_value_op, [], -1), -1)
+            self.goto(exit_block)
+            self.activate_block(false_block)
+
+        self.comprehension_helper(loop_params, gen_inner_stmts, exit_block, gen.line)
+        return retval
+
     def translate_refexpr_call(self, expr: CallExpr, callee: RefExpr) -> Value:
         """Translate a non-method call."""
 
@@ -2081,48 +2108,22 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
 
         # TODO: Generalize special cases
 
-        def gen_any_all_inner_stmts(comparison: Value, op: OpDescription) -> None:
-            true_block, false_block = BasicBlock(), BasicBlock()
-            self.add_bool_branch(comparison, true_block, false_block)
-            self.activate_block(true_block)
-            self.assign(retval, self.primitive_op(op, [], -1), -1)
-            self.nonlocal_control[-1].gen_break(self)
-            self.activate_block(false_block)
-
         # Special case builtins.any
         if (callee.fullname == 'builtins.any'
                 and len(expr.args) == 1
                 and expr.arg_kinds == [ARG_POS]
                 and isinstance(expr.args[0], GeneratorExpr)):
-            gen = expr.args[0]
-            retval = self.alloc_temp(bool_rprimitive)
-            self.assign(retval, self.primitive_op(false_op, [], -1), -1)
-            loop_params = list(zip(gen.indices, gen.sequences, gen.condlists))
-
-            def gen_inner_stmts() -> None:
-                comparison = self.accept(gen.left_expr)
-                gen_any_all_inner_stmts(comparison, true_op)
-
-            self.comprehension_helper(loop_params, gen_inner_stmts, expr.line)
-            return retval
+            return self.any_all_helper(expr.args[0], false_op, lambda x: x, true_op)
 
         # Special case builtins.all
         if (callee.fullname == 'builtins.all'
                 and len(expr.args) == 1
                 and expr.arg_kinds == [ARG_POS]
                 and isinstance(expr.args[0], GeneratorExpr)):
-            gen = expr.args[0]
-            retval = self.alloc_temp(bool_rprimitive)
-            self.assign(retval, self.primitive_op(true_op, [], -1), -1)
-            loop_params = list(zip(gen.indices, gen.sequences, gen.condlists))
-
-            def gen_inner_stmts() -> None:
-                comparison = self.accept(gen.left_expr)
-                not_comparison = self.unary_op(comparison, 'not', expr.line)
-                gen_any_all_inner_stmts(not_comparison, false_op)
-
-            self.comprehension_helper(loop_params, gen_inner_stmts, expr.line)
-            return retval
+            return self.any_all_helper(expr.args[0],
+                                       true_op,
+                                       lambda x: self.unary_op(x, 'not', expr.line),
+                                       false_op)
 
         # Gen the argument values
         arg_values = [self.accept(arg) for arg in expr.args]
@@ -2962,7 +2963,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             e = self.accept(gen.left_expr)
             self.primitive_op(list_append_op, [list_ops, e], o.line)
 
-        self.comprehension_helper(loop_params, gen_inner_stmts, o.line)
+        self.comprehension_helper(loop_params, gen_inner_stmts, None, o.line)
         return list_ops
 
     def visit_set_comprehension(self, o: SetComprehension) -> Value:
@@ -2974,7 +2975,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             e = self.accept(gen.left_expr)
             self.primitive_op(set_add_op, [set_ops, e], o.line)
 
-        self.comprehension_helper(loop_params, gen_inner_stmts, o.line)
+        self.comprehension_helper(loop_params, gen_inner_stmts, None, o.line)
         return set_ops
 
     def visit_dictionary_comprehension(self, o: DictionaryComprehension) -> Value:
@@ -2986,7 +2987,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             v = self.accept(o.value)
             self.primitive_op(dict_set_item_op, [d, k, v], o.line)
 
-        self.comprehension_helper(loop_params, gen_inner_stmts, o.line)
+        self.comprehension_helper(loop_params, gen_inner_stmts, None, o.line)
         return d
 
     def visit_generator_expr(self, o: GeneratorExpr) -> Value:
@@ -3001,12 +3002,13 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             e = self.accept(gen.left_expr)
             self.primitive_op(list_append_op, [list_ops, e], o.line)
 
-        self.comprehension_helper(loop_params, gen_inner_stmts, o.line)
+        self.comprehension_helper(loop_params, gen_inner_stmts, None, o.line)
         return list_ops
 
     def comprehension_helper(self,
                              loop_params: List[Tuple[Lvalue, Expression, List[Expression]]],
                              gen_inner_stmts: Callable[[], None],
+                             exit_block: Optional[BasicBlock],
                              line: int) -> None:
         """Helper function for list comprehensions.
 
@@ -3026,7 +3028,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             index, expr, conds = loop_params[0]
             self.for_loop_helper(index, expr,
                                  lambda: loop_contents(conds, loop_params[1:]),
-                                 None, line)
+                                 None, exit_block, line)
 
         def loop_contents(
                 conds: List[Expression],

--- a/test-data/fixtures/ir.py
+++ b/test-data/fixtures/ir.py
@@ -154,6 +154,8 @@ class RuntimeError(Exception): pass
 class NotImplementedError(RuntimeError): pass
 
 
+def any(i: Iterable[T]) -> bool: pass
+def all(i: Iterable[T]) -> bool: pass
 def id(o: object) -> int: pass
 def len(o: Sized) -> int: pass
 def print(*object) -> None: pass

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -2946,3 +2946,111 @@ L4:
     r15 = r11.__setitem__(r14, r13) :: object
     r16 = None
     return r16
+
+[case testAnyAll]
+from typing import Iterable
+
+def call_any(l: Iterable[int]) -> bool:
+    return any(i == 0 for i in l)
+
+def call_all(l: Iterable[int]) -> bool:
+    return all(i == 0 for i in l)
+
+[out]
+def call_any(l):
+    l :: object
+    r0 :: list
+    r1, r2 :: object
+    i, r3, r4 :: int
+    r5 :: bool
+    r6 :: object
+    r7, r8, r9 :: bool
+    r10, r11 :: object
+    r12, r13 :: int
+    r14, r15, r16 :: bool
+L0:
+    r0 = []
+    r1 = iter l :: object
+L1:
+    r2 = next r1 :: object
+    if is_error(r2) goto L3 else goto L2
+L2:
+    r3 = unbox(int, r2)
+    i = r3
+    r4 = 0
+    r5 = i == r4 :: int
+    r6 = box(bool, r5)
+    r7 = r0.append(r6) :: list
+    goto L1
+L3:
+    r8 = no_err_occurred
+L4:
+    r9 = False
+    r10 = iter l :: object
+L5:
+    r11 = next r10 :: object
+    if is_error(r11) goto L9 else goto L6
+L6:
+    r12 = unbox(int, r11)
+    i = r12
+    r13 = 0
+    r14 = i == r13 :: int
+    if r14 goto L7 else goto L8 :: bool
+L7:
+    r15 = True
+    return r15
+L8:
+    goto L5
+L9:
+    r16 = no_err_occurred
+L10:
+    return r9
+def call_all(l):
+    l :: object
+    r0 :: list
+    r1, r2 :: object
+    i, r3, r4 :: int
+    r5 :: bool
+    r6 :: object
+    r7, r8, r9 :: bool
+    r10, r11 :: object
+    r12, r13 :: int
+    r14, r15, r16, r17 :: bool
+L0:
+    r0 = []
+    r1 = iter l :: object
+L1:
+    r2 = next r1 :: object
+    if is_error(r2) goto L3 else goto L2
+L2:
+    r3 = unbox(int, r2)
+    i = r3
+    r4 = 0
+    r5 = i == r4 :: int
+    r6 = box(bool, r5)
+    r7 = r0.append(r6) :: list
+    goto L1
+L3:
+    r8 = no_err_occurred
+L4:
+    r9 = True
+    r10 = iter l :: object
+L5:
+    r11 = next r10 :: object
+    if is_error(r11) goto L9 else goto L6
+L6:
+    r12 = unbox(int, r11)
+    i = r12
+    r13 = 0
+    r14 = i == r13 :: int
+    r15 = !r14
+    if r15 goto L7 else goto L8 :: bool
+L7:
+    r16 = False
+    return r16
+L8:
+    goto L5
+L9:
+    r17 = no_err_occurred
+L10:
+    return r9

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -2947,7 +2947,7 @@ L4:
     r16 = None
     return r16
 
-[case testAnyAll]
+[case testAnyAllG]
 from typing import Iterable
 
 def call_any(l: Iterable[int]) -> bool:
@@ -2959,98 +2959,60 @@ def call_all(l: Iterable[int]) -> bool:
 [out]
 def call_any(l):
     l :: object
-    r0 :: list
-    r1, r2 :: object
-    i, r3, r4 :: int
-    r5 :: bool
-    r6 :: object
-    r7, r8, r9 :: bool
-    r10, r11 :: object
-    r12, r13 :: int
-    r14, r15, r16 :: bool
+    r0, r1 :: bool
+    r2, r3 :: object
+    i, r4, r5 :: int
+    r6, r7, r8 :: bool
 L0:
-    r0 = []
-    r1 = iter l :: object
+    r1 = False
+    r0 = r1
+    r2 = iter l :: object
 L1:
-    r2 = next r1 :: object
-    if is_error(r2) goto L3 else goto L2
+    r3 = next r2 :: object
+    if is_error(r3) goto L5 else goto L2
 L2:
-    r3 = unbox(int, r2)
-    i = r3
-    r4 = 0
-    r5 = i == r4 :: int
-    r6 = box(bool, r5)
-    r7 = r0.append(r6) :: list
-    goto L1
+    r4 = unbox(int, r3)
+    i = r4
+    r5 = 0
+    r6 = i == r5 :: int
+    if r6 goto L3 else goto L4 :: bool
 L3:
-    r8 = no_err_occurred
+    r7 = True
+    r0 = r7
+    goto L6
 L4:
-    r9 = False
-    r10 = iter l :: object
+    goto L1
 L5:
-    r11 = next r10 :: object
-    if is_error(r11) goto L9 else goto L6
+    r8 = no_err_occurred
 L6:
-    r12 = unbox(int, r11)
-    i = r12
-    r13 = 0
-    r14 = i == r13 :: int
-    if r14 goto L7 else goto L8 :: bool
-L7:
-    r15 = True
-    return r15
-L8:
-    goto L5
-L9:
-    r16 = no_err_occurred
-L10:
-    return r9
+    return r0
 def call_all(l):
     l :: object
-    r0 :: list
-    r1, r2 :: object
-    i, r3, r4 :: int
-    r5 :: bool
-    r6 :: object
-    r7, r8, r9 :: bool
-    r10, r11 :: object
-    r12, r13 :: int
-    r14, r15, r16, r17 :: bool
+    r0, r1 :: bool
+    r2, r3 :: object
+    i, r4, r5 :: int
+    r6, r7, r8, r9 :: bool
 L0:
-    r0 = []
-    r1 = iter l :: object
+    r1 = True
+    r0 = r1
+    r2 = iter l :: object
 L1:
-    r2 = next r1 :: object
-    if is_error(r2) goto L3 else goto L2
+    r3 = next r2 :: object
+    if is_error(r3) goto L5 else goto L2
 L2:
-    r3 = unbox(int, r2)
-    i = r3
-    r4 = 0
-    r5 = i == r4 :: int
-    r6 = box(bool, r5)
-    r7 = r0.append(r6) :: list
-    goto L1
+    r4 = unbox(int, r3)
+    i = r4
+    r5 = 0
+    r6 = i == r5 :: int
+    r7 = !r6
+    if r7 goto L3 else goto L4 :: bool
 L3:
-    r8 = no_err_occurred
+    r8 = False
+    r0 = r8
+    goto L6
 L4:
-    r9 = True
-    r10 = iter l :: object
+    goto L1
 L5:
-    r11 = next r10 :: object
-    if is_error(r11) goto L9 else goto L6
+    r9 = no_err_occurred
 L6:
-    r12 = unbox(int, r11)
-    i = r12
-    r13 = 0
-    r14 = i == r13 :: int
-    r15 = !r14
-    if r15 goto L7 else goto L8 :: bool
-L7:
-    r16 = False
-    return r16
-L8:
-    goto L5
-L9:
-    r17 = no_err_occurred
-L10:
-    return r9
+    return r0

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -3201,11 +3201,13 @@ contextmanager: exited
 [case testAnyAll]
 from typing import Iterable
 
-def call_any(l: Iterable[int], val: int = 0) -> bool:
-    return any(i == val for i in l)
+def call_any(l: Iterable[int], val: int = 0) -> int:
+    res = any(i == val for i in l)
+    return 0 if res else 1
 
-def call_all(l: Iterable[int], val: int = 0) -> bool:
-    return all(i == val for i in l)
+def call_all(l: Iterable[int], val: int = 0) -> int:
+    res = all(i == val for i in l)
+    return 0 if res else 1
 
 [file driver.py]
 from native import call_any, call_all
@@ -3219,20 +3221,20 @@ mixed_011 = [0, 1, 1]
 mixed_101 = [1, 0, 1]
 mixed_110 = [1, 1, 0]
 
-assert call_any(zeros) == True
-assert call_any(ones) == False
-assert call_any(mixed_001) == True
-assert call_any(mixed_010) == True
-assert call_any(mixed_100) == True
-assert call_any(mixed_011) == True
-assert call_any(mixed_101) == True
-assert call_any(mixed_110) == True
+assert call_any(zeros) == 0
+assert call_any(ones) == 1
+assert call_any(mixed_001) == 0
+assert call_any(mixed_010) == 0
+assert call_any(mixed_100) == 0
+assert call_any(mixed_011) == 0
+assert call_any(mixed_101) == 0
+assert call_any(mixed_110) == 0
 
-assert call_all(zeros) == True
-assert call_all(ones) == False
-assert call_all(mixed_001) == False
-assert call_all(mixed_010) == False
-assert call_all(mixed_100) == False
-assert call_all(mixed_011) == False
-assert call_all(mixed_101) == False
-assert call_all(mixed_110) == False
+assert call_all(zeros) == 0
+assert call_all(ones) == 1
+assert call_all(mixed_001) == 1
+assert call_all(mixed_010) == 1
+assert call_all(mixed_100) == 1
+assert call_all(mixed_011) == 1
+assert call_all(mixed_101) == 1
+assert call_all(mixed_110) == 1

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -3197,3 +3197,42 @@ hello!
 contextmanager: exited
 contextmanager: entering
 contextmanager: exited
+
+[case testAnyAll]
+from typing import Iterable
+
+def call_any(l: Iterable[int], val: int = 0) -> bool:
+    return any(i == val for i in l)
+
+def call_all(l: Iterable[int], val: int = 0) -> bool:
+    return all(i == val for i in l)
+
+[file driver.py]
+from native import call_any, call_all
+
+zeros = [0, 0, 0]
+ones = [1, 1, 1]
+mixed_001 = [0, 0, 1]
+mixed_010 = [0, 1, 0]
+mixed_100 = [1, 0, 0]
+mixed_011 = [0, 1, 1]
+mixed_101 = [1, 0, 1]
+mixed_110 = [1, 1, 0]
+
+assert call_any(zeros) == True
+assert call_any(ones) == False
+assert call_any(mixed_001) == True
+assert call_any(mixed_010) == True
+assert call_any(mixed_100) == True
+assert call_any(mixed_011) == True
+assert call_any(mixed_101) == True
+assert call_any(mixed_110) == True
+
+assert call_all(zeros) == True
+assert call_all(ones) == False
+assert call_all(mixed_001) == False
+assert call_all(mixed_010) == False
+assert call_all(mixed_100) == False
+assert call_all(mixed_011) == False
+assert call_all(mixed_101) == False
+assert call_all(mixed_110) == False


### PR DESCRIPTION
Instead of passing a list comprehension as an argument using a
`py_call` to the` any` and `all` functions, we instead special case these
by generating code that manually loops through the iterable and
checks if the conditional is true/false.

This fixes #330.