### PR TITLE
Allow ints at runtime when floats are expected

### DIFF
--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -764,6 +764,16 @@ static int CPyDict_UpdateFromSeq(PyObject *dict, PyObject *stuff) {
     }
 }
 
+// mypy lets ints silently coerce to floats, so a mypyc runtime float
+// might be an int also
+static inline bool CPyFloat_Check(PyObject *o) {
+    return PyFloat_Check(o) || PyLong_Check(o);
+}
+
+static PyObject *CPyLong_FromFloat(PyObject *o) {
+    return PyLong_Check(o) ? o : PyLong_FromDouble(PyFloat_AS_DOUBLE(o));
+}
+
 static PyCodeObject *CPy_CreateCodeObject(const char *filename, const char *funcname, int line) {
     PyObject *filename_obj = PyUnicode_FromString(filename);
     PyObject *funcname_obj = PyUnicode_FromString(funcname);

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -330,7 +330,7 @@ class Emitter:
             elif is_set_rprimitive(typ):
                 prefix = 'PySet'
             elif is_float_rprimitive(typ):
-                prefix = 'PyFloat'
+                prefix = 'CPyFloat'
             elif is_str_rprimitive(typ):
                 prefix = 'PyUnicode'
             elif is_int_rprimitive(typ):

--- a/mypyc/ops_int.py
+++ b/mypyc/ops_int.py
@@ -23,8 +23,7 @@ func_op(
     arg_types=[float_rprimitive],
     result_type=object_rprimitive,
     error_kind=ERR_MAGIC,
-    emit=simple_emit(
-        '{dest} = PyLong_FromDouble(PyFloat_AS_DOUBLE({args[0]}));'),
+    emit=simple_emit('{dest} = CPyLong_FromFloat({args[0]});'),
     priority=1)
 
 

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -1468,6 +1468,7 @@ assert sum == 50.0
 
 assert str(from_int(10)) == '10.0'
 assert str(to_int(3.14)) == '3'
+assert str(to_int(3)) == '3'
 
 [case testBytes]
 def f(x: bytes) -> bytes:


### PR DESCRIPTION
This is necessary because mypy allows silent coercions from int to
float. Though it might be better to just not have a float primitive.