### PR TITLE
Add a notion of "short" integers

### DIFF
--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -403,10 +403,6 @@ static CPyTagged CPyTagged_Negate(CPyTagged num) {
     return CPyTagged_StealFromObject(result);
 }
 
-static inline CPyTagged CPyTagged_AddUnsafe(CPyTagged left, CPyTagged right) {
-    return left + right;
-}
-
 static CPyTagged CPyTagged_Add(CPyTagged left, CPyTagged right) {
     // TODO: Use clang/gcc extension __builtin_saddll_overflow instead.
     if (CPyTagged_CheckShort(left) && CPyTagged_CheckShort(right)) {

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -617,7 +617,23 @@ static PyObject *CPyList_GetItemShort(PyObject *list, CPyTagged index) {
 
 static PyObject *CPyList_GetItem(PyObject *list, CPyTagged index) {
     if (CPyTagged_CheckShort(index)) {
-        return CPyList_GetItemShort(list, index);
+        long long n = CPyTagged_ShortAsLongLong(index);
+        Py_ssize_t size = PyList_GET_SIZE(list);
+        if (n >= 0) {
+            if (n >= size) {
+                PyErr_SetString(PyExc_IndexError, "list index out of range");
+                return NULL;
+            }
+        } else {
+            n += size;
+            if (n < 0) {
+                PyErr_SetString(PyExc_IndexError, "list index out of range");
+                return NULL;
+            }
+        }
+        PyObject *result = PyList_GET_ITEM(list, n);
+        Py_INCREF(result);
+        return result;
     } else {
         PyErr_SetString(PyExc_IndexError, "list index out of range");
         return NULL;

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -599,25 +599,29 @@ static inline bool CPyTagged_IsLe(CPyTagged left, CPyTagged right) {
     }
 }
 
+static PyObject *CPyList_GetItemShort(PyObject *list, CPyTagged index) {
+    long long n = CPyTagged_ShortAsLongLong(index);
+    Py_ssize_t size = PyList_GET_SIZE(list);
+    if (n >= 0) {
+        if (n >= size) {
+            PyErr_SetString(PyExc_IndexError, "list index out of range");
+            return NULL;
+        }
+    } else {
+        n += size;
+        if (n < 0) {
+            PyErr_SetString(PyExc_IndexError, "list index out of range");
+            return NULL;
+        }
+    }
+    PyObject *result = PyList_GET_ITEM(list, n);
+    Py_INCREF(result);
+    return result;
+}
+
 static PyObject *CPyList_GetItem(PyObject *list, CPyTagged index) {
     if (CPyTagged_CheckShort(index)) {
-        long long n = CPyTagged_ShortAsLongLong(index);
-        Py_ssize_t size = PyList_GET_SIZE(list);
-        if (n >= 0) {
-            if (n >= size) {
-                PyErr_SetString(PyExc_IndexError, "list index out of range");
-                return NULL;
-            }
-        } else {
-            n += size;
-            if (n < 0) {
-                PyErr_SetString(PyExc_IndexError, "list index out of range");
-                return NULL;
-            }
-        }
-        PyObject *result = PyList_GET_ITEM(list, n);
-        Py_INCREF(result);
-        return result;
+        return CPyList_GetItemShort(list, index);
     } else {
         PyErr_SetString(PyExc_IndexError, "list index out of range");
         return NULL;

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -403,6 +403,10 @@ static CPyTagged CPyTagged_Negate(CPyTagged num) {
     return CPyTagged_StealFromObject(result);
 }
 
+static inline CPyTagged CPyTagged_AddUnsafe(CPyTagged left, CPyTagged right) {
+    return left + right;
+}
+
 static CPyTagged CPyTagged_Add(CPyTagged left, CPyTagged right) {
     // TODO: Use clang/gcc extension __builtin_saddll_overflow instead.
     if (CPyTagged_CheckShort(left) && CPyTagged_CheckShort(right)) {

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -6,7 +6,8 @@ from typing import List, Set, Dict, Optional, List, Callable, Union
 from mypyc.common import REG_PREFIX, STATIC_PREFIX, TYPE_PREFIX, NATIVE_PREFIX
 from mypyc.ops import (
     Any, AssignmentTarget, Environment, BasicBlock, Value, Register, RType, RTuple, RInstance,
-    RUnion, RPrimitive, RUnion, is_int_rprimitive, is_float_rprimitive, is_bool_rprimitive,
+    RUnion, RPrimitive, is_int_rprimitive, is_unsafe_int_rprimitive,
+    is_float_rprimitive, is_bool_rprimitive,
     short_name, is_list_rprimitive, is_dict_rprimitive, is_set_rprimitive, is_tuple_rprimitive,
     is_none_rprimitive, is_object_rprimitive, object_rprimitive, is_str_rprimitive, ClassIR,
     FuncIR, FuncDecl, int_rprimitive, is_optional_type, optional_value_type
@@ -490,7 +491,7 @@ class Emitter:
         else:
             failure = [raise_exc,
                        '%s = %s;' % (dest, self.c_error_value(typ))]
-        if is_int_rprimitive(typ):
+        if is_int_rprimitive(typ) or is_unsafe_int_rprimitive(typ):
             if declare_dest:
                 self.emit_line('CPyTagged {};'.format(dest))
             self.emit_arg_check(src, dest, typ, '(PyLong_Check({}))'.format(src), optional)
@@ -565,7 +566,7 @@ class Emitter:
             declaration = 'PyObject *'
         else:
             declaration = ''
-        if is_int_rprimitive(typ):
+        if is_int_rprimitive(typ) or is_unsafe_int_rprimitive(typ):
             # Steal the existing reference if it exists.
             self.emit_line('{}{} = CPyTagged_StealAsObject({});'.format(declaration, dest, src))
         elif is_bool_rprimitive(typ):

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -6,7 +6,7 @@ from typing import List, Set, Dict, Optional, List, Callable, Union
 from mypyc.common import REG_PREFIX, STATIC_PREFIX, TYPE_PREFIX, NATIVE_PREFIX
 from mypyc.ops import (
     Any, AssignmentTarget, Environment, BasicBlock, Value, Register, RType, RTuple, RInstance,
-    RUnion, RPrimitive, is_int_rprimitive, is_unsafe_int_rprimitive,
+    RUnion, RPrimitive, is_int_rprimitive, is_short_int_rprimitive,
     is_float_rprimitive, is_bool_rprimitive,
     short_name, is_list_rprimitive, is_dict_rprimitive, is_set_rprimitive, is_tuple_rprimitive,
     is_none_rprimitive, is_object_rprimitive, object_rprimitive, is_str_rprimitive, ClassIR,
@@ -491,7 +491,7 @@ class Emitter:
         else:
             failure = [raise_exc,
                        '%s = %s;' % (dest, self.c_error_value(typ))]
-        if is_int_rprimitive(typ) or is_unsafe_int_rprimitive(typ):
+        if is_int_rprimitive(typ) or is_short_int_rprimitive(typ):
             if declare_dest:
                 self.emit_line('CPyTagged {};'.format(dest))
             self.emit_arg_check(src, dest, typ, '(PyLong_Check({}))'.format(src), optional)
@@ -566,7 +566,7 @@ class Emitter:
             declaration = 'PyObject *'
         else:
             declaration = ''
-        if is_int_rprimitive(typ) or is_unsafe_int_rprimitive(typ):
+        if is_int_rprimitive(typ) or is_short_int_rprimitive(typ):
             # Steal the existing reference if it exists.
             self.emit_line('{}{} = CPyTagged_StealAsObject({});'.format(declaration, dest, src))
         elif is_bool_rprimitive(typ):

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -62,10 +62,10 @@ from mypyc.ops import (
     is_object_rprimitive, LiteralsMap, FuncSignature, VTableAttr, VTableMethod, VTableEntries,
     NAMESPACE_TYPE, RaiseStandardError, LoadErrorValue, NO_TRACEBACK_LINE_NO, FuncDecl,
     FUNC_NORMAL, FUNC_STATICMETHOD, FUNC_CLASSMETHOD,
-    RUnion, is_optional_type, optional_value_type, is_unsafe_int_rprimitive,
+    RUnion, is_optional_type, optional_value_type, is_short_int_rprimitive,
 )
 from mypyc.ops_primitive import binary_ops, unary_ops, func_ops, method_ops, name_ref_ops
-from mypyc.ops_int import unsafe_add
+from mypyc.ops_int import unsafe_short_add
 from mypyc.ops_list import (
     list_append_op, list_extend_op, list_len_op, list_get_item_op, list_set_item_op, new_list_op,
 )
@@ -1653,9 +1653,9 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
 
             # Increment index register. If the range is known to fit in short ints, use
             # short ints.
-            if is_unsafe_int_rprimitive(start_reg.type) and is_unsafe_int_rprimitive(end_reg.type):
+            if is_short_int_rprimitive(start_reg.type) and is_short_int_rprimitive(end_reg.type):
                 new_val = self.primitive_op(
-                    unsafe_add, [self.read(index_target, line), self.add(LoadInt(1))], line)
+                    unsafe_short_add, [self.read(index_target, line), self.add(LoadInt(1))], line)
             else:
                 new_val = self.binary_op(
                     self.read(index_target, line), self.add(LoadInt(1)), '+', line)
@@ -1701,7 +1701,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
 
             self.goto_and_activate(increment_block)
             self.assign(index_target, self.primitive_op(
-                unsafe_add,
+                unsafe_short_add,
                 [self.read(index_target, line), self.add(LoadInt(1))], line), line)
             self.goto(condition_block)
 

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -62,9 +62,10 @@ from mypyc.ops import (
     is_object_rprimitive, LiteralsMap, FuncSignature, VTableAttr, VTableMethod, VTableEntries,
     NAMESPACE_TYPE, RaiseStandardError, LoadErrorValue, NO_TRACEBACK_LINE_NO, FuncDecl,
     FUNC_NORMAL, FUNC_STATICMETHOD, FUNC_CLASSMETHOD,
-    RUnion, is_optional_type, optional_value_type
+    RUnion, is_optional_type, optional_value_type, is_unsafe_int_rprimitive,
 )
 from mypyc.ops_primitive import binary_ops, unary_ops, func_ops, method_ops, name_ref_ops
+from mypyc.ops_int import unsafe_add
 from mypyc.ops_list import (
     list_append_op, list_extend_op, list_len_op, list_get_item_op, list_set_item_op, new_list_op,
 )
@@ -1650,9 +1651,15 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
 
             self.goto_and_activate(increment_block)
 
-            # Increment index register.
-            self.assign(index_target, self.binary_op(self.read(index_target, line),
-                                                     self.add(LoadInt(1)), '+', line), line)
+            # Increment index register. If the range is known to fit in short ints, use
+            # short ints.
+            if is_unsafe_int_rprimitive(start_reg.type) and is_unsafe_int_rprimitive(end_reg.type):
+                new_val = self.primitive_op(
+                    unsafe_add, [self.read(index_target, line), self.add(LoadInt(1))], line)
+            else:
+                new_val = self.binary_op(
+                    self.read(index_target, line), self.add(LoadInt(1)), '+', line)
+            self.assign(index_target, new_val, line)
 
             # Go back to loop condition check.
             self.goto(condition_block)
@@ -1693,8 +1700,9 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             body_insts()
 
             self.goto_and_activate(increment_block)
-            self.assign(index_target, self.binary_op(self.read(index_target, line),
-                                                     self.add(LoadInt(1)), '+', line), line)
+            self.assign(index_target, self.primitive_op(
+                unsafe_add,
+                [self.read(index_target, line), self.add(LoadInt(1))], line), line)
             self.goto(condition_block)
 
             self.pop_loop_stack()

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -67,7 +67,7 @@ from mypyc.ops import (
 from mypyc.ops_primitive import binary_ops, unary_ops, func_ops, method_ops, name_ref_ops
 from mypyc.ops_int import unsafe_short_add
 from mypyc.ops_list import (
-    list_append_op, list_extend_op, list_len_op, list_get_item_op, list_set_item_op, new_list_op,
+    list_append_op, list_extend_op, list_len_op, new_list_op,
 )
 from mypyc.ops_tuple import list_tuple_op
 from mypyc.ops_dict import new_dict_op, dict_get_item_op, dict_set_item_op, dict_update_op
@@ -1690,9 +1690,10 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             assert isinstance(target_list_type, Instance)
             target_type = self.type_to_rtype(target_list_type.args[0])
 
-            value_box = self.add(PrimitiveOp([self.read(expr_target, line),
-                                              self.read(index_target, line)],
-                                             list_get_item_op, line))
+            value_box = self.translate_special_method_call(
+                self.read(expr_target, line), '__getitem__',
+                [self.read(index_target, line)], None, line)
+            assert value_box
 
             self.assign(self.get_assignment_target(index),
                         self.unbox_or_cast(value_box, target_type, line), line)

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -943,7 +943,7 @@ class LoadInt(RegisterOp):
     def __init__(self, value: int, line: int = -1) -> None:
         super().__init__(line)
         self.value = value
-        self.type = int_rprimitive
+        self.type = unsafe_int_rprimitive
 
     def sources(self) -> List[Value]:
         return []

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -112,7 +112,7 @@ object_rprimitive = RPrimitive('builtins.object', is_unboxed=False, is_refcounte
 int_rprimitive = RPrimitive('builtins.int', is_unboxed=True, is_refcounted=True, ctype='CPyTagged')
 
 short_int_rprimitive = RPrimitive('builtins.int', is_unboxed=True, is_refcounted=False,
-                                   ctype='CPyTagged')
+                                  ctype='CPyTagged')
 
 float_rprimitive = RPrimitive('builtins.float', is_unboxed=False, is_refcounted=True)
 
@@ -1117,7 +1117,12 @@ class TupleSet(RegisterOp):
     def __init__(self, items: List[Value], line: int) -> None:
         super().__init__(line)
         self.items = items
-        self.tuple_type = RTuple([arg.type for arg in items])
+        # Don't keep track of the fact that an int is short after it
+        # is put into a tuple, since we don't properly implement
+        # runtime subtyping for tuples.
+        self.tuple_type = RTuple(
+            [arg.type if not is_short_int_rprimitive(arg.type) else int_rprimitive
+             for arg in items])
         self.type = self.tuple_type
 
     def sources(self) -> List[Value]:

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -111,6 +111,9 @@ object_rprimitive = RPrimitive('builtins.object', is_unboxed=False, is_refcounte
 
 int_rprimitive = RPrimitive('builtins.int', is_unboxed=True, is_refcounted=True, ctype='CPyTagged')
 
+unsafe_int_rprimitive = RPrimitive('builtins._int', is_unboxed=True, is_refcounted=False,
+                                   ctype='CPyTagged')
+
 float_rprimitive = RPrimitive('builtins.float', is_unboxed=False, is_refcounted=True)
 
 bool_rprimitive = RPrimitive('builtins.bool', is_unboxed=True, is_refcounted=False, ctype='char')
@@ -131,7 +134,11 @@ tuple_rprimitive = RPrimitive('builtins.tuple', is_unboxed=False, is_refcounted=
 
 
 def is_int_rprimitive(rtype: RType) -> bool:
-    return isinstance(rtype, RPrimitive) and rtype.name == 'builtins.int'
+    return rtype is int_rprimitive
+
+
+def is_unsafe_int_rprimitive(rtype: RType) -> bool:
+    return rtype is unsafe_int_rprimitive
 
 
 def is_float_rprimitive(rtype: RType) -> bool:

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -111,7 +111,7 @@ object_rprimitive = RPrimitive('builtins.object', is_unboxed=False, is_refcounte
 
 int_rprimitive = RPrimitive('builtins.int', is_unboxed=True, is_refcounted=True, ctype='CPyTagged')
 
-short_int_rprimitive = RPrimitive('short_int', is_unboxed=True, is_refcounted=False,
+short_int_rprimitive = RPrimitive('builtins.int', is_unboxed=True, is_refcounted=False,
                                    ctype='CPyTagged')
 
 float_rprimitive = RPrimitive('builtins.float', is_unboxed=False, is_refcounted=True)

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -111,7 +111,7 @@ object_rprimitive = RPrimitive('builtins.object', is_unboxed=False, is_refcounte
 
 int_rprimitive = RPrimitive('builtins.int', is_unboxed=True, is_refcounted=True, ctype='CPyTagged')
 
-short_int_rprimitive = RPrimitive('builtins.int', is_unboxed=True, is_refcounted=False,
+short_int_rprimitive = RPrimitive('short_int', is_unboxed=True, is_refcounted=False,
                                   ctype='CPyTagged')
 
 float_rprimitive = RPrimitive('builtins.float', is_unboxed=False, is_refcounted=True)

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -111,7 +111,7 @@ object_rprimitive = RPrimitive('builtins.object', is_unboxed=False, is_refcounte
 
 int_rprimitive = RPrimitive('builtins.int', is_unboxed=True, is_refcounted=True, ctype='CPyTagged')
 
-unsafe_int_rprimitive = RPrimitive('builtins._int', is_unboxed=True, is_refcounted=False,
+short_int_rprimitive = RPrimitive('short_int', is_unboxed=True, is_refcounted=False,
                                    ctype='CPyTagged')
 
 float_rprimitive = RPrimitive('builtins.float', is_unboxed=False, is_refcounted=True)
@@ -137,8 +137,8 @@ def is_int_rprimitive(rtype: RType) -> bool:
     return rtype is int_rprimitive
 
 
-def is_unsafe_int_rprimitive(rtype: RType) -> bool:
-    return rtype is unsafe_int_rprimitive
+def is_short_int_rprimitive(rtype: RType) -> bool:
+    return rtype is short_int_rprimitive
 
 
 def is_float_rprimitive(rtype: RType) -> bool:
@@ -943,7 +943,7 @@ class LoadInt(RegisterOp):
     def __init__(self, value: int, line: int = -1) -> None:
         super().__init__(line)
         self.value = value
-        self.type = unsafe_int_rprimitive
+        self.type = short_int_rprimitive
 
     def sources(self) -> List[Value]:
         return []

--- a/mypyc/ops_int.py
+++ b/mypyc/ops_int.py
@@ -73,7 +73,7 @@ int_compare_op('>', 'CPyTagged_IsGt')
 int_compare_op('>=', 'CPyTagged_IsGe')
 
 unsafe_short_add = custom_op(
-    arg_types=[short_int_rprimitive, short_int_rprimitive],
+    arg_types=[int_rprimitive, int_rprimitive],
     result_type=short_int_rprimitive,
     error_kind=ERR_NEVER,
     format_str='{dest} = {args[0]} + {args[1]} :: int',

--- a/mypyc/ops_int.py
+++ b/mypyc/ops_int.py
@@ -44,7 +44,7 @@ def int_compare_op(op: str, c_func_name: str) -> None:
               arg_types=[short_int_rprimitive, short_int_rprimitive],
               result_type=bool_rprimitive,
               error_kind=ERR_NEVER,
-              format_str='{dest} = {args[0]} %s {args[1]} :: int' % op,
+              format_str='{dest} = {args[0]} %s {args[1]} :: short_int' % op,
               emit=simple_emit(
                   '{dest} = (CPySignedInt){args[0]} %s (CPySignedInt){args[1]};' % op),
               priority=2)
@@ -76,7 +76,7 @@ unsafe_short_add = custom_op(
     arg_types=[int_rprimitive, int_rprimitive],
     result_type=short_int_rprimitive,
     error_kind=ERR_NEVER,
-    format_str='{dest} = {args[0]} + {args[1]} :: int',
+    format_str='{dest} = {args[0]} + {args[1]} :: short_int',
     emit=simple_emit('{dest} = CPyTagged_AddUnsafe({args[0]}, {args[1]});'))
 
 

--- a/mypyc/ops_int.py
+++ b/mypyc/ops_int.py
@@ -1,11 +1,12 @@
 from typing import List
 
 from mypyc.ops import (
-    PrimitiveOp, int_rprimitive, bool_rprimitive, float_rprimitive, object_rprimitive,
+    PrimitiveOp,
+    int_rprimitive, bool_rprimitive, float_rprimitive, object_rprimitive, unsafe_int_rprimitive,
     RType, EmitterInterface, OpDescription,
     ERR_NEVER, ERR_MAGIC,
 )
-from mypyc.ops_primitive import name_ref_op, binary_op, unary_op, func_op, simple_emit
+from mypyc.ops_primitive import name_ref_op, binary_op, unary_op, func_op, custom_op, simple_emit
 
 # These int constructors produce object_rprimitives that then need to be unboxed
 # I guess unboxing ourselves would save a check and branch though?
@@ -38,6 +39,15 @@ def int_binary_op(op: str, c_func_name: str, result_type: RType = int_rprimitive
 
 def int_compare_op(op: str, c_func_name: str) -> None:
     int_binary_op(op, c_func_name, bool_rprimitive)
+    # Generate a straight compare if we know both sides are short
+    binary_op(op=op,
+              arg_types=[unsafe_int_rprimitive, unsafe_int_rprimitive],
+              result_type=bool_rprimitive,
+              error_kind=ERR_NEVER,
+              format_str='{dest} = {args[0]} %s {args[1]} :: unsafe_int' % op,
+              emit=simple_emit(
+                  '{dest} = (CPySignedInt){args[0]} %s (CPySignedInt){args[1]};' % op),
+              priority=2)
 
 
 int_binary_op('+', 'CPyTagged_Add')
@@ -61,6 +71,13 @@ int_compare_op('<', 'CPyTagged_IsLt')
 int_compare_op('<=', 'CPyTagged_IsLe')
 int_compare_op('>', 'CPyTagged_IsGt')
 int_compare_op('>=', 'CPyTagged_IsGe')
+
+unsafe_add = custom_op(
+    arg_types=[unsafe_int_rprimitive, unsafe_int_rprimitive],
+    result_type=unsafe_int_rprimitive,
+    error_kind=ERR_NEVER,
+    format_str='{dest} = {args[0]} + {args[1]} :: unsafe_int',
+    emit=simple_emit('{dest} = CPyTagged_AddUnsafe({args[0]}, {args[1]});'))
 
 
 def int_unary_op(op: str, c_func_name: str) -> OpDescription:

--- a/mypyc/ops_int.py
+++ b/mypyc/ops_int.py
@@ -2,7 +2,7 @@ from typing import List
 
 from mypyc.ops import (
     PrimitiveOp,
-    int_rprimitive, bool_rprimitive, float_rprimitive, object_rprimitive, unsafe_int_rprimitive,
+    int_rprimitive, bool_rprimitive, float_rprimitive, object_rprimitive, short_int_rprimitive,
     RType, EmitterInterface, OpDescription,
     ERR_NEVER, ERR_MAGIC,
 )
@@ -41,10 +41,10 @@ def int_compare_op(op: str, c_func_name: str) -> None:
     int_binary_op(op, c_func_name, bool_rprimitive)
     # Generate a straight compare if we know both sides are short
     binary_op(op=op,
-              arg_types=[unsafe_int_rprimitive, unsafe_int_rprimitive],
+              arg_types=[short_int_rprimitive, short_int_rprimitive],
               result_type=bool_rprimitive,
               error_kind=ERR_NEVER,
-              format_str='{dest} = {args[0]} %s {args[1]} :: unsafe_int' % op,
+              format_str='{dest} = {args[0]} %s {args[1]} :: short_int' % op,
               emit=simple_emit(
                   '{dest} = (CPySignedInt){args[0]} %s (CPySignedInt){args[1]};' % op),
               priority=2)
@@ -72,11 +72,11 @@ int_compare_op('<=', 'CPyTagged_IsLe')
 int_compare_op('>', 'CPyTagged_IsGt')
 int_compare_op('>=', 'CPyTagged_IsGe')
 
-unsafe_add = custom_op(
-    arg_types=[unsafe_int_rprimitive, unsafe_int_rprimitive],
-    result_type=unsafe_int_rprimitive,
+unsafe_short_add = custom_op(
+    arg_types=[short_int_rprimitive, short_int_rprimitive],
+    result_type=short_int_rprimitive,
     error_kind=ERR_NEVER,
-    format_str='{dest} = {args[0]} + {args[1]} :: unsafe_int',
+    format_str='{dest} = {args[0]} + {args[1]} :: short_int',
     emit=simple_emit('{dest} = CPyTagged_AddUnsafe({args[0]}, {args[1]});'))
 
 

--- a/mypyc/ops_int.py
+++ b/mypyc/ops_int.py
@@ -77,7 +77,7 @@ unsafe_short_add = custom_op(
     result_type=short_int_rprimitive,
     error_kind=ERR_NEVER,
     format_str='{dest} = {args[0]} + {args[1]} :: short_int',
-    emit=simple_emit('{dest} = CPyTagged_AddUnsafe({args[0]}, {args[1]});'))
+    emit=simple_emit('{dest} = {args[0]} + {args[1]};'))
 
 
 def int_unary_op(op: str, c_func_name: str) -> OpDescription:

--- a/mypyc/ops_int.py
+++ b/mypyc/ops_int.py
@@ -44,7 +44,7 @@ def int_compare_op(op: str, c_func_name: str) -> None:
               arg_types=[short_int_rprimitive, short_int_rprimitive],
               result_type=bool_rprimitive,
               error_kind=ERR_NEVER,
-              format_str='{dest} = {args[0]} %s {args[1]} :: short_int' % op,
+              format_str='{dest} = {args[0]} %s {args[1]} :: int' % op,
               emit=simple_emit(
                   '{dest} = (CPySignedInt){args[0]} %s (CPySignedInt){args[1]};' % op),
               priority=2)
@@ -76,7 +76,7 @@ unsafe_short_add = custom_op(
     arg_types=[short_int_rprimitive, short_int_rprimitive],
     result_type=short_int_rprimitive,
     error_kind=ERR_NEVER,
-    format_str='{dest} = {args[0]} + {args[1]} :: short_int',
+    format_str='{dest} = {args[0]} + {args[1]} :: int',
     emit=simple_emit('{dest} = CPyTagged_AddUnsafe({args[0]}, {args[1]});'))
 
 

--- a/mypyc/ops_list.py
+++ b/mypyc/ops_list.py
@@ -3,7 +3,8 @@
 from typing import List
 
 from mypyc.ops import (
-    int_rprimitive, list_rprimitive, object_rprimitive, bool_rprimitive, ERR_MAGIC, ERR_NEVER,
+    int_rprimitive, unsafe_int_rprimitive, list_rprimitive, object_rprimitive, bool_rprimitive,
+    ERR_MAGIC, ERR_NEVER,
     ERR_FALSE, EmitterInterface, PrimitiveOp, Value
 )
 from mypyc.ops_primitive import (
@@ -110,6 +111,6 @@ def emit_len(emitter: EmitterInterface, args: List[str], dest: str) -> None:
 
 list_len_op = func_op(name='builtins.len',
                       arg_types=[list_rprimitive],
-                      result_type=int_rprimitive,
+                      result_type=unsafe_int_rprimitive,
                       error_kind=ERR_NEVER,
                       emit=emit_len)

--- a/mypyc/ops_list.py
+++ b/mypyc/ops_list.py
@@ -3,7 +3,7 @@
 from typing import List
 
 from mypyc.ops import (
-    int_rprimitive, unsafe_int_rprimitive, list_rprimitive, object_rprimitive, bool_rprimitive,
+    int_rprimitive, short_int_rprimitive, list_rprimitive, object_rprimitive, bool_rprimitive,
     ERR_MAGIC, ERR_NEVER,
     ERR_FALSE, EmitterInterface, PrimitiveOp, Value
 )
@@ -111,6 +111,6 @@ def emit_len(emitter: EmitterInterface, args: List[str], dest: str) -> None:
 
 list_len_op = func_op(name='builtins.len',
                       arg_types=[list_rprimitive],
-                      result_type=unsafe_int_rprimitive,
+                      result_type=short_int_rprimitive,
                       error_kind=ERR_NEVER,
                       emit=emit_len)

--- a/mypyc/ops_list.py
+++ b/mypyc/ops_list.py
@@ -45,6 +45,16 @@ list_get_item_op = method_op(
     emit=simple_emit('{dest} = CPyList_GetItem({args[0]}, {args[1]});'))
 
 
+# Version with no int bounds check for when it is known to be short
+method_op(
+    name='__getitem__',
+    arg_types=[list_rprimitive, short_int_rprimitive],
+    result_type=object_rprimitive,
+    error_kind=ERR_MAGIC,
+    emit=simple_emit('{dest} = CPyList_GetItemShort({args[0]}, {args[1]});'),
+    priority=2)
+
+
 list_set_item_op = method_op(
     name='__setitem__',
     arg_types=[list_rprimitive, int_rprimitive, object_rprimitive],

--- a/mypyc/rt_subtype.py
+++ b/mypyc/rt_subtype.py
@@ -1,4 +1,17 @@
-"""*Runtime* Subtype check for RTypes."""
+"""'Runtime subtype' check for RTypes.
+
+A type S is a runtime subtype of T if a value of type S can be used at runtime
+when a value of type T is expected without requiring any runtime conversions.
+
+For boxed types, runtime subtyping is the same as regular subtyping.
+Unboxed subtypes, on the other hand, are not runtime subtypes of object
+(since they require boxing to be used as an object), but short ints
+are runtime subtypes of int.
+
+Subtyping is used to determine whether an object can be in a
+particular place and runtime subtyping is used to determine whether a
+coercion is necessary first.
+"""
 
 from mypyc.ops import (
     RType, RUnion, RInstance, RPrimitive, RTuple, RVoid, RTypeVisitor,
@@ -11,8 +24,6 @@ from mypyc.subtype import is_subtype
 
 
 def is_runtime_subtype(left: RType, right: RType) -> bool:
-    if not left.is_unboxed and is_object_rprimitive(right):
-        return True
     return left.accept(RTSubtypeVisitor(right))
 
 
@@ -27,7 +38,7 @@ class RTSubtypeVisitor(RTypeVisitor[bool]):
         self.right = right
 
     def visit_rinstance(self, left: RInstance) -> bool:
-        return isinstance(self.right, RInstance) and is_subtype(left, self.right)
+        return is_subtype(left, self.right)
 
     def visit_runion(self, left: RUnion) -> bool:
         return is_subtype(left, self.right)

--- a/mypyc/rt_subtype.py
+++ b/mypyc/rt_subtype.py
@@ -38,11 +38,10 @@ class RTSubtypeVisitor(RTypeVisitor[bool]):
         return left is self.right
 
     def visit_rtuple(self, left: RTuple) -> bool:
+        # We might want to implement runtime subtyping for tuples. The
+        # obstacle is that we generate different (but equivalent)
+        # tuple structs.
         return is_same_type(left, self.right)
-        # if isinstance(self.right, RTuple):
-        #     return len(self.right.types) == len(left.types) and all(
-        #         is_runtime_subtype(t1, t2) for t1, t2 in zip(left.types, self.right.types))
-        # return False
 
     def visit_rvoid(self, left: RVoid) -> bool:
         return isinstance(self.right, RVoid)

--- a/mypyc/rt_subtype.py
+++ b/mypyc/rt_subtype.py
@@ -3,7 +3,7 @@
 from mypyc.ops import (
     RType, RUnion, RInstance, RPrimitive, RTuple, RVoid, RTypeVisitor,
     is_bool_rprimitive, is_int_rprimitive, is_tuple_rprimitive, none_rprimitive,
-    is_unsafe_int_rprimitive,
+    is_short_int_rprimitive,
     is_object_rprimitive
 )
 from mypyc.sametype import is_same_type
@@ -33,7 +33,7 @@ class RTSubtypeVisitor(RTypeVisitor[bool]):
         return is_subtype(left, self.right)
 
     def visit_rprimitive(self, left: RPrimitive) -> bool:
-        if is_unsafe_int_rprimitive(left) and is_int_rprimitive(self.right):
+        if is_short_int_rprimitive(left) and is_int_rprimitive(self.right):
             return True
         return isinstance(self.right, RPrimitive) and left.name == self.right.name
 

--- a/mypyc/rt_subtype.py
+++ b/mypyc/rt_subtype.py
@@ -35,7 +35,7 @@ class RTSubtypeVisitor(RTypeVisitor[bool]):
     def visit_rprimitive(self, left: RPrimitive) -> bool:
         if is_short_int_rprimitive(left) and is_int_rprimitive(self.right):
             return True
-        return isinstance(self.right, RPrimitive) and left.name == self.right.name
+        return left is self.right
 
     def visit_rtuple(self, left: RTuple) -> bool:
         return is_same_type(left, self.right)

--- a/mypyc/rt_subtype.py
+++ b/mypyc/rt_subtype.py
@@ -30,8 +30,7 @@ class RTSubtypeVisitor(RTypeVisitor[bool]):
         return isinstance(self.right, RInstance) and is_subtype(left, self.right)
 
     def visit_runion(self, left: RUnion) -> bool:
-        # XXX
-        return isinstance(self.right, RUnion) and is_subtype(left, self.right)
+        return is_subtype(left, self.right)
 
     def visit_rprimitive(self, left: RPrimitive) -> bool:
         if is_unsafe_int_rprimitive(left) and is_int_rprimitive(self.right):

--- a/mypyc/rt_subtype.py
+++ b/mypyc/rt_subtype.py
@@ -1,0 +1,49 @@
+"""*Runtime* Subtype check for RTypes."""
+
+from mypyc.ops import (
+    RType, RUnion, RInstance, RPrimitive, RTuple, RVoid, RTypeVisitor,
+    is_bool_rprimitive, is_int_rprimitive, is_tuple_rprimitive, none_rprimitive,
+    is_unsafe_int_rprimitive,
+    is_object_rprimitive
+)
+from mypyc.sametype import is_same_type
+from mypyc.subtype import is_subtype
+
+
+def is_runtime_subtype(left: RType, right: RType) -> bool:
+    if not left.is_unboxed and is_object_rprimitive(right):
+        return True
+    return left.accept(RTSubtypeVisitor(right))
+
+
+class RTSubtypeVisitor(RTypeVisitor[bool]):
+    """Is left a runtime subtype of right?
+
+    A few special cases such as right being 'object' are handled in
+    is_runtime_subtype and don't need to be covered here.
+    """
+
+    def __init__(self, right: RType) -> None:
+        self.right = right
+
+    def visit_rinstance(self, left: RInstance) -> bool:
+        return isinstance(self.right, RInstance) and is_subtype(left, self.right)
+
+    def visit_runion(self, left: RUnion) -> bool:
+        # XXX
+        return isinstance(self.right, RUnion) and is_subtype(left, self.right)
+
+    def visit_rprimitive(self, left: RPrimitive) -> bool:
+        if is_unsafe_int_rprimitive(left) and is_int_rprimitive(self.right):
+            return True
+        return isinstance(self.right, RPrimitive) and left.name == self.right.name
+
+    def visit_rtuple(self, left: RTuple) -> bool:
+        return is_same_type(left, self.right)
+        # if isinstance(self.right, RTuple):
+        #     return len(self.right.types) == len(left.types) and all(
+        #         is_runtime_subtype(t1, t2) for t1, t2 in zip(left.types, self.right.types))
+        # return False
+
+    def visit_rvoid(self, left: RVoid) -> bool:
+        return isinstance(self.right, RVoid)

--- a/mypyc/sametype.py
+++ b/mypyc/sametype.py
@@ -45,7 +45,7 @@ class SameTypeVisitor(RTypeVisitor[bool]):
         return False
 
     def visit_rprimitive(self, left: RPrimitive) -> bool:
-        return isinstance(self.right, RPrimitive) and left.name == self.right.name
+        return left is self.right
 
     def visit_rtuple(self, left: RTuple) -> bool:
         return (isinstance(self.right, RTuple)

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -3,6 +3,7 @@
 from mypyc.ops import (
     RType, RInstance, RPrimitive, RTuple, RVoid, RTypeVisitor, RUnion,
     is_bool_rprimitive, is_int_rprimitive, is_tuple_rprimitive, none_rprimitive,
+    is_unsafe_int_rprimitive,
     is_object_rprimitive
 )
 
@@ -42,6 +43,8 @@ class SubtypeVisitor(RTypeVisitor[bool]):
 
     def visit_rprimitive(self, left: RPrimitive) -> bool:
         if is_bool_rprimitive(left) and is_int_rprimitive(self.right):
+            return True
+        if is_unsafe_int_rprimitive(left) and is_int_rprimitive(self.right):
             return True
         return isinstance(self.right, RPrimitive) and left.name == self.right.name
 

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -3,7 +3,7 @@
 from mypyc.ops import (
     RType, RInstance, RPrimitive, RTuple, RVoid, RTypeVisitor, RUnion,
     is_bool_rprimitive, is_int_rprimitive, is_tuple_rprimitive, none_rprimitive,
-    is_unsafe_int_rprimitive,
+    is_short_int_rprimitive,
     is_object_rprimitive
 )
 
@@ -44,7 +44,7 @@ class SubtypeVisitor(RTypeVisitor[bool]):
     def visit_rprimitive(self, left: RPrimitive) -> bool:
         if is_bool_rprimitive(left) and is_int_rprimitive(self.right):
             return True
-        if is_unsafe_int_rprimitive(left) and is_int_rprimitive(self.right):
+        if is_short_int_rprimitive(left) and is_int_rprimitive(self.right):
             return True
         return isinstance(self.right, RPrimitive) and left.name == self.right.name
 

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -46,7 +46,7 @@ class SubtypeVisitor(RTypeVisitor[bool]):
             return True
         if is_short_int_rprimitive(left) and is_int_rprimitive(self.right):
             return True
-        return isinstance(self.right, RPrimitive) and left.name == self.right.name
+        return left is self.right
 
     def visit_rtuple(self, left: RTuple) -> bool:
         if is_tuple_rprimitive(self.right):

--- a/test-data/analysis.test
+++ b/test-data/analysis.test
@@ -9,9 +9,14 @@ def f(a: int) -> None:
         z = 1
 [out]
 def f(a):
-    a, r0, x :: int
+    a :: int
+    r0 :: short_int
+    x :: int
     r1 :: bool
-    r2, y, r3, z :: int
+    r2 :: short_int
+    y :: int
+    r3 :: short_int
+    z :: int
     r4 :: None
 L0:
     r0 = 1
@@ -50,7 +55,10 @@ def f(a: int) -> int:
         return x
 [out]
 def f(a):
-    a, r0, x, r1 :: int
+    a :: int
+    r0 :: short_int
+    x :: int
+    r1 :: short_int
     r2 :: bool
 L0:
     r0 = 1
@@ -81,7 +89,11 @@ def f() -> int:
     return x
 [out]
 def f():
-    r0, x, r1, y, r2 :: int
+    r0 :: short_int
+    x :: int
+    r1 :: short_int
+    y :: int
+    r2 :: short_int
 L0:
     r0 = 1
     x = r0
@@ -106,7 +118,8 @@ def f(a: int) -> int:
     return a
 [out]
 def f(a):
-    a, r0, r1, r2 :: int
+    a :: int
+    r0, r1, r2 :: short_int
 L0:
     r0 = 1
     a = r0
@@ -132,9 +145,14 @@ def f(a: int) -> None:
         x = 2
 [out]
 def f(a):
-    a, r0 :: int
+    a :: int
+    r0 :: short_int
     r1 :: bool
-    r2, y, r3, x, r4 :: int
+    r2 :: short_int
+    y :: int
+    r3 :: short_int
+    x :: int
+    r4 :: short_int
     r5 :: None
 L0:
     r0 = 1
@@ -183,9 +201,11 @@ def f(n: int) -> None:
         m = n
 [out]
 def f(n):
-    n, r0 :: int
+    n :: int
+    r0 :: short_int
     r1 :: bool
-    r2, r3, m :: int
+    r2 :: short_int
+    r3, m :: int
     r4 :: None
 L0:
 L1:
@@ -224,11 +244,16 @@ def f(n: int) -> None:
             n = x
 [out]
 def f(n):
-    n, r0, x, r1, y, r2 :: int
+    n :: int
+    r0 :: short_int
+    x :: int
+    r1 :: short_int
+    y :: int
+    r2 :: short_int
     r3 :: bool
-    r4 :: int
+    r4 :: short_int
     r5 :: bool
-    r6 :: int
+    r6 :: short_int
     r7 :: None
 L0:
     r0 = 1
@@ -282,7 +307,9 @@ def f(x: int) -> int:
     return f(a) + a
 [out]
 def f(x):
-    x, r0, r1, a, r2, r3, r4 :: int
+    x :: int
+    r0 :: short_int
+    r1, a, r2, r3, r4 :: int
 L0:
     r0 = 1
     r1 = f(r0)
@@ -367,7 +394,8 @@ def f(a: int) -> int:
     return a
 [out]
 def f(a):
-    a, b, r0 :: int
+    a, b :: int
+    r0 :: short_int
 L0:
     b = a
     r0 = 1
@@ -390,7 +418,9 @@ def f(a: int) -> int:
 def f(a):
     a :: int
     r0 :: bool
-    r1, x, r2, r3 :: int
+    r1 :: short_int
+    x :: int
+    r2, r3 :: short_int
 L0:
     r0 = a == a :: int
     if r0 goto L1 else goto L2 :: bool
@@ -427,9 +457,15 @@ def f(a: int) -> int:
     return sum
 [out]
 def f(a):
-    a, r0, sum, r1, i :: int
+    a :: int
+    r0 :: short_int
+    sum :: int
+    r1 :: short_int
+    i :: int
     r2 :: bool
-    r3, r4, r5 :: int
+    r3 :: int
+    r4 :: short_int
+    r5 :: int
 L0:
     r0 = 0
     sum = r0
@@ -483,9 +519,11 @@ def lol(x):
     r7 :: str
     r8 :: object
     r9 :: bool
-    r10, r11 :: int
+    r10 :: short_int
+    r11 :: int
     r12, r13 :: bool
-    r14, r15, r16 :: int
+    r14 :: short_int
+    r15, r16 :: int
 L0:
 L1:
     r0 = builtins.module :: static

--- a/test-data/exceptions.test
+++ b/test-data/exceptions.test
@@ -15,7 +15,6 @@ def f(x):
 L0:
     r0 = 0
     r1 = x[r0] :: list
-    dec_ref r0 :: int
     if is_error(r1) goto L3 (error at f:3) else goto L1
 L1:
     r2 = unbox(int, r1)
@@ -149,7 +148,6 @@ L4:
     r6 = 1
     r7 = i + r6 :: int
     dec_ref i :: int
-    dec_ref r6 :: int
     i = r7
     goto L1
 L5:
@@ -414,7 +412,6 @@ L6:
 L7:
     r10 = 1
     r11 = -r10 :: int
-    dec_ref r10 :: int
     restore_exc_info r5
     dec_ref r5
     return r11
@@ -438,7 +435,6 @@ L13:
     r14 = 1
     r15 = st + r14 :: int
     dec_ref st :: int
-    dec_ref r14 :: int
     return r15
 L14:
     r16 = <error> :: int

--- a/test-data/exceptions.test
+++ b/test-data/exceptions.test
@@ -9,7 +9,7 @@ def f(x: List[int]) -> int:
 [out]
 def f(x):
     x :: list
-    r0 :: int
+    r0 :: short_int
     r1 :: object
     r2, r3 :: int
 L0:
@@ -77,11 +77,12 @@ def f(x):
     x :: union[A, None]
     r0 :: None
     r1 :: bool
-    r2 :: int
+    r2 :: short_int
     r3 :: A
     r4 :: None
     r5, r6 :: bool
-    r7, r8, r9 :: int
+    r7, r8 :: short_int
+    r9 :: int
 L0:
     r0 = None
     r1 = x is r0
@@ -121,10 +122,16 @@ def sum(a: List[int], l: int) -> int:
 [out]
 def sum(a, l):
     a :: list
-    l, r0, sum, r1, i :: int
+    l :: int
+    r0 :: short_int
+    sum :: int
+    r1 :: short_int
+    i :: int
     r2 :: bool
     r3 :: object
-    r4, r5, r6, r7, r8 :: int
+    r4, r5 :: int
+    r6 :: short_int
+    r7, r8 :: int
 L0:
     r0 = 0
     sum = r0
@@ -379,9 +386,11 @@ def lol(x):
     r7 :: str
     r8 :: object
     r9 :: bool
-    r10, r11 :: int
+    r10 :: short_int
+    r11 :: int
     r12, r13 :: bool
-    r14, r15, r16 :: int
+    r14 :: short_int
+    r15, r16 :: int
 L0:
 L1:
     r0 = builtins.module :: static

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -3,7 +3,7 @@ def f() -> int:
     return 1
 [out]
 def f():
-    r0 :: int
+    r0 :: short_int
 L0:
     r0 = 1
     return r0
@@ -44,7 +44,8 @@ def f() -> int:
     return y
 [out]
 def f():
-    r0, x, y :: int
+    r0 :: short_int
+    x, y :: int
 L0:
     r0 = 1
     x = r0
@@ -58,7 +59,9 @@ def f(x: int) -> None:
     return
 [out]
 def f(x):
-    x, r0, y :: int
+    x :: int
+    r0 :: short_int
+    y :: int
     r1 :: None
 L0:
     r0 = 1
@@ -72,7 +75,9 @@ def f(x: int, y: int) -> int:
     return x * (y + 1)
 [out]
 def f(x, y):
-    x, y, r0, r1, r2 :: int
+    x, y :: int
+    r0 :: short_int
+    r1, r2 :: int
 L0:
     r0 = 1
     r1 = y + r0 :: int
@@ -88,7 +93,7 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: int
+    r1 :: short_int
 L0:
     r0 = x < y :: int
     if r0 goto L1 else goto L2 :: bool
@@ -109,7 +114,7 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1, r2 :: int
+    r1, r2 :: short_int
 L0:
     r0 = x < y :: int
     if r0 goto L1 else goto L2 :: bool
@@ -134,7 +139,7 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0, r1 :: bool
-    r2, r3 :: int
+    r2, r3 :: short_int
 L0:
     r0 = x < y :: int
     if r0 goto L1 else goto L3 :: bool
@@ -184,7 +189,7 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0, r1 :: bool
-    r2, r3 :: int
+    r2, r3 :: short_int
 L0:
     r0 = x < y :: int
     if r0 goto L2 else goto L1 :: bool
@@ -232,7 +237,7 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1 :: int
+    r1 :: short_int
 L0:
     r0 = x < y :: int
     if r0 goto L2 else goto L1 :: bool
@@ -251,7 +256,7 @@ def f(x: int, y: int) -> int:
 def f(x, y):
     x, y :: int
     r0, r1 :: bool
-    r2 :: int
+    r2 :: short_int
 L0:
     r0 = x < y :: int
     if r0 goto L1 else goto L2 :: bool
@@ -293,7 +298,8 @@ def f(x: int, y: int) -> int:
     return x
 [out]
 def f(x, y):
-    x, y, r0 :: int
+    x, y :: int
+    r0 :: short_int
     r1 :: bool
     r2 :: int
 L0:
@@ -324,7 +330,8 @@ def f() -> None:
     x = 1
 [out]
 def f():
-    r0, x :: int
+    r0 :: short_int
+    x :: int
     r1 :: None
 L0:
     r0 = 1
@@ -342,7 +349,7 @@ def f(x: int, y: int) -> None:
 def f(x, y):
     x, y :: int
     r0 :: bool
-    r1, r2 :: int
+    r1, r2 :: short_int
     r3 :: None
 L0:
     r0 = x < y :: int
@@ -366,9 +373,13 @@ def f(n: int) -> int:
         return f(n - 1) + f(n - 2)
 [out]
 def f(n):
-    n, r0 :: int
+    n :: int
+    r0 :: short_int
     r1 :: bool
-    r2, r3, r4, r5, r6, r7, r8, r9 :: int
+    r2, r3 :: short_int
+    r4, r5 :: int
+    r6 :: short_int
+    r7, r8, r9 :: int
 L0:
     r0 = 1
     r1 = n <= r0 :: int
@@ -410,11 +421,14 @@ def f(n: int) -> int:
     return x
 [out]
 def f(n):
-    n, r0 :: int
+    n :: int
+    r0 :: short_int
     r1 :: bool
-    r2, x, r3 :: int
+    r2 :: short_int
+    x :: int
+    r3 :: short_int
     r4 :: bool
-    r5, r6 :: int
+    r5, r6 :: short_int
 L0:
     r0 = 0
     r1 = n < r0 :: int
@@ -443,7 +457,9 @@ def f(n: int) -> int:
     return -1
 [out]
 def f(n):
-    n, r0, r1 :: int
+    n :: int
+    r0 :: short_int
+    r1 :: int
 L0:
     r0 = 1
     r1 = -r0 :: int
@@ -454,9 +470,11 @@ def f(n: int) -> int:
     return 0 if n == 0 else 1
 [out]
 def f(n):
-    n, r0 :: int
+    n :: int
+    r0 :: short_int
     r1 :: bool
-    r2, r3, r4 :: int
+    r2 :: int
+    r3, r4 :: short_int
 L0:
     r0 = 0
     r1 = n == r0 :: int
@@ -478,7 +496,10 @@ def f() -> int:
     return x
 [out]
 def f():
-    r0, x, r1, r2 :: int
+    r0 :: short_int
+    x :: int
+    r1 :: short_int
+    r2 :: int
 L0:
     r0 = 0
     x = r0
@@ -588,7 +609,7 @@ def f(x):
     r0 :: object
     r1 :: str
     r2 :: object
-    r3 :: int
+    r3 :: short_int
     r4, r5 :: object
     r6, r7 :: None
 L0:
@@ -596,7 +617,7 @@ L0:
     r1 = unicode_1 :: static  ('print')
     r2 = getattr r0, r1
     r3 = 5
-    r4 = box(int, r3)
+    r4 = box(short_int, r3)
     r5 = py_call(r2, r4)
     r6 = cast(None, r5)
     r7 = None
@@ -608,7 +629,8 @@ def f(x: int) -> None:
     print(5)
 [out]
 def f(x):
-    x, r0 :: int
+    x :: int
+    r0 :: short_int
     r1 :: object
     r2 :: str
     r3, r4, r5 :: object
@@ -618,7 +640,7 @@ L0:
     r1 = builtins.module :: static
     r2 = unicode_1 :: static  ('print')
     r3 = getattr r1, r2
-    r4 = box(int, r0)
+    r4 = box(short_int, r0)
     r5 = py_call(r3, r4)
     r6 = cast(None, r5)
     r7 = None
@@ -683,14 +705,14 @@ def g(y: object) -> None:
 def g(y):
     y :: object
     r0 :: None
-    r1 :: int
+    r1 :: short_int
     r2 :: object
     r3 :: list
     r4, r5, r6, r7 :: None
 L0:
     r0 = g(y)
     r1 = 1
-    r2 = box(int, r1)
+    r2 = box(short_int, r1)
     r3 = [r2]
     r4 = g(r3)
     r5 = None
@@ -708,20 +730,20 @@ def g(y: object) -> object:
 [out]
 def g(y):
     y :: object
-    r0 :: int
+    r0 :: short_int
     r1, r2 :: object
     r3, a :: list
-    r4, r5 :: int
+    r4, r5 :: short_int
     r6 :: tuple[int, int]
-    r7 :: int
+    r7 :: short_int
     r8 :: object
     r9, r10 :: bool
     r11 :: object
-    r12 :: int
+    r12 :: short_int
     r13 :: object
 L0:
     r0 = 1
-    r1 = box(int, r0)
+    r1 = box(short_int, r0)
     r2 = g(r1)
     r3 = [y]
     a = r3
@@ -735,7 +757,7 @@ L0:
     r11 = box(bool, r10)
     y = r11
     r12 = 3
-    r13 = box(int, r12)
+    r13 = box(short_int, r12)
     return r13
 
 [case testCoerceToObject2]
@@ -749,7 +771,7 @@ def f(a: A, o: object) -> None:
 def f(a, o):
     a :: A
     o :: object
-    r0 :: int
+    r0 :: short_int
     r1 :: object
     r2 :: bool
     r3 :: int
@@ -757,7 +779,7 @@ def f(a, o):
     r5 :: None
 L0:
     r0 = 1
-    r1 = box(int, r0)
+    r1 = box(short_int, r0)
     a.x = r1; r2 = is_error
     r3 = a.n
     r4 = box(int, r3)
@@ -930,7 +952,12 @@ def big_int() -> None:
     max_32_bit = 2147483647
 [out]
 def big_int():
-    r0, a_62_bit, r1, max_62_bit, r2, b_63_bit, r3, c_63_bit, r4, max_63_bit, r5, d_64_bit, r6, max_32_bit :: int
+    r0 :: short_int
+    a_62_bit :: int
+    r1 :: short_int
+    max_62_bit, r2, b_63_bit, r3, c_63_bit, r4, max_63_bit, r5, d_64_bit :: int
+    r6 :: short_int
+    max_32_bit :: int
     r7 :: None
 L0:
     r0 = 4611686018427387902
@@ -972,7 +999,8 @@ def call_callable_type() -> float:
     return f()
 [out]
 def absolute_value(x):
-    x, r0 :: int
+    x :: int
+    r0 :: short_int
     r1 :: bool
     r2, r3 :: int
 L0:
@@ -1040,7 +1068,7 @@ def call_python_method_with_keyword_args(xs: List[int], first: int, second: int)
 [out]
 def call_python_function_with_keyword_arg(x):
     x :: str
-    r0 :: int
+    r0 :: short_int
     r1 :: object
     r2 :: str
     r3 :: tuple[str]
@@ -1055,7 +1083,7 @@ L0:
     r2 = unicode_3 :: static  ('base')
     r3 = (x)
     r4 = {}
-    r5 = box(int, r0)
+    r5 = box(short_int, r0)
     r6 = r4.__setitem__(r2, r5) :: dict
     r7 = box(tuple[str], r3)
     r8 = py_call_with_kwargs(r1, r7, r4)
@@ -1063,7 +1091,8 @@ L0:
     return r9
 def call_python_method_with_keyword_args(xs, first, second):
     xs :: list
-    first, second, r0 :: int
+    first, second :: int
+    r0 :: short_int
     r1 :: str
     r2 :: object
     r3 :: str
@@ -1073,7 +1102,7 @@ def call_python_method_with_keyword_args(xs, first, second):
     r7 :: bool
     r8, r9 :: object
     r10 :: None
-    r11 :: int
+    r11 :: short_int
     r12 :: str
     r13 :: object
     r14, r15 :: str
@@ -1106,7 +1135,7 @@ L0:
     r17 = {}
     r18 = box(int, second)
     r19 = r17.__setitem__(r14, r18) :: dict
-    r20 = box(int, r11)
+    r20 = box(short_int, r11)
     r21 = r17.__setitem__(r15, r20) :: dict
     r22 = box(tuple[], r16)
     r23 = py_call_with_kwargs(r13, r22, r17)
@@ -1137,7 +1166,7 @@ def lst(x: List[int]) -> int:
 def obj(x):
     x :: object
     r0 :: bool
-    r1, r2 :: int
+    r1, r2 :: short_int
 L0:
     r0 = bool x :: object
     if r0 goto L1 else goto L2 :: bool
@@ -1150,9 +1179,10 @@ L2:
 L3:
     unreachable
 def num(x):
-    x, r0 :: int
+    x :: int
+    r0 :: short_int
     r1 :: bool
-    r2, r3 :: int
+    r2, r3 :: short_int
 L0:
     r0 = 0
     r1 = x != r0 :: int
@@ -1167,13 +1197,13 @@ L3:
     unreachable
 def lst(x):
     x :: list
-    r0, r1 :: int
+    r0, r1 :: short_int
     r2 :: bool
-    r3, r4 :: int
+    r3, r4 :: short_int
 L0:
     r0 = len x :: list
     r1 = 0
-    r2 = r0 != r1 :: int
+    r2 = r0 != r1 :: short_int
     if r2 goto L1 else goto L2 :: bool
 L1:
     r3 = 1
@@ -1211,9 +1241,10 @@ def opt_int(x):
     x :: union[int, None]
     r0 :: None
     r1 :: bool
-    r2, r3 :: int
+    r2 :: int
+    r3 :: short_int
     r4 :: bool
-    r5, r6 :: int
+    r5, r6 :: short_int
 L0:
     r0 = None
     r1 = x is not r0
@@ -1235,7 +1266,7 @@ def opt_a(x):
     x :: union[A, None]
     r0 :: None
     r1 :: bool
-    r2, r3 :: int
+    r2, r3 :: short_int
 L0:
     r0 = None
     r1 = x is not r0
@@ -1254,7 +1285,7 @@ def opt_o(x):
     r1 :: bool
     r2 :: object
     r3 :: bool
-    r4, r5 :: int
+    r4, r5 :: short_int
 L0:
     r0 = None
     r1 = x is not r0
@@ -1338,7 +1369,7 @@ def __top_level__():
     r2 :: bool
     r3 :: str
     r4 :: object
-    r5 :: int
+    r5 :: short_int
     r6 :: object
     r7 :: str
     r8 :: object
@@ -1364,7 +1395,7 @@ L2:
     r5 = 1
     r6 = __main__.globals :: static
     r7 = unicode_1 :: static  ('x')
-    r8 = box(int, r5)
+    r8 = box(short_int, r5)
     r9 = r6.__setitem__(r7, r8) :: object
     r10 = __main__.globals :: static
     r11 = unicode_1 :: static  ('x')
@@ -1394,7 +1425,7 @@ def f():
     r0 :: object
     r1 :: str
     r2 :: object
-    r3 :: int
+    r3 :: short_int
     r4, r5 :: object
     r6 :: str
 L0:
@@ -1402,7 +1433,7 @@ L0:
     r1 = unicode_2 :: static  ('f')
     r2 = getattr r0, r1
     r3 = 1
-    r4 = box(int, r3)
+    r4 = box(short_int, r3)
     r5 = py_call(r2, r4)
     r6 = cast(str, r5)
     return r6
@@ -1423,9 +1454,9 @@ L0:
     return r0
 def g():
     r0 :: str
-    r1 :: int
+    r1 :: short_int
     r2 :: None
-    r3 :: int
+    r3 :: short_int
     r4 :: str
     r5, r6 :: None
 L0:
@@ -1457,9 +1488,9 @@ L0:
 def g(a):
     a :: A
     r0 :: str
-    r1 :: int
+    r1 :: short_int
     r2 :: None
-    r3 :: int
+    r3 :: short_int
     r4 :: str
     r5, r6 :: None
 L0:
@@ -1488,7 +1519,7 @@ L0:
     r0 = (a, b, c)
     return r0
 def g():
-    r0, r1, r2 :: int
+    r0, r1, r2 :: short_int
     r3 :: tuple[int, int, int]
     r4 :: object
     r5 :: str
@@ -1516,7 +1547,7 @@ L0:
     r13 = unbox(tuple[int, int, int], r12)
     return r13
 def h():
-    r0, r1, r2 :: int
+    r0, r1, r2 :: short_int
     r3 :: tuple[int, int]
     r4 :: object
     r5 :: str
@@ -1535,7 +1566,7 @@ L0:
     r4 = __main__.globals :: static
     r5 = unicode_3 :: static  ('f')
     r6 = r4[r5] :: dict
-    r7 = box(int, r0)
+    r7 = box(short_int, r0)
     r8 = [r7]
     r9 = box(tuple[int, int], r3)
     r10 = r8.extend(r9) :: list
@@ -1562,11 +1593,11 @@ L0:
     return r0
 def g():
     r0 :: str
-    r1 :: int
+    r1 :: short_int
     r2 :: str
-    r3 :: int
+    r3 :: short_int
     r4 :: str
-    r5 :: int
+    r5 :: short_int
     r6 :: dict
     r7 :: object
     r8 :: bool
@@ -1590,11 +1621,11 @@ L0:
     r4 = unicode_5 :: static  ('c')
     r5 = 3
     r6 = {}
-    r7 = box(int, r1)
+    r7 = box(short_int, r1)
     r8 = r6.__setitem__(r0, r7) :: dict
-    r9 = box(int, r3)
+    r9 = box(short_int, r3)
     r10 = r6.__setitem__(r2, r9) :: dict
-    r11 = box(int, r5)
+    r11 = box(short_int, r5)
     r12 = r6.__setitem__(r4, r11) :: dict
     r13 = __main__.globals :: static
     r14 = unicode_6 :: static  ('f')
@@ -1607,11 +1638,11 @@ L0:
     r21 = unbox(tuple[int, int, int], r20)
     return r21
 def h():
-    r0 :: int
+    r0 :: short_int
     r1 :: str
-    r2 :: int
+    r2 :: short_int
     r3 :: str
-    r4 :: int
+    r4 :: short_int
     r5 :: dict
     r6 :: object
     r7 :: bool
@@ -1632,9 +1663,9 @@ L0:
     r3 = unicode_5 :: static  ('c')
     r4 = 3
     r5 = {}
-    r6 = box(int, r2)
+    r6 = box(short_int, r2)
     r7 = r5.__setitem__(r1, r6) :: dict
-    r8 = box(int, r4)
+    r8 = box(short_int, r4)
     r9 = r5.__setitem__(r3, r8) :: dict
     r10 = __main__.globals :: static
     r11 = unicode_6 :: static  ('f')
@@ -1658,7 +1689,7 @@ def g() -> None:
 def f(x, y, z):
     x, y :: int
     z :: str
-    r0 :: int
+    r0 :: short_int
     r1 :: str
     r2 :: None
 L0:
@@ -1675,10 +1706,11 @@ L4:
     r2 = None
     return r2
 def g():
-    r0, r1 :: int
+    r0 :: short_int
+    r1 :: int
     r2 :: str
     r3 :: None
-    r4, r5 :: int
+    r4, r5 :: short_int
     r6 :: str
     r7, r8 :: None
 L0:
@@ -1707,7 +1739,7 @@ def A.f(self, x, y, z):
     self :: A
     x, y :: int
     z :: str
-    r0 :: int
+    r0 :: short_int
     r1 :: str
     r2 :: None
 L0:
@@ -1725,10 +1757,11 @@ L4:
     return r2
 def g():
     r0, a :: A
-    r1, r2 :: int
+    r1 :: short_int
+    r2 :: int
     r3 :: str
     r4 :: None
-    r5, r6 :: int
+    r5, r6 :: short_int
     r7 :: str
     r8, r9 :: None
 L0:
@@ -1753,34 +1786,35 @@ def f() -> List[int]:
 [out]
 def f():
     r0 :: list
-    r1, r2, r3 :: int
+    r1, r2, r3 :: short_int
     r4, r5, r6 :: object
     r7 :: list
-    r8, r9, r10 :: int
+    r8, r9, r10 :: short_int
     r11 :: bool
     r12 :: object
-    x, r13, r14 :: int
+    x, r13 :: int
+    r14 :: short_int
     r15 :: bool
-    r16 :: int
+    r16 :: short_int
     r17 :: bool
     r18 :: int
     r19 :: object
     r20 :: bool
-    r21, r22 :: int
+    r21, r22 :: short_int
 L0:
     r0 = []
     r1 = 1
     r2 = 2
     r3 = 3
-    r4 = box(int, r1)
-    r5 = box(int, r2)
-    r6 = box(int, r3)
+    r4 = box(short_int, r1)
+    r5 = box(short_int, r2)
+    r6 = box(short_int, r3)
     r7 = [r4, r5, r6]
     r8 = 0
     r9 = r8
 L1:
     r10 = len r7 :: list
-    r11 = r9 < r10 :: int
+    r11 = r9 < r10 :: short_int
     if r11 goto L2 else goto L8 :: bool
 L2:
     r12 = r7[r9] :: list
@@ -1803,7 +1837,7 @@ L6:
     r20 = r0.append(r19) :: list
 L7:
     r21 = 1
-    r22 = r9 + r21 :: int
+    r22 = r9 + r21 :: short_int
     r9 = r22
     goto L1
 L8:
@@ -1816,34 +1850,35 @@ def f() -> Dict[int, int]:
 [out]
 def f():
     r0 :: dict
-    r1, r2, r3 :: int
+    r1, r2, r3 :: short_int
     r4, r5, r6 :: object
     r7 :: list
-    r8, r9, r10 :: int
+    r8, r9, r10 :: short_int
     r11 :: bool
     r12 :: object
-    x, r13, r14 :: int
+    x, r13 :: int
+    r14 :: short_int
     r15 :: bool
-    r16 :: int
+    r16 :: short_int
     r17 :: bool
     r18 :: int
     r19, r20 :: object
     r21 :: bool
-    r22, r23 :: int
+    r22, r23 :: short_int
 L0:
     r0 = {}
     r1 = 1
     r2 = 2
     r3 = 3
-    r4 = box(int, r1)
-    r5 = box(int, r2)
-    r6 = box(int, r3)
+    r4 = box(short_int, r1)
+    r5 = box(short_int, r2)
+    r6 = box(short_int, r3)
     r7 = [r4, r5, r6]
     r8 = 0
     r9 = r8
 L1:
     r10 = len r7 :: list
-    r11 = r9 < r10 :: int
+    r11 = r9 < r10 :: short_int
     if r11 goto L2 else goto L8 :: bool
 L2:
     r12 = r7[r9] :: list
@@ -1867,7 +1902,7 @@ L6:
     r21 = r0.__setitem__(r19, r20) :: dict
 L7:
     r22 = 1
-    r23 = r9 + r22 :: int
+    r23 = r9 + r22 :: short_int
     r9 = r23
     goto L1
 L8:
@@ -1882,14 +1917,15 @@ def f(l: List[Tuple[int, int, int]]) -> List[int]:
 [out]
 def f(l):
     l :: list
-    r0, r1, r2 :: int
+    r0, r1, r2 :: short_int
     r3 :: bool
     r4 :: object
     x, y, z :: int
     r5 :: tuple[int, int, int]
-    r6, r7, r8, r9, r10 :: int
+    r6, r7, r8 :: int
+    r9, r10 :: short_int
     r11 :: list
-    r12, r13, r14 :: int
+    r12, r13, r14 :: short_int
     r15 :: bool
     r16 :: object
     x0, y0, z0 :: int
@@ -1897,13 +1933,13 @@ def f(l):
     r18, r19, r20, r21, r22 :: int
     r23 :: object
     r24 :: bool
-    r25, r26 :: int
+    r25, r26 :: short_int
 L0:
     r0 = 0
     r1 = r0
 L1:
     r2 = len l :: list
-    r3 = r1 < r2 :: int
+    r3 = r1 < r2 :: short_int
     if r3 goto L2 else goto L4 :: bool
 L2:
     r4 = l[r1] :: list
@@ -1916,7 +1952,7 @@ L2:
     z = r8
 L3:
     r9 = 1
-    r10 = r1 + r9 :: int
+    r10 = r1 + r9 :: short_int
     r1 = r10
     goto L1
 L4:
@@ -1925,7 +1961,7 @@ L4:
     r13 = r12
 L5:
     r14 = len l :: list
-    r15 = r13 < r14 :: int
+    r15 = r13 < r14 :: short_int
     if r15 goto L6 else goto L8 :: bool
 L6:
     r16 = l[r13] :: list
@@ -1942,7 +1978,7 @@ L6:
     r24 = r11.append(r23) :: list
 L7:
     r25 = 1
-    r26 = r13 + r25 :: int
+    r26 = r13 + r25 :: short_int
     r13 = r26
     goto L5
 L8:
@@ -1993,7 +2029,8 @@ L0:
     return r3
 def PropertyHolder.twice_value(self):
     self :: PropertyHolder
-    r0, r1, r2 :: int
+    r0 :: short_int
+    r1, r2 :: int
 L0:
     r0 = 2
     r1 = self.value
@@ -2063,7 +2100,9 @@ L0:
     return r1
 def BaseProperty.next(self):
     self :: BaseProperty
-    r0, r1, r2 :: int
+    r0 :: int
+    r1 :: short_int
+    r2 :: int
     r3 :: BaseProperty
 L0:
     r0 = self._incrementer
@@ -2220,11 +2259,11 @@ L0:
     return self
 def SubclassedTrait.boxed(self):
     self :: SubclassedTrait
-    r0 :: int
+    r0 :: short_int
     r1 :: object
 L0:
     r0 = 3
-    r1 = box(int, r0)
+    r1 = box(short_int, r0)
     return r1
 def DerivingObject.this(self):
     self :: DerivingObject
@@ -2237,7 +2276,7 @@ L0:
     return r0
 def DerivingObject.boxed(self):
     self :: DerivingObject
-    r0 :: int
+    r0 :: short_int
 L0:
     r0 = 5
     return r0
@@ -2322,7 +2361,7 @@ def __top_level__():
     r39, r40, r41 :: object
     r42 :: str
     r43 :: bool
-    r44 :: int
+    r44 :: short_int
     r45 :: str
     r46 :: object
     r47 :: str
@@ -2344,7 +2383,7 @@ def __top_level__():
     r69, r70, r71 :: object
     r72 :: str
     r73 :: bool
-    r74, r75, r76 :: int
+    r74, r75, r76 :: short_int
     r77, r78, r79 :: object
     r80 :: list
     r81 :: object
@@ -2411,7 +2450,7 @@ L4:
     r46 = __main__.globals :: static
     r47 = unicode_5 :: static  ('Lol')
     r48 = r46[r47] :: dict
-    r49 = box(int, r44)
+    r49 = box(short_int, r44)
     r50 = py_call(r48, r49, r45)
     r51 = cast(tuple, r50)
     r52 = __main__.globals :: static
@@ -2439,9 +2478,9 @@ L4:
     r74 = 1
     r75 = 2
     r76 = 3
-    r77 = box(int, r74)
-    r78 = box(int, r75)
-    r79 = box(int, r76)
+    r77 = box(short_int, r74)
+    r78 = box(short_int, r75)
+    r79 = box(short_int, r76)
     r80 = [r77, r78, r79]
     r81 = __main__.globals :: static
     r82 = unicode_12 :: static  ('Bar')
@@ -2945,7 +2984,8 @@ def call_any(l):
     l :: object
     r0, r1 :: bool
     r2, r3 :: object
-    i, r4, r5 :: int
+    i, r4 :: int
+    r5 :: short_int
     r6, r7, r8 :: bool
 L0:
     r1 = False
@@ -2975,7 +3015,8 @@ def call_all(l):
     l :: object
     r0, r1 :: bool
     r2, r3 :: object
-    i, r4, r5 :: int
+    i, r4 :: int
+    r5 :: short_int
     r6, r7, r8, r9 :: bool
 L0:
     r1 = True

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -21,7 +21,7 @@ def f(a: A) -> None:
 [out]
 def f(a):
     a :: A
-    r0 :: int
+    r0 :: short_int
     r1 :: bool
     r2 :: None
 L0:
@@ -43,13 +43,15 @@ def f() -> int:
 [out]
 def f():
     r0, c :: C
-    r1 :: int
+    r1 :: short_int
     r2 :: bool
     r3, a :: list
-    r4 :: int
+    r4 :: short_int
     r5 :: object
     r6, d :: C
-    r7, r8, r9 :: int
+    r7 :: int
+    r8 :: short_int
+    r9 :: int
 L0:
     r0 = C()
     c = r0
@@ -78,14 +80,15 @@ def A.f(self, x, y):
     self :: A
     x :: int
     y :: str
-    r0, r1 :: int
+    r0 :: short_int
+    r1 :: int
 L0:
     r0 = 10
     r1 = x + r0 :: int
     return r1
 def g(a):
     a :: A
-    r0 :: int
+    r0 :: short_int
     r1 :: str
     r2 :: int
     r3 :: None
@@ -125,10 +128,11 @@ def Node.length(self):
     r0 :: union[Node, None]
     r1 :: None
     r2, r3 :: bool
-    r4 :: int
+    r4 :: short_int
     r5 :: union[Node, None]
     r6 :: Node
-    r7, r8, r9 :: int
+    r7, r8 :: int
+    r9 :: short_int
 L0:
     r0 = self.next
     r1 = None
@@ -157,7 +161,7 @@ class B(A):
 [out]
 def A.__init__(self):
     self :: A
-    r0 :: int
+    r0 :: short_int
     r1 :: bool
     r2 :: None
 L0:
@@ -167,9 +171,9 @@ L0:
     return r2
 def B.__init__(self):
     self :: B
-    r0 :: int
+    r0 :: short_int
     r1 :: bool
-    r2 :: int
+    r2 :: short_int
     r3 :: bool
     r4 :: None
 L0:
@@ -191,7 +195,7 @@ def increment(o: O) -> O:
 [out]
 def O.__init__(self):
     self :: O
-    r0 :: int
+    r0 :: short_int
     r1 :: bool
     r2 :: None
 L0:
@@ -201,7 +205,9 @@ L0:
     return r2
 def increment(o):
     o :: O
-    r0, r1, r2 :: int
+    r0 :: int
+    r1 :: short_int
+    r2 :: int
     r3 :: bool
 L0:
     r0 = o.x
@@ -546,22 +552,28 @@ def lol() -> int:
     return C.foo(1) + C.bar(2)
 [out]
 def C.foo(x):
-    x, r0, r1 :: int
+    x :: int
+    r0 :: short_int
+    r1 :: int
 L0:
     r0 = 10
     r1 = r0 + x :: int
     return r1
 def C.bar(cls, x):
     cls :: object
-    x, r0, r1 :: int
+    x :: int
+    r0 :: short_int
+    r1 :: int
 L0:
     r0 = 10
     r1 = r0 + x :: int
     return r1
 def lol():
-    r0, r1 :: int
+    r0 :: short_int
+    r1 :: int
     r2 :: object
-    r3, r4, r5 :: int
+    r3 :: short_int
+    r4, r5 :: int
 L0:
     r0 = 1
     r1 = C.foo(r0)
@@ -661,7 +673,7 @@ class B(A):
 [out]
 def A.lol(self):
     self :: A
-    r0 :: int
+    r0 :: short_int
     r1 :: bool
     r2 :: None
 L0:
@@ -671,7 +683,7 @@ L0:
     return r2
 def A.__mypyc_defaults_setup(__mypyc_self__):
     __mypyc_self__ :: A
-    r0 :: int
+    r0 :: short_int
     r1, r2 :: bool
 L0:
     r0 = 10
@@ -687,7 +699,7 @@ def B.__mypyc_defaults_setup(__mypyc_self__):
     r4 :: bool
     r5 :: None
     r6, r7, r8 :: bool
-    r9 :: int
+    r9 :: short_int
     r10, r11 :: bool
 L0:
     r0 = __main__.globals :: static

--- a/test-data/genops-dict.test
+++ b/test-data/genops-dict.test
@@ -5,12 +5,12 @@ def f(d: Dict[int, bool]) -> bool:
 [out]
 def f(d):
     d :: dict
-    r0 :: int
+    r0 :: short_int
     r1, r2 :: object
     r3 :: bool
 L0:
     r0 = 0
-    r1 = box(int, r0)
+    r1 = box(short_int, r0)
     r2 = d[r1] :: dict
     r3 = unbox(bool, r2)
     return r3
@@ -23,14 +23,14 @@ def f(d: Dict[int, bool]) -> None:
 def f(d):
     d :: dict
     r0 :: bool
-    r1 :: int
+    r1 :: short_int
     r2, r3 :: object
     r4 :: bool
     r5 :: None
 L0:
     r0 = False
     r1 = 0
-    r2 = box(int, r1)
+    r2 = box(short_int, r1)
     r3 = box(bool, r0)
     r4 = d.__setitem__(r2, r3) :: dict
     r5 = None
@@ -56,7 +56,7 @@ def f(x: object) -> None:
 [out]
 def f(x):
     x :: object
-    r0, r1 :: int
+    r0, r1 :: short_int
     r2 :: str
     r3 :: dict
     r4, r5 :: object
@@ -68,8 +68,8 @@ L0:
     r1 = 2
     r2 = unicode_1 :: static
     r3 = {}
-    r4 = box(int, r0)
-    r5 = box(int, r1)
+    r4 = box(short_int, r0)
+    r5 = box(short_int, r1)
     r6 = r3.__setitem__(r4, r5) :: dict
     r7 = r3.__setitem__(r2, x) :: dict
     d = r3
@@ -86,12 +86,12 @@ def f(d: Dict[int, int]) -> bool:
 [out]
 def f(d):
     d :: dict
-    r0 :: int
+    r0 :: short_int
     r1 :: object
     r2, r3, r4 :: bool
 L0:
     r0 = 4
-    r1 = box(int, r0)
+    r1 = box(short_int, r0)
     r2 = r1 in d :: dict
     if r2 goto L1 else goto L2 :: bool
 L1:
@@ -113,12 +113,12 @@ def f(d: Dict[int, int]) -> bool:
 [out]
 def f(d):
     d :: dict
-    r0 :: int
+    r0 :: short_int
     r1 :: object
     r2, r3, r4, r5 :: bool
 L0:
     r0 = 4
-    r1 = box(int, r0)
+    r1 = box(short_int, r0)
     r2 = r1 in d :: dict
     r3 = !r2
     if r3 goto L1 else goto L2 :: bool
@@ -158,7 +158,7 @@ def increment(d):
     r0, r1 :: object
     k, r2 :: str
     r3 :: object
-    r4 :: int
+    r4 :: short_int
     r5, r6 :: object
     r7, r8 :: bool
 L0:
@@ -171,7 +171,7 @@ L2:
     k = r2
     r3 = d[k] :: dict
     r4 = 1
-    r5 = box(int, r4)
+    r5 = box(short_int, r4)
     r6 = r3 += r5
     r7 = d.__setitem__(k, r6) :: dict
     goto L1

--- a/test-data/genops-generators.test
+++ b/test-data/genops-generators.test
@@ -13,27 +13,27 @@ def yield_three_times__gen.__mypyc_generator_helper__(__mypyc_self__, type, valu
     r1 :: int
     r2 :: None
     r3, r4 :: bool
-    r5 :: int
+    r5 :: short_int
     r6 :: object
-    r7 :: int
+    r7 :: short_int
     r8 :: bool
     r9 :: None
     r10, r11 :: bool
     r12 :: None
-    r13 :: int
+    r13 :: short_int
     r14 :: object
-    r15 :: int
+    r15 :: short_int
     r16 :: bool
     r17 :: None
     r18, r19 :: bool
     r20, r21 :: None
-    r22 :: int
+    r22 :: short_int
     r23, r24 :: bool
-    r25 :: int
+    r25 :: short_int
     r26 :: bool
-    r27 :: int
+    r27 :: short_int
     r28 :: bool
-    r29 :: int
+    r29 :: short_int
     r30, r31 :: bool
 L0:
     r0 = __mypyc_self__.__mypyc_env__
@@ -49,7 +49,7 @@ L2:
 L3:
 L4:
     r5 = 1
-    r6 = box(int, r5)
+    r6 = box(short_int, r5)
     r7 = 1
     r0.__mypyc_next_label__ = r7; r8 = is_error
     return r6
@@ -64,7 +64,7 @@ L7:
     r12 = None
 L8:
     r13 = 2
-    r14 = box(int, r13)
+    r14 = box(short_int, r13)
     r15 = 2
     r0.__mypyc_next_label__ = r15; r16 = is_error
     return r14
@@ -131,7 +131,7 @@ def yield_three_times():
     r0 :: yield_three_times__env
     r1 :: yield_three_times__gen
     r2 :: bool
-    r3 :: int
+    r3 :: short_int
     r4 :: bool
 L0:
     r0 = yield_three_times__env()
@@ -158,25 +158,28 @@ def yield_while_loop__gen.__mypyc_generator_helper__(__mypyc_self__, type, value
     r1 :: int
     r2 :: None
     r3, r4 :: bool
-    r5 :: int
+    r5 :: short_int
     r6 :: bool
-    r7, r8 :: int
+    r7 :: int
+    r8 :: short_int
     r9 :: bool
     r10 :: int
     r11 :: object
-    r12 :: int
+    r12 :: short_int
     r13 :: bool
     r14 :: None
     r15, r16 :: bool
     r17 :: None
-    r18, r19, r20 :: int
+    r18 :: int
+    r19 :: short_int
+    r20 :: int
     r21 :: bool
     r22 :: None
-    r23 :: int
+    r23 :: short_int
     r24, r25 :: bool
-    r26 :: int
+    r26 :: short_int
     r27 :: bool
-    r28 :: int
+    r28 :: short_int
     r29, r30 :: bool
 L0:
     r0 = __mypyc_self__.__mypyc_env__
@@ -269,7 +272,7 @@ def yield_while_loop():
     r0 :: yield_while_loop__env
     r1 :: yield_while_loop__gen
     r2 :: bool
-    r3 :: int
+    r3 :: short_int
     r4 :: bool
 L0:
     r0 = yield_while_loop__env()
@@ -304,36 +307,36 @@ def yield_for_loop_list__gen.__mypyc_generator_helper__(__mypyc_self__, type, va
     r1 :: int
     r2 :: None
     r3, r4 :: bool
-    r5 :: int
+    r5 :: short_int
     r6 :: object
     r7 :: str
     r8, r9, r10 :: object
     r11 :: list
     r12 :: bool
     r13 :: list
-    r14 :: int
+    r14 :: short_int
     r15, r16 :: bool
     r17 :: list
-    r18, r19 :: int
+    r18, r19 :: short_int
     r20 :: bool
     r21 :: list
-    r22 :: int
+    r22 :: short_int
     r23, r24 :: object
     r25 :: bool
     r26 :: object
-    r27 :: int
+    r27 :: short_int
     r28 :: bool
     r29 :: None
     r30, r31 :: bool
     r32 :: None
-    r33, r34, r35 :: int
+    r33, r34, r35 :: short_int
     r36 :: bool
     r37 :: None
-    r38 :: int
+    r38 :: short_int
     r39, r40 :: bool
-    r41 :: int
+    r41 :: short_int
     r42 :: bool
-    r43 :: int
+    r43 :: short_int
     r44, r45 :: bool
 L0:
     r0 = __mypyc_self__.__mypyc_env__
@@ -351,7 +354,7 @@ L3:
     r6 = builtins.module :: static
     r7 = unicode_3 :: static  ('range')
     r8 = getattr r6, r7
-    r9 = box(int, r5)
+    r9 = box(short_int, r5)
     r10 = py_call(r8, r9)
     r11 = [r10]
     r0.l = r11; r12 = is_error
@@ -363,7 +366,7 @@ L4:
     r17 = r0.__mypyc_temp__0
     r18 = len r17 :: list
     r19 = r0.__mypyc_temp__1
-    r20 = r19 < r18 :: int
+    r20 = r19 < r18 :: short_int
     if r20 goto L5 else goto L11 :: bool
 L5:
     r21 = r0.__mypyc_temp__0
@@ -388,7 +391,7 @@ L9:
 L10:
     r33 = r0.__mypyc_temp__1
     r34 = 1
-    r35 = r33 + r34 :: int
+    r35 = r33 + r34 :: short_int
     r0.__mypyc_temp__1 = r35; r36 = is_error
     goto L4
 L11:
@@ -442,7 +445,7 @@ def yield_for_loop_list():
     r0 :: yield_for_loop_list__env
     r1 :: yield_for_loop_list__gen
     r2 :: bool
-    r3 :: int
+    r3 :: short_int
     r4 :: bool
 L0:
     r0 = yield_for_loop_list__env()
@@ -459,15 +462,17 @@ def yield_for_loop_dict__gen.__mypyc_generator_helper__(__mypyc_self__, type, va
     r2 :: None
     r3, r4 :: bool
     r5 :: dict
-    r6, r7 :: int
+    r6, r7 :: short_int
     r8, r9 :: bool
-    r10, r11 :: int
+    r10 :: int
+    r11 :: short_int
     r12 :: bool
     r13 :: int
     r14 :: None
     r15 :: object
     r16 :: bool
-    r17, r18, r19 :: int
+    r17 :: int
+    r18, r19 :: short_int
     r20, r21 :: bool
     r22 :: dict
     r23 :: object
@@ -477,18 +482,18 @@ def yield_for_loop_dict__gen.__mypyc_generator_helper__(__mypyc_self__, type, va
     r29 :: bool
     r30 :: int
     r31 :: object
-    r32 :: int
+    r32 :: short_int
     r33 :: bool
     r34 :: None
     r35, r36 :: bool
     r37 :: None
     r38 :: bool
     r39 :: None
-    r40 :: int
+    r40 :: short_int
     r41, r42 :: bool
-    r43 :: int
+    r43 :: short_int
     r44 :: bool
-    r45 :: int
+    r45 :: short_int
     r46, r47 :: bool
 L0:
     r0 = __mypyc_self__.__mypyc_env__
@@ -520,7 +525,7 @@ L5:
 L6:
     r17 = r0.i
     r18 = 1
-    r19 = r17 + r18 :: int
+    r19 = r17 + r18 :: short_int
     r0.i = r19; r20 = is_error
     goto L4
 L7:
@@ -605,7 +610,7 @@ def yield_for_loop_dict():
     r0 :: yield_for_loop_dict__env
     r1 :: yield_for_loop_dict__gen
     r2 :: bool
-    r3 :: int
+    r3 :: short_int
     r4 :: bool
 L0:
     r0 = yield_for_loop_dict__env()
@@ -621,25 +626,27 @@ def yield_for_loop_range__gen.__mypyc_generator_helper__(__mypyc_self__, type, v
     r1 :: int
     r2 :: None
     r3, r4 :: bool
-    r5, r6 :: int
+    r5, r6 :: short_int
     r7, r8 :: bool
-    r9, r10 :: int
+    r9 :: int
+    r10 :: short_int
     r11 :: bool
     r12 :: int
     r13 :: object
-    r14 :: int
+    r14 :: short_int
     r15 :: bool
     r16 :: None
     r17, r18 :: bool
     r19 :: None
-    r20, r21, r22 :: int
+    r20 :: int
+    r21, r22 :: short_int
     r23 :: bool
     r24 :: None
-    r25 :: int
+    r25 :: short_int
     r26, r27 :: bool
-    r28 :: int
+    r28 :: short_int
     r29 :: bool
-    r30 :: int
+    r30 :: short_int
     r31, r32 :: bool
 L0:
     r0 = __mypyc_self__.__mypyc_env__
@@ -681,7 +688,7 @@ L9:
 L10:
     r20 = r0.i
     r21 = 1
-    r22 = r20 + r21 :: int
+    r22 = r20 + r21 :: short_int
     r0.i = r22; r23 = is_error
     goto L4
 L11:
@@ -735,7 +742,7 @@ def yield_for_loop_range():
     r0 :: yield_for_loop_range__env
     r1 :: yield_for_loop_range__gen
     r2 :: bool
-    r3 :: int
+    r3 :: short_int
     r4 :: bool
 L0:
     r0 = yield_for_loop_range__env()
@@ -763,25 +770,27 @@ def yield_with_vars__gen.__mypyc_generator_helper__(__mypyc_self__, type, value,
     r1 :: int
     r2 :: None
     r3, r4 :: bool
-    r5 :: int
+    r5 :: short_int
     r6 :: bool
     r7, r8 :: int
     r9 :: bool
     r10 :: int
     r11 :: object
-    r12 :: int
+    r12 :: short_int
     r13 :: bool
     r14 :: None
     r15, r16 :: bool
     r17 :: None
-    r18, r19, r20 :: int
+    r18 :: int
+    r19 :: short_int
+    r20 :: int
     r21 :: bool
     r22 :: float
-    r23 :: int
+    r23 :: short_int
     r24, r25 :: bool
-    r26 :: int
+    r26 :: short_int
     r27 :: bool
-    r28 :: int
+    r28 :: short_int
     r29, r30 :: bool
 L0:
     r0 = __mypyc_self__.__mypyc_env__
@@ -877,7 +886,7 @@ def yield_with_vars(a, b):
     r1, r2 :: bool
     r3 :: yield_with_vars__gen
     r4 :: bool
-    r5 :: int
+    r5 :: short_int
     r6 :: bool
 L0:
     r0 = yield_with_vars__env()
@@ -904,18 +913,18 @@ def generator__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, trace
     r1 :: int
     r2 :: None
     r3, r4 :: bool
-    r5 :: int
+    r5 :: short_int
     r6 :: object
-    r7 :: int
+    r7 :: short_int
     r8 :: bool
     r9 :: None
     r10, r11 :: bool
     r12, r13 :: None
-    r14 :: int
+    r14 :: short_int
     r15, r16 :: bool
-    r17 :: int
+    r17 :: short_int
     r18 :: bool
-    r19 :: int
+    r19 :: short_int
     r20, r21 :: bool
 L0:
     r0 = __mypyc_self__.__mypyc_env__
@@ -931,7 +940,7 @@ L2:
 L3:
 L4:
     r5 = 0
-    r6 = box(int, r5)
+    r6 = box(short_int, r5)
     r7 = 1
     r0.__mypyc_next_label__ = r7; r8 = is_error
     return r6
@@ -996,7 +1005,7 @@ def A.generator(self):
     r1 :: bool
     r2 :: generator__gen
     r3 :: bool
-    r4 :: int
+    r4 :: short_int
     r5 :: bool
 L0:
     r0 = generator__env()
@@ -1024,23 +1033,24 @@ def generator__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, trace
     r1 :: int
     r2 :: None
     r3, r4 :: bool
-    r5, r6 :: int
+    r5 :: int
+    r6 :: short_int
     r7 :: bool
     r8 :: int
     r9 :: object
-    r10 :: int
+    r10 :: short_int
     r11 :: bool
     r12 :: None
     r13, r14 :: bool
     r15, r16 :: None
-    r17 :: int
+    r17 :: short_int
     r18, r19 :: bool
     r20 :: None
-    r21 :: int
+    r21 :: short_int
     r22, r23 :: bool
-    r24 :: int
+    r24 :: short_int
     r25 :: bool
-    r26 :: int
+    r26 :: short_int
     r27, r28 :: bool
 L0:
     r0 = __mypyc_self__.__mypyc_env__
@@ -1135,7 +1145,7 @@ def generator(a):
     r1 :: bool
     r2 :: generator__gen
     r3 :: bool
-    r4 :: int
+    r4 :: short_int
     r5 :: bool
 L0:
     r0 = generator__env()
@@ -1217,20 +1227,20 @@ def generator__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, trace
     r3, r4 :: bool
     r5 :: normal_generator_obj
     r6, r7 :: bool
-    r8 :: int
+    r8 :: short_int
     r9, r10, r11 :: object
     r12 :: int
     r13 :: object
-    r14 :: int
+    r14 :: short_int
     r15 :: bool
     r16 :: None
     r17, r18 :: bool
     r19, r20 :: None
-    r21 :: int
+    r21 :: short_int
     r22, r23 :: bool
-    r24 :: int
+    r24 :: short_int
     r25 :: bool
-    r26 :: int
+    r26 :: short_int
     r27, r28 :: bool
 L0:
     r0 = __mypyc_self__.__mypyc_env__
@@ -1250,7 +1260,7 @@ L3:
 L4:
     r8 = 1
     r9 = r0.normal
-    r10 = box(int, r8)
+    r10 = box(short_int, r8)
     r11 = py_call(r9, r10)
     r12 = unbox(int, r11)
     r13 = box(int, r12)
@@ -1318,7 +1328,7 @@ def generator(a):
     r1 :: bool
     r2 :: generator__gen
     r3 :: bool
-    r4 :: int
+    r4 :: short_int
     r5 :: bool
 L0:
     r0 = generator__env()
@@ -1353,25 +1363,25 @@ def generator_normal_gen.__mypyc_generator_helper__(__mypyc_self__, type, value,
     r6, r7 :: bool
     r8 :: int
     r9 :: object
-    r10 :: int
+    r10 :: short_int
     r11 :: bool
     r12 :: None
     r13, r14 :: bool
     r15 :: None
     r16 :: int
     r17 :: object
-    r18 :: int
+    r18 :: short_int
     r19 :: bool
     r20 :: None
     r21, r22 :: bool
     r23, r24 :: None
-    r25 :: int
+    r25 :: short_int
     r26, r27 :: bool
-    r28 :: int
+    r28 :: short_int
     r29 :: bool
-    r30 :: int
+    r30 :: short_int
     r31 :: bool
-    r32 :: int
+    r32 :: short_int
     r33, r34 :: bool
 L0:
     r0 = __mypyc_self__.__mypyc_env__
@@ -1478,7 +1488,7 @@ def generator_normal_obj.__call__(__mypyc_self__, x):
     r3, r4 :: bool
     r5 :: generator_normal_gen
     r6 :: bool
-    r7 :: int
+    r7 :: short_int
     r8 :: bool
 L0:
     r0 = __mypyc_self__.__mypyc_env__
@@ -1540,7 +1550,9 @@ def inner_triple_generator_obj.__call__(__mypyc_self__):
     r0 :: generator_triple_env
     r1 :: triple__env
     r2, inner :: object
-    r3, r4, r5 :: int
+    r3 :: int
+    r4 :: short_int
+    r5 :: int
     r6 :: bool
     r7 :: int
 L0:
@@ -1563,25 +1575,26 @@ def generator_triple_gen.__mypyc_generator_helper__(__mypyc_self__, type, value,
     r4, generator :: object
     r5 :: None
     r6, r7 :: bool
-    r8 :: int
+    r8 :: short_int
     r9 :: bool
     r10 :: inner_triple_generator_obj
     r11, r12 :: bool
-    r13, r14 :: int
+    r13 :: int
+    r14 :: short_int
     r15 :: bool
     r16, r17 :: object
     r18 :: int
     r19 :: object
-    r20 :: int
+    r20 :: short_int
     r21 :: bool
     r22 :: None
     r23, r24 :: bool
     r25, r26 :: None
-    r27 :: int
+    r27 :: short_int
     r28, r29 :: bool
-    r30 :: int
+    r30 :: short_int
     r31 :: bool
-    r32 :: int
+    r32 :: short_int
     r33, r34 :: bool
 L0:
     r0 = __mypyc_self__.__mypyc_env__
@@ -1683,7 +1696,7 @@ def generator_triple_obj.__call__(__mypyc_self__):
     r3 :: bool
     r4 :: generator_triple_gen
     r5 :: bool
-    r6 :: int
+    r6 :: short_int
     r7 :: bool
 L0:
     r0 = __mypyc_self__.__mypyc_env__
@@ -1731,25 +1744,29 @@ def recursive_outer_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, 
     r4, recursive :: object
     r5 :: None
     r6, r7 :: bool
-    r8, r9 :: int
+    r8 :: int
+    r9 :: short_int
     r10 :: bool
-    r11, r12 :: int
+    r11 :: short_int
+    r12 :: int
     r13, r14 :: bool
     r15, r16 :: int
     r17 :: bool
     r18 :: int
     r19 :: object
-    r20 :: int
+    r20 :: short_int
     r21 :: bool
     r22 :: None
     r23, r24 :: bool
     r25 :: None
-    r26, r27, r28 :: int
+    r26 :: int
+    r27 :: short_int
+    r28 :: int
     r29 :: bool
     r30 :: None
-    r31 :: int
+    r31 :: short_int
     r32, r33 :: bool
-    r34 :: int
+    r34 :: short_int
     r35, r36, r37 :: object
     r38, r39 :: bool
     r40, r41 :: object
@@ -1757,20 +1774,20 @@ def recursive_outer_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, 
     r43 :: bool
     r44 :: int
     r45 :: object
-    r46 :: int
+    r46 :: short_int
     r47 :: bool
     r48 :: None
     r49, r50 :: bool
     r51 :: None
     r52 :: bool
     r53 :: None
-    r54 :: int
+    r54 :: short_int
     r55, r56 :: bool
-    r57 :: int
+    r57 :: short_int
     r58 :: bool
-    r59 :: int
+    r59 :: short_int
     r60 :: bool
-    r61 :: int
+    r61 :: short_int
     r62, r63 :: bool
 L0:
     r0 = __mypyc_self__.__mypyc_env__
@@ -1833,7 +1850,7 @@ L13:
     unreachable
 L14:
     r34 = 5
-    r35 = box(int, r34)
+    r35 = box(short_int, r34)
     r36 = py_call(recursive, r35)
     r37 = iter r36 :: object
     r0.__mypyc_temp__1 = r36; r38 = is_error
@@ -1923,7 +1940,7 @@ def recursive_outer_obj.__call__(__mypyc_self__, n):
     r3, r4 :: bool
     r5 :: recursive_outer_gen
     r6 :: bool
-    r7 :: int
+    r7 :: short_int
     r8 :: bool
 L0:
     r0 = __mypyc_self__.__mypyc_env__
@@ -1941,7 +1958,7 @@ def outer():
     r0 :: outer__env
     r1 :: recursive_outer_obj
     r2, r3 :: bool
-    r4 :: int
+    r4 :: short_int
     r5, r6, r7 :: object
 L0:
     r0 = outer__env()
@@ -1950,7 +1967,7 @@ L0:
     r0.recursive = r1; r3 = is_error
     r4 = 10
     r5 = r0.recursive
-    r6 = box(int, r4)
+    r6 = box(short_int, r4)
     r7 = py_call(r5, r6)
     return r7
 
@@ -1975,16 +1992,16 @@ def yield_try_finally__gen.__mypyc_generator_helper__(__mypyc_self__, type, valu
     r1 :: int
     r2 :: None
     r3, r4 :: bool
-    r5 :: int
+    r5 :: short_int
     r6 :: object
-    r7 :: int
+    r7 :: short_int
     r8 :: bool
     r9 :: None
     r10, r11 :: bool
     r12 :: None
-    r13 :: int
+    r13 :: short_int
     r14 :: object
-    r15 :: int
+    r15 :: short_int
     r16 :: bool
     r17 :: None
     r18, r19 :: bool
@@ -2007,16 +2024,16 @@ def yield_try_finally__gen.__mypyc_generator_helper__(__mypyc_self__, type, valu
     r39, r40 :: object
     r41 :: None
     r42 :: bool
-    r43 :: int
+    r43 :: short_int
     r44, r45, r46 :: bool
     r47 :: None
-    r48 :: int
+    r48 :: short_int
     r49, r50 :: bool
-    r51 :: int
+    r51 :: short_int
     r52 :: bool
-    r53 :: int
+    r53 :: short_int
     r54 :: bool
-    r55 :: int
+    r55 :: short_int
     r56, r57 :: bool
 L0:
     r0 = __mypyc_self__.__mypyc_env__
@@ -2034,7 +2051,7 @@ L4:
 L5:
 L6:
     r5 = 1
-    r6 = box(int, r5)
+    r6 = box(short_int, r5)
     r7 = 1
     r0.__mypyc_next_label__ = r7; r8 = is_error
     return r6
@@ -2049,7 +2066,7 @@ L9:
     r12 = None
 L10:
     r13 = 2
-    r14 = box(int, r13)
+    r14 = box(short_int, r13)
     r15 = 2
     r0.__mypyc_next_label__ = r15; r16 = is_error
     return r14
@@ -2183,7 +2200,7 @@ def yield_try_finally():
     r0 :: yield_try_finally__env
     r1 :: yield_try_finally__gen
     r2 :: bool
-    r3 :: int
+    r3 :: short_int
     r4 :: bool
 L0:
     r0 = yield_try_finally__env()

--- a/test-data/genops-generics.test
+++ b/test-data/genops-generics.test
@@ -15,7 +15,7 @@ L0:
     return x
 def g(x):
     x :: list
-    r0 :: int
+    r0 :: short_int
     r1 :: object
     r2 :: list
 L0:
@@ -52,10 +52,10 @@ def f() -> None:
 [out]
 def f():
     r0, c :: C
-    r1 :: int
+    r1 :: short_int
     r2 :: object
     r3 :: bool
-    r4 :: int
+    r4 :: short_int
     r5 :: object
     r6, r7 :: int
     r8 :: None
@@ -63,7 +63,7 @@ L0:
     r0 = C()
     c = r0
     r1 = 1
-    r2 = box(int, r1)
+    r2 = box(short_int, r1)
     c.x = r2; r3 = is_error
     r4 = 2
     r5 = c.x
@@ -115,10 +115,12 @@ L0:
 def f(x):
     x :: C
     r0 :: object
-    r1, y, r2, r3 :: int
+    r1, y :: int
+    r2 :: short_int
+    r3 :: int
     r4 :: object
     r5 :: None
-    r6 :: int
+    r6 :: short_int
     r7 :: object
     r8 :: C
     r9 :: None
@@ -131,7 +133,7 @@ L0:
     r4 = box(int, r3)
     r5 = x.set(r4)
     r6 = 2
-    r7 = box(int, r6)
+    r7 = box(short_int, r6)
     r8 = C(r7)
     x = r8
     r9 = None

--- a/test-data/genops-lists.test
+++ b/test-data/genops-lists.test
@@ -5,7 +5,7 @@ def f(x: List[int]) -> int:
 [out]
 def f(x):
     x :: list
-    r0 :: int
+    r0 :: short_int
     r1 :: object
     r2 :: int
 L0:
@@ -21,7 +21,7 @@ def f(x: List[List[int]]) -> List[int]:
 [out]
 def f(x):
     x :: list
-    r0 :: int
+    r0 :: short_int
     r1 :: object
     r2 :: list
 L0:
@@ -37,10 +37,10 @@ def f(x: List[List[int]]) -> int:
 [out]
 def f(x):
     x :: list
-    r0 :: int
+    r0 :: short_int
     r1 :: object
     r2 :: list
-    r3 :: int
+    r3 :: short_int
     r4 :: object
     r5 :: int
 L0:
@@ -59,14 +59,14 @@ def f(x: List[int]) -> None:
 [out]
 def f(x):
     x :: list
-    r0, r1 :: int
+    r0, r1 :: short_int
     r2 :: object
     r3 :: bool
     r4 :: None
 L0:
     r0 = 1
     r1 = 0
-    r2 = box(int, r0)
+    r2 = box(short_int, r0)
     r3 = x.__setitem__(r1, r2) :: list
     r4 = None
     return r4
@@ -91,15 +91,15 @@ def f() -> None:
     x: List[int] = [1, 2]
 [out]
 def f():
-    r0, r1 :: int
+    r0, r1 :: short_int
     r2, r3 :: object
     r4, x :: list
     r5 :: None
 L0:
     r0 = 1
     r1 = 2
-    r2 = box(int, r0)
-    r3 = box(int, r1)
+    r2 = box(short_int, r0)
+    r3 = box(short_int, r1)
     r4 = [r2, r3]
     x = r4
     r5 = None
@@ -113,9 +113,9 @@ def f(a: List[int]) -> None:
 [out]
 def f(a):
     a :: list
-    r0 :: int
+    r0 :: short_int
     r1, b :: list
-    r2, r3 :: int
+    r2, r3 :: short_int
     r4 :: object
     r5, r6 :: list
     r7 :: None
@@ -125,7 +125,7 @@ L0:
     b = r1
     r2 = 3
     r3 = 4
-    r4 = box(int, r3)
+    r4 = box(short_int, r3)
     r5 = [r4]
     r6 = r2 * r5 :: list
     b = r6
@@ -139,7 +139,7 @@ def f(a: List[int]) -> int:
 [out]
 def f(a):
     a :: list
-    r0 :: int
+    r0 :: short_int
 L0:
     r0 = len a :: list
     return r0
@@ -171,13 +171,14 @@ def increment(l: List[int]) -> List[int]:
 [out]
 def increment(l):
     l :: list
-    r0, r1, i :: int
+    r0, r1 :: short_int
+    i :: int
     r2 :: bool
     r3 :: object
-    r4 :: int
+    r4 :: short_int
     r5, r6 :: object
     r7 :: bool
-    r8, r9 :: int
+    r8, r9 :: short_int
 L0:
     r0 = 0
     r1 = len l :: list
@@ -188,12 +189,12 @@ L1:
 L2:
     r3 = l[i] :: list
     r4 = 1
-    r5 = box(int, r4)
+    r5 = box(short_int, r4)
     r6 = r3 += r5
     r7 = l.__setitem__(i, r6) :: list
 L3:
     r8 = 1
-    r9 = i + r8 :: int
+    r9 = i + r8 :: short_int
     i = r9
     goto L1
 L4:
@@ -206,7 +207,7 @@ def f() -> None:
 [out]
 def f():
     r0, x :: list
-    r1 :: int
+    r1 :: short_int
     r2 :: object
     r3 :: bool
     r4, r5 :: None
@@ -214,7 +215,7 @@ L0:
     r0 = []
     x = r0
     r1 = 1
-    r2 = box(int, r1)
+    r2 = box(short_int, r1)
     r3 = x.append(r2) :: list
     r4 = None
     r5 = None

--- a/test-data/genops-nested.test
+++ b/test-data/genops-nested.test
@@ -341,9 +341,10 @@ def inner_b_obj.__call__(__mypyc_self__):
     __mypyc_self__ :: inner_b_obj
     r0 :: b__env
     r1, inner :: object
-    r2 :: int
+    r2 :: short_int
     r3 :: bool
-    r4, foo, r5 :: int
+    r4 :: short_int
+    foo, r5 :: int
 L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.inner
@@ -356,7 +357,7 @@ L0:
     return r5
 def b():
     r0 :: b__env
-    r1 :: int
+    r1 :: short_int
     r2 :: bool
     r3 :: inner_b_obj
     r4, r5 :: bool
@@ -510,7 +511,9 @@ def b_a_obj.__call__(__mypyc_self__):
     r1, b :: object
     r2 :: b_a_env
     r3 :: bool
-    r4, r5, r6 :: int
+    r4 :: int
+    r5 :: short_int
+    r6 :: int
     r7 :: bool
     r8 :: c_a_b_obj
     r9, r10 :: bool
@@ -535,7 +538,7 @@ L0:
     return r13
 def a():
     r0 :: a__env
-    r1 :: int
+    r1 :: short_int
     r2 :: bool
     r3 :: b_a_obj
     r4, r5 :: bool
@@ -676,7 +679,9 @@ def foo_f_obj.__call__(__mypyc_self__):
     __mypyc_self__ :: foo_f_obj
     r0 :: f__env
     r1, foo :: object
-    r2, r3, r4 :: int
+    r2 :: int
+    r3 :: short_int
+    r4 :: int
 L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.foo
@@ -731,9 +736,10 @@ def baz_f_obj.__call__(__mypyc_self__, n):
     n :: int
     r0 :: f__env
     r1, baz :: object
-    r2 :: int
+    r2 :: short_int
     r3 :: bool
-    r4, r5, r6 :: int
+    r4, r5 :: short_int
+    r6 :: int
     r7, r8 :: object
     r9, r10 :: int
 L0:
@@ -848,9 +854,11 @@ def baz(n: int) -> int:
 
 [out]
 def baz(n):
-    n, r0 :: int
+    n :: int
+    r0 :: short_int
     r1 :: bool
-    r2, r3, r4, r5, r6 :: int
+    r2, r3 :: short_int
+    r4, r5, r6 :: int
 L0:
     r0 = 0
     r1 = n == r0 :: int

--- a/test-data/genops-optional.test
+++ b/test-data/genops-optional.test
@@ -12,7 +12,7 @@ def f(x):
     x :: union[A, None]
     r0 :: None
     r1 :: bool
-    r2, r3 :: int
+    r2, r3 :: short_int
 L0:
     r0 = None
     r1 = x is r0
@@ -51,7 +51,7 @@ def f(x):
     r1 :: bool
     r2 :: A
     r3 :: bool
-    r4, r5 :: int
+    r4, r5 :: short_int
 L0:
     r0 = None
     r1 = x is not r0
@@ -81,7 +81,7 @@ def f(x):
     x :: union[A, None]
     r0 :: None
     r1, r2 :: bool
-    r3, r4 :: int
+    r3, r4 :: short_int
 L0:
     r0 = None
     r1 = x is r0
@@ -114,10 +114,10 @@ def f(x, y, z):
     z :: union[int, None]
     r0 :: None
     r1 :: A
-    r2 :: int
+    r2 :: short_int
     r3 :: object
     r4, a :: A
-    r5 :: int
+    r5 :: short_int
     r6 :: object
     r7 :: bool
     r8 :: None
@@ -130,12 +130,12 @@ L0:
     x = r1
     x = y
     r2 = 1
-    r3 = box(int, r2)
+    r3 = box(short_int, r2)
     z = r3
     r4 = A()
     a = r4
     r5 = 1
-    r6 = box(int, r5)
+    r6 = box(short_int, r5)
     a.a = r6; r7 = is_error
     r8 = None
     a.a = r8; r9 = is_error
@@ -151,17 +151,17 @@ def f(x: List[Optional[int]]) -> None:
 [out]
 def f(x):
     x :: list
-    r0, r1 :: int
+    r0, r1 :: short_int
     r2 :: object
     r3 :: bool
     r4 :: None
-    r5 :: int
+    r5 :: short_int
     r6 :: bool
     r7 :: None
 L0:
     r0 = 0
     r1 = 0
-    r2 = box(int, r0)
+    r2 = box(short_int, r0)
     r3 = x.__setitem__(r1, r2) :: list
     r4 = None
     r5 = 1
@@ -214,7 +214,7 @@ def f(y):
     y :: int
     r0 :: None
     x :: union[int, None]
-    r1 :: int
+    r1 :: short_int
     r2 :: bool
     r3 :: object
     r4 :: None
@@ -258,7 +258,9 @@ def f(x):
     x :: union[int, A]
     r0 :: object
     r1 :: bool
-    r2, r3, r4 :: int
+    r2 :: int
+    r3 :: short_int
+    r4 :: int
     r5 :: A
     r6 :: int
 L0:
@@ -285,7 +287,7 @@ def f(x: List[Union[int, str]]) -> object:
 [out]
 def f(x):
     x :: list
-    r0 :: int
+    r0 :: short_int
     r1 :: object
     r2 :: union[int, str]
 L0:
@@ -373,13 +375,13 @@ L0:
 def C.f(self, x):
     self :: C
     x :: object
-    r0 :: int
+    r0 :: short_int
 L0:
     r0 = 0
     return r0
 def g(o):
     o :: union[A, B, C]
-    r0 :: int
+    r0 :: short_int
     r1, r2 :: object
     r3 :: bool
     r4 :: A
@@ -410,13 +412,13 @@ L2:
     if r8 goto L3 else goto L4 :: bool
 L3:
     r9 = cast(B, o)
-    r10 = box(int, r0)
+    r10 = box(short_int, r0)
     r11 = r9.f(r10)
     r1 = r11
     goto L5
 L4:
     r12 = cast(C, o)
-    r13 = box(int, r0)
+    r13 = box(short_int, r0)
     r14 = r12.f(r13)
     r15 = box(int, r14)
     r1 = r15

--- a/test-data/genops-set.test
+++ b/test-data/genops-set.test
@@ -5,25 +5,25 @@ def f() -> Set[int]:
 [out]
 def f():
     r0 :: set
-    r1 :: int
+    r1 :: short_int
     r2 :: object
     r3 :: bool
-    r4 :: int
+    r4 :: short_int
     r5 :: object
     r6 :: bool
-    r7 :: int
+    r7 :: short_int
     r8 :: object
     r9 :: bool
 L0:
     r0 = set 
     r1 = 1
-    r2 = box(int, r1)
+    r2 = box(short_int, r1)
     r3 = r0.add(r2) :: set
     r4 = 2
-    r5 = box(int, r4)
+    r5 = box(short_int, r4)
     r6 = r0.add(r5) :: set
     r7 = 3
-    r8 = box(int, r7)
+    r8 = box(short_int, r7)
     r9 = r0.add(r8) :: set
     return r0
 
@@ -57,26 +57,26 @@ def f() -> int:
 [out]
 def f():
     r0 :: set
-    r1 :: int
+    r1 :: short_int
     r2 :: object
     r3 :: bool
-    r4 :: int
+    r4 :: short_int
     r5 :: object
     r6 :: bool
-    r7 :: int
+    r7 :: short_int
     r8 :: object
     r9 :: bool
     r10 :: int
 L0:
     r0 = set 
     r1 = 1
-    r2 = box(int, r1)
+    r2 = box(short_int, r1)
     r3 = r0.add(r2) :: set
     r4 = 2
-    r5 = box(int, r4)
+    r5 = box(short_int, r4)
     r6 = r0.add(r5) :: set
     r7 = 3
-    r8 = box(int, r7)
+    r8 = box(short_int, r7)
     r9 = r0.add(r8) :: set
     r10 = len r0 :: set
     return r10
@@ -89,27 +89,27 @@ def f() -> bool:
 [out]
 def f():
     r0 :: set
-    r1 :: int
+    r1 :: short_int
     r2 :: object
     r3 :: bool
-    r4 :: int
+    r4 :: short_int
     r5 :: object
     r6 :: bool
     x :: set
-    r7 :: int
+    r7 :: short_int
     r8 :: object
     r9 :: bool
 L0:
     r0 = set 
     r1 = 3
-    r2 = box(int, r1)
+    r2 = box(short_int, r1)
     r3 = r0.add(r2) :: set
     r4 = 4
-    r5 = box(int, r4)
+    r5 = box(short_int, r4)
     r6 = r0.add(r5) :: set
     x = r0
     r7 = 5
-    r8 = box(int, r7)
+    r8 = box(short_int, r7)
     r9 = r8 in x :: set
     return r9
 
@@ -122,7 +122,7 @@ def f() -> Set[int]:
 [out]
 def f():
     r0, x :: set
-    r1 :: int
+    r1 :: short_int
     r2 :: object
     r3 :: bool
     r4 :: None
@@ -130,7 +130,7 @@ L0:
     r0 = set 
     x = r0
     r1 = 1
-    r2 = box(int, r1)
+    r2 = box(short_int, r1)
     r3 = x.remove(r2) :: set
     r4 = None
     return x
@@ -144,7 +144,7 @@ def f() -> Set[int]:
 [out]
 def f():
     r0, x :: set
-    r1 :: int
+    r1 :: short_int
     r2 :: object
     r3 :: bool
     r4 :: None
@@ -152,7 +152,7 @@ L0:
     r0 = set 
     x = r0
     r1 = 1
-    r2 = box(int, r1)
+    r2 = box(short_int, r1)
     r3 = x.discard(r2) :: set
     r4 = None
     return x
@@ -166,7 +166,7 @@ def f() -> Set[int]:
 [out]
 def f():
     r0, x :: set
-    r1 :: int
+    r1 :: short_int
     r2 :: object
     r3 :: bool
     r4 :: None
@@ -174,7 +174,7 @@ L0:
     r0 = set 
     x = r0
     r1 = 1
-    r2 = box(int, r1)
+    r2 = box(short_int, r1)
     r3 = x.add(r2) :: set
     r4 = None
     return x

--- a/test-data/genops-statements.test
+++ b/test-data/genops-statements.test
@@ -5,9 +5,13 @@ def f() -> None:
         x = x + i
 [out]
 def f():
-    r0, x, r1, r2, i :: int
+    r0 :: short_int
+    x :: int
+    r1, r2 :: short_int
+    i :: int
     r3 :: bool
-    r4, r5, r6 :: int
+    r4 :: int
+    r5, r6 :: short_int
     r7 :: None
 L0:
     r0 = 0
@@ -23,7 +27,7 @@ L2:
     x = r4
 L3:
     r5 = 1
-    r6 = i + r5 :: int
+    r6 = i + r5 :: short_int
     i = r6
     goto L1
 L4:
@@ -37,7 +41,9 @@ def f() -> None:
       break
 [out]
 def f():
-    r0, n, r1 :: int
+    r0 :: short_int
+    n :: int
+    r1 :: short_int
     r2 :: bool
     r3 :: None
 L0:
@@ -58,9 +64,10 @@ def f() -> None:
         break
 [out]
 def f():
-    r0, r1, n :: int
+    r0, r1 :: short_int
+    n :: int
     r2 :: bool
-    r3, r4 :: int
+    r3, r4 :: short_int
     r5 :: None
 L0:
     r0 = 0
@@ -73,7 +80,7 @@ L2:
     goto L4
 L3:
     r3 = 1
-    r4 = n + r3 :: int
+    r4 = n + r3 :: short_int
     n = r4
     goto L1
 L4:
@@ -89,9 +96,11 @@ def f() -> None:
         break
 [out]
 def f():
-    r0, n, r1 :: int
+    r0 :: short_int
+    n :: int
+    r1 :: short_int
     r2 :: bool
-    r3 :: int
+    r3 :: short_int
     r4 :: bool
     r5 :: None
 L0:
@@ -119,7 +128,9 @@ def f() -> None:
       continue
 [out]
 def f():
-    r0, n, r1 :: int
+    r0 :: short_int
+    n :: int
+    r1 :: short_int
     r2 :: bool
     r3 :: None
 L0:
@@ -141,9 +152,10 @@ def f() -> None:
         continue
 [out]
 def f():
-    r0, r1, n :: int
+    r0, r1 :: short_int
+    n :: int
     r2 :: bool
-    r3, r4 :: int
+    r3, r4 :: short_int
     r5 :: None
 L0:
     r0 = 0
@@ -155,7 +167,7 @@ L1:
 L2:
 L3:
     r3 = 1
-    r4 = n + r3 :: int
+    r4 = n + r3 :: short_int
     n = r4
     goto L1
 L4:
@@ -171,9 +183,11 @@ def f() -> None:
         continue
 [out]
 def f():
-    r0, n, r1 :: int
+    r0 :: short_int
+    n :: int
+    r1 :: short_int
     r2 :: bool
-    r3 :: int
+    r3 :: short_int
     r4 :: bool
     r5 :: None
 L0:
@@ -207,10 +221,13 @@ def f(ls: List[int]) -> int:
 [out]
 def f(ls):
     ls :: list
-    r0, y, r1, r2, r3 :: int
+    r0 :: short_int
+    y :: int
+    r1, r2, r3 :: short_int
     r4 :: bool
     r5 :: object
-    x, r6, r7, r8, r9 :: int
+    x, r6, r7 :: int
+    r8, r9 :: short_int
 L0:
     r0 = 0
     y = r0
@@ -218,7 +235,7 @@ L0:
     r2 = r1
 L1:
     r3 = len ls :: list
-    r4 = r2 < r3 :: int
+    r4 = r2 < r3 :: short_int
     if r4 goto L2 else goto L4 :: bool
 L2:
     r5 = ls[r2] :: list
@@ -228,7 +245,7 @@ L2:
     y = r7
 L3:
     r8 = 1
-    r9 = r2 + r8 :: int
+    r9 = r2 + r8 :: short_int
     r2 = r9
     goto L1
 L4:
@@ -280,11 +297,15 @@ def sum_over_even_values(d: Dict[int, int]) -> int:
 [out]
 def sum_over_even_values(d):
     d :: dict
-    r0, s :: int
+    r0 :: short_int
+    s :: int
     r1, r2 :: object
     key, r3 :: int
     r4, r5 :: object
-    r6, r7, r8, r9 :: int
+    r6 :: int
+    r7 :: short_int
+    r8 :: int
+    r9 :: short_int
     r10 :: bool
     r11, r12 :: object
     r13, r14 :: int
@@ -456,7 +477,9 @@ def multi_assign(t, a, l):
     t :: tuple[int, tuple[str, object]]
     a :: A
     l :: list
-    z, r0, r1 :: int
+    z :: int
+    r0 :: short_int
+    r1 :: int
     r2 :: bool
     r3 :: tuple[str, object]
     r4 :: str
@@ -493,7 +516,7 @@ def complex_msg(x: Optional[str], s: str) -> None:
 [out]
 def no_msg(x):
     x, r0 :: bool
-    r1 :: int
+    r1 :: short_int
 L0:
     if x goto L2 else goto L1 :: bool
 L1:
@@ -505,7 +528,7 @@ L2:
 def literal_msg(x):
     x :: object
     r0, r1 :: bool
-    r2 :: int
+    r2 :: short_int
 L0:
     r0 = bool x :: object
     if r0 goto L2 else goto L1 :: bool
@@ -571,30 +594,30 @@ def delAttributeMultiple() -> None:
     del dummy.x, dummy.y
 [out]
 def delList():
-    r0, r1 :: int
+    r0, r1 :: short_int
     r2, r3 :: object
     r4, l :: list
-    r5 :: int
+    r5 :: short_int
     r6 :: object
     r7 :: bool
     r8 :: None
 L0:
     r0 = 1
     r1 = 2
-    r2 = box(int, r0)
-    r3 = box(int, r1)
+    r2 = box(short_int, r0)
+    r3 = box(short_int, r1)
     r4 = [r2, r3]
     l = r4
     r5 = 1
-    r6 = box(int, r5)
+    r6 = box(short_int, r5)
     r7 = l.__delitem__(r6) :: object
     r8 = None
     return r8
 def delDict():
     r0 :: str
-    r1 :: int
+    r1 :: short_int
     r2 :: str
-    r3 :: int
+    r3 :: short_int
     r4 :: dict
     r5 :: object
     r6 :: bool
@@ -610,9 +633,9 @@ L0:
     r2 = unicode_2 :: static  ('two')
     r3 = 2
     r4 = {}
-    r5 = box(int, r1)
+    r5 = box(short_int, r1)
     r6 = r4.__setitem__(r0, r5) :: dict
-    r7 = box(int, r3)
+    r7 = box(short_int, r3)
     r8 = r4.__setitem__(r2, r7) :: dict
     d = r4
     r9 = unicode_1 :: static  ('one')
@@ -620,16 +643,16 @@ L0:
     r11 = None
     return r11
 def delListMultiple():
-    r0, r1, r2, r3, r4, r5, r6 :: int
+    r0, r1, r2, r3, r4, r5, r6 :: short_int
     r7, r8, r9, r10, r11, r12, r13 :: object
     r14, l :: list
-    r15 :: int
+    r15 :: short_int
     r16 :: object
     r17 :: bool
-    r18 :: int
+    r18 :: short_int
     r19 :: object
     r20 :: bool
-    r21 :: int
+    r21 :: short_int
     r22 :: object
     r23 :: bool
     r24 :: None
@@ -641,35 +664,35 @@ L0:
     r4 = 5
     r5 = 6
     r6 = 7
-    r7 = box(int, r0)
-    r8 = box(int, r1)
-    r9 = box(int, r2)
-    r10 = box(int, r3)
-    r11 = box(int, r4)
-    r12 = box(int, r5)
-    r13 = box(int, r6)
+    r7 = box(short_int, r0)
+    r8 = box(short_int, r1)
+    r9 = box(short_int, r2)
+    r10 = box(short_int, r3)
+    r11 = box(short_int, r4)
+    r12 = box(short_int, r5)
+    r13 = box(short_int, r6)
     r14 = [r7, r8, r9, r10, r11, r12, r13]
     l = r14
     r15 = 1
-    r16 = box(int, r15)
+    r16 = box(short_int, r15)
     r17 = l.__delitem__(r16) :: object
     r18 = 2
-    r19 = box(int, r18)
+    r19 = box(short_int, r18)
     r20 = l.__delitem__(r19) :: object
     r21 = 3
-    r22 = box(int, r21)
+    r22 = box(short_int, r21)
     r23 = l.__delitem__(r22) :: object
     r24 = None
     return r24
 def delDictMultiple():
     r0 :: str
-    r1 :: int
+    r1 :: short_int
     r2 :: str
-    r3 :: int
+    r3 :: short_int
     r4 :: str
-    r5 :: int
+    r5 :: short_int
     r6 :: str
-    r7 :: int
+    r7 :: short_int
     r8 :: dict
     r9 :: object
     r10 :: bool
@@ -695,13 +718,13 @@ L0:
     r6 = unicode_4 :: static  ('four')
     r7 = 4
     r8 = {}
-    r9 = box(int, r1)
+    r9 = box(short_int, r1)
     r10 = r8.__setitem__(r0, r9) :: dict
-    r11 = box(int, r3)
+    r11 = box(short_int, r3)
     r12 = r8.__setitem__(r2, r11) :: dict
-    r13 = box(int, r5)
+    r13 = box(short_int, r5)
     r14 = r8.__setitem__(r4, r13) :: dict
-    r15 = box(int, r7)
+    r15 = box(short_int, r7)
     r16 = r8.__setitem__(r6, r15) :: dict
     d = r8
     r17 = unicode_1 :: static  ('one')
@@ -721,7 +744,7 @@ L0:
     r2 = None
     return r2
 def delAttribute():
-    r0, r1 :: int
+    r0, r1 :: short_int
     r2, dummy :: Dummy
     r3 :: str
     r4 :: bool
@@ -736,7 +759,7 @@ L0:
     r5 = None
     return r5
 def delAttributeMultiple():
-    r0, r1 :: int
+    r0, r1 :: short_int
     r2, dummy :: Dummy
     r3 :: str
     r4 :: bool

--- a/test-data/genops-tuple.test
+++ b/test-data/genops-tuple.test
@@ -22,7 +22,7 @@ def f() -> int:
 [out]
 def f():
     r0 :: bool
-    r1 :: int
+    r1 :: short_int
     r2, t :: tuple[bool, int]
     r3 :: int
 L0:
@@ -40,7 +40,7 @@ def f(x: Tuple[bool, bool, int]) -> int:
 [out]
 def f(x):
     x :: tuple[bool, bool, int]
-    r0 :: int
+    r0 :: short_int
 L0:
     r0 = 3
     return r0
@@ -53,7 +53,7 @@ def f(x: List[bool]) -> bool:
 def f(x):
     x :: list
     r0 :: tuple
-    r1 :: int
+    r1 :: short_int
     r2 :: object
     r3 :: bool
 L0:
@@ -82,11 +82,11 @@ def f() -> int:
     return t[1]
 [out]
 def f():
-    r0, r1 :: int
+    r0, r1 :: short_int
     r2 :: tuple[int, int]
     t :: tuple
     r3 :: object
-    r4 :: int
+    r4 :: short_int
     r5 :: object
     r6 :: int
 L0:

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -5,7 +5,7 @@ def f() -> int:
     return 1
 [out]
 def f():
-    r0 :: int
+    r0 :: short_int
 L0:
     r0 = 1
     return r0
@@ -16,7 +16,8 @@ def f() -> int:
     return x
 [out]
 def f():
-    r0, x :: int
+    r0 :: short_int
+    x :: int
 L0:
     r0 = 1
     x = r0
@@ -30,7 +31,8 @@ def f() -> int:
     return x
 [out]
 def f():
-    r0, x, y :: int
+    r0 :: short_int
+    x, y :: int
 L0:
     r0 = 1
     x = r0
@@ -46,7 +48,8 @@ def f() -> int:
     return y + z
 [out]
 def f():
-    r0, x, y, z, r1 :: int
+    r0 :: short_int
+    x, y, z, r1 :: int
 L0:
     r0 = 1
     x = r0
@@ -67,7 +70,11 @@ def f() -> int:
     return y
 [out]
 def f():
-    r0, x, r1, y, r2 :: int
+    r0 :: short_int
+    x :: int
+    r1 :: short_int
+    y :: int
+    r2 :: short_int
     r3 :: bool
 L0:
     r0 = 1
@@ -95,7 +102,9 @@ def f(a: int, b: int) -> int:
     return y
 [out]
 def f(a, b):
-    a, b, r0, r1, x, r2, y :: int
+    a, b :: int
+    r0 :: short_int
+    r1, x, r2, y :: int
 L0:
     r0 = 1
     r1 = a + r0 :: int
@@ -113,7 +122,9 @@ def f(a: int) -> int:
     return x + y
 [out]
 def f(a):
-    a, x, y, r0, r1 :: int
+    a, x, y :: int
+    r0 :: short_int
+    r1 :: int
 L0:
     inc_ref a :: int
     x = a
@@ -134,7 +145,9 @@ def f(a: int) -> int:
     return y
 [out]
 def f(a):
-    a, r0, y :: int
+    a :: int
+    r0 :: short_int
+    y :: int
 L0:
     r0 = 1
     a = r0
@@ -149,7 +162,8 @@ def f(a: int) -> int:
     return a
 [out]
 def f(a):
-    a, r0, r1, r2 :: int
+    a :: int
+    r0, r1, r2 :: short_int
 L0:
     r0 = 1
     a = r0
@@ -169,7 +183,9 @@ def f(a: int) -> int:
     return a
 [out]
 def f(a):
-    a, r0, x, y :: int
+    a :: int
+    r0 :: short_int
+    x, y :: int
 L0:
     r0 = 1
     x = r0
@@ -201,7 +217,10 @@ def f(a: int) -> int:
 def f(a):
     a :: int
     r0 :: bool
-    r1, r2, x, r3, r4, y :: int
+    r1, r2 :: short_int
+    x :: int
+    r3 :: short_int
+    r4, y :: int
 L0:
     r0 = a == a :: int
     if r0 goto L1 else goto L2 :: bool
@@ -236,7 +255,10 @@ def f(a: int) -> int:
 def f(a):
     a :: int
     r0 :: bool
-    r1, x, r2, r3, r4, y :: int
+    r1 :: short_int
+    x :: int
+    r2, r3 :: short_int
+    r4, y :: int
 L0:
     r0 = a == a :: int
     if r0 goto L1 else goto L2 :: bool
@@ -267,7 +289,7 @@ def f(a: int) -> int:
 def f(a):
     a :: int
     r0 :: bool
-    r1 :: int
+    r1 :: short_int
 L0:
     r0 = a == a :: int
     if r0 goto L1 else goto L3 :: bool
@@ -289,7 +311,9 @@ def f(a: int) -> int:
 -- This is correct but bad code
 [out]
 def f(a):
-    a, r0, x, r1 :: int
+    a :: int
+    r0 :: short_int
+    x, r1 :: int
 L0:
     inc_ref a :: int
     a = a
@@ -311,7 +335,13 @@ def f(a: int) -> int:
     return a + x
 [out]
 def f(a):
-    a, r0, r1, r2, x, r3, r4, r5 :: int
+    a :: int
+    r0 :: short_int
+    r1 :: int
+    r2 :: short_int
+    x :: int
+    r3 :: short_int
+    r4, r5 :: int
 L0:
     r0 = 1
     r1 = a + r0 :: int
@@ -333,7 +363,10 @@ def f() -> None:
     x = x + 1
 [out]
 def f():
-    r0, x, r1, r2 :: int
+    r0 :: short_int
+    x :: int
+    r1 :: short_int
+    r2 :: int
     r3 :: None
 L0:
     r0 = 1
@@ -353,7 +386,10 @@ def f() -> None:
     x = y + 1
 [out]
 def f():
-    r0, y, r1, r2, x :: int
+    r0 :: short_int
+    y :: int
+    r1 :: short_int
+    r2, x :: int
     r3 :: None
 L0:
     r0 = 1
@@ -408,7 +444,9 @@ def f(a: int) -> None:
     z = y + y
 [out]
 def f(a):
-    a, r0, x, r1, y, r2, z :: int
+    a, r0, x :: int
+    r1 :: short_int
+    y, r2, z :: int
     r3 :: None
 L0:
     r0 = a + a :: int
@@ -431,7 +469,9 @@ def f(a: int) -> None:
     x = x + x
 [out]
 def f(a):
-    a, r0, r1, x, r2 :: int
+    a, r0 :: int
+    r1 :: short_int
+    x, r2 :: int
     r3 :: None
 L0:
     r0 = a + a :: int
@@ -458,9 +498,15 @@ def f() -> int:
     return x + y - a
 [out]
 def f():
-    r0, x, r1, y, r2, z :: int
+    r0 :: short_int
+    x :: int
+    r1 :: short_int
+    y :: int
+    r2 :: short_int
+    z :: int
     r3 :: bool
-    r4, a, r5, r6 :: int
+    r4 :: short_int
+    a, r5, r6 :: int
 L0:
     r0 = 1
     x = r0
@@ -500,9 +546,15 @@ def f(a: int) -> int:
     return sum
 [out]
 def f(a):
-    a, r0, sum, r1, i :: int
+    a :: int
+    r0 :: short_int
+    sum :: int
+    r1 :: short_int
+    i :: int
     r2 :: bool
-    r3, r4, r5 :: int
+    r3 :: int
+    r4 :: short_int
+    r5 :: int
 L0:
     r0 = 0
     sum = r0
@@ -531,7 +583,9 @@ def f(a: int) -> int:
     return f(a + 1)
 [out]
 def f(a):
-    a, r0, r1, r2 :: int
+    a :: int
+    r0 :: short_int
+    r1, r2 :: int
 L0:
     r0 = 1
     r1 = a + r0 :: int
@@ -548,15 +602,15 @@ def f() -> int:
     return 0
 [out]
 def f():
-    r0, r1 :: int
+    r0, r1 :: short_int
     r2, r3 :: object
     r4, a :: list
-    r5 :: int
+    r5 :: short_int
 L0:
     r0 = 0
     r1 = 1
-    r2 = box(int, r0)
-    r3 = box(int, r1)
+    r2 = box(short_int, r0)
+    r3 = box(short_int, r1)
     r4 = [r2, r3]
     a = r4
     dec_ref a
@@ -585,9 +639,10 @@ def f(a: List[int], b: List[int]) -> None:
 [out]
 def f(a, b):
     a, b :: list
-    r0 :: int
+    r0 :: short_int
     r1 :: object
-    r2, r3 :: int
+    r2 :: int
+    r3 :: short_int
     r4 :: object
     r5 :: bool
     r6 :: None
@@ -649,7 +704,7 @@ def f() -> None:
 def f():
     r0 :: C
     r1, a :: list
-    r2 :: int
+    r2 :: short_int
     r3 :: object
     r4, d :: C
     r5 :: None
@@ -675,7 +730,7 @@ def f(x: bool) -> int:
 [out]
 def f(x):
     x :: bool
-    r0, r1 :: int
+    r0, r1 :: short_int
 L0:
     if x goto L1 else goto L2 :: bool
 L1:
@@ -702,7 +757,7 @@ def g(x: str) -> int:
 [out]
 def g(x):
     x :: str
-    r0 :: int
+    r0 :: short_int
     r1 :: object
     r2 :: str
     r3 :: tuple[str]
@@ -717,7 +772,7 @@ L0:
     r2 = unicode_1 :: static  ('base')
     r3 = (x)
     r4 = {}
-    r5 = box(int, r0)
+    r5 = box(short_int, r0)
     r6 = r4.__setitem__(r2, r5) :: dict
     dec_ref r5
     r7 = box(tuple[str], r3)

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -76,7 +76,6 @@ L0:
     y = r1
     r2 = 1
     r3 = x == r2 :: int
-    dec_ref r2 :: int
     if r3 goto L3 else goto L4 :: bool
 L1:
     return x
@@ -100,7 +99,6 @@ def f(a, b):
 L0:
     r0 = 1
     r1 = a + r0 :: int
-    dec_ref r0 :: int
     x = r1
     r2 = x + a :: int
     dec_ref x :: int
@@ -220,7 +218,6 @@ L3:
     r3 = 1
     r4 = a + r3 :: int
     dec_ref a :: int
-    dec_ref r3 :: int
     y = r4
     return y
 L4:
@@ -255,7 +252,6 @@ L3:
     r3 = 1
     r4 = a + r3 :: int
     dec_ref a :: int
-    dec_ref r3 :: int
     y = r4
     return y
 L4:
@@ -319,14 +315,12 @@ def f(a):
 L0:
     r0 = 1
     r1 = a + r0 :: int
-    dec_ref r0 :: int
     a = r1
     r2 = 1
     x = r2
     r3 = 1
     r4 = x + r3 :: int
     dec_ref x :: int
-    dec_ref r3 :: int
     x = r4
     r5 = a + x :: int
     dec_ref a :: int
@@ -347,7 +341,6 @@ L0:
     r1 = 1
     r2 = x + r1 :: int
     dec_ref x :: int
-    dec_ref r1 :: int
     x = r2
     dec_ref x :: int
     r3 = None
@@ -368,7 +361,6 @@ L0:
     r1 = 1
     r2 = y + r1 :: int
     dec_ref y :: int
-    dec_ref r1 :: int
     x = r2
     dec_ref x :: int
     r3 = None
@@ -526,7 +518,6 @@ L2:
     r4 = 1
     r5 = i + r4 :: int
     dec_ref i :: int
-    dec_ref r4 :: int
     i = r5
     goto L1
 L3:
@@ -544,7 +535,6 @@ def f(a):
 L0:
     r0 = 1
     r1 = a + r0 :: int
-    dec_ref r0 :: int
     r2 = f(r1)
     dec_ref r1 :: int
     return r2
@@ -604,13 +594,11 @@ def f(a, b):
 L0:
     r0 = 0
     r1 = b[r0] :: list
-    dec_ref r0 :: int
     r2 = unbox(int, r1)
     dec_ref r1
     r3 = 0
     r4 = box(int, r2)
     r5 = a.__setitem__(r3, r4) :: list
-    dec_ref r3 :: int
     r6 = None
     inc_ref r6
     return r6
@@ -672,7 +660,6 @@ L0:
     r2 = 0
     r3 = a[r2] :: list
     dec_ref a
-    dec_ref r2 :: int
     r4 = cast(C, r3)
     d = r4
     dec_ref d

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -59,6 +59,7 @@ from native import count, list_iter, count_between
 count(5)
 list_iter(list(reversed(range(5))))
 count_between(11, 15)
+count_between(10**20, 10**20+3)
 [out]
 0
 1
@@ -74,6 +75,9 @@ count_between(11, 15)
 12
 13
 14
+100000000000000000000
+100000000000000000001
+100000000000000000002
 
 [case testLoopElse]
 from typing import Iterator


### PR DESCRIPTION
"Short" integers are a runtime subtype of regular ints, and can be used 
without coercion wherever an int can be used. However, they cannot be
big ints, and so do not need reference counting, and can enable some operations
to use fewer branches.

This patch currently causes the short versions of everything to appear in the IR
exactly like the old versions, to reduce test churn. I think I'll probably change that before I merge this?