### PR TITLE
Call PyObject_GetIter on the lists we produce in generators

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -3023,7 +3023,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             self.primitive_op(list_append_op, [list_ops, e], o.line)
 
         self.comprehension_helper(loop_params, gen_inner_stmts, o.line)
-        return list_ops
+        return self.primitive_op(iter_op, [list_ops], o.line)
 
     def comprehension_helper(self,
                              loop_params: List[Tuple[Lvalue, Expression, List[Expression]]],


### PR DESCRIPTION
It is still wrong to generate lists for generator comprehensions, but
at least we output the right type now.  (This lets us avoid having to
hack around this some places in mypy that call `next` directly on a
comprehension.)