### PR TITLE
Optimize isinstance() even more

### DIFF
--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -15,6 +15,8 @@ MAX_SHORT_INT = (1 << 62) - 1
 
 TOP_LEVEL_NAME = '__top_level__'  # Special function representing module top level
 
+MAX_CHILDREN = 2  # Number of children for a class to trigger fast path in isinstance() checks.
+
 
 def decorator_helper_name(func_name: str) -> str:
     return '__mypyc_{}_decorator_helper__'.format(func_name)

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -15,8 +15,8 @@ MAX_SHORT_INT = (1 << 62) - 1
 
 TOP_LEVEL_NAME = '__top_level__'  # Special function representing module top level
 
-FAST_ISINSTANCE_MAX_SUBCLASSES = 2  # Maximal number of subclasses for a class to
-                                    # trigger fast path in isinstance() checks.
+# Maximal number of subclasses for a class to trigger fast path in isinstance() checks.
+FAST_ISINSTANCE_MAX_SUBCLASSES = 2
 
 
 def decorator_helper_name(func_name: str) -> str:

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -15,7 +15,8 @@ MAX_SHORT_INT = (1 << 62) - 1
 
 TOP_LEVEL_NAME = '__top_level__'  # Special function representing module top level
 
-MAX_CHILDREN = 2  # Number of children for a class to trigger fast path in isinstance() checks.
+FAST_ISINSTANCE_MAX_SUBCLASSES = 2  # Maximal number of subclasses for a class to
+                                    # trigger fast path in isinstance() checks.
 
 
 def decorator_helper_name(func_name: str) -> str:

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -3,7 +3,7 @@
 from collections import OrderedDict
 from typing import List, Set, Dict, Optional, List, Callable, Union
 
-from mypyc.common import REG_PREFIX, STATIC_PREFIX, TYPE_PREFIX, NATIVE_PREFIX
+from mypyc.common import REG_PREFIX, STATIC_PREFIX, TYPE_PREFIX, NATIVE_PREFIX, MAX_CHILDREN
 from mypyc.ops import (
     Any, AssignmentTarget, Environment, BasicBlock, Value, Register, RType, RTuple, RInstance,
     RUnion, RPrimitive, is_int_rprimitive, is_short_int_rprimitive,
@@ -360,13 +360,20 @@ class Emitter:
         elif isinstance(typ, RInstance):
             if declare_dest:
                 self.emit_line('PyObject *{};'.format(dest))
-            if typ.class_ir.children:
+            all_types = {typ.class_ir}.union(typ.class_ir.subclasses())
+            concrete = {c for c in all_types if not c.is_trait}
+            n_types = len(concrete)
+            if n_types > MAX_CHILDREN + 1:
                 check = '(PyObject_TypeCheck({}, {}))'.format(
                     src, self.type_struct_name(typ.class_ir))
             else:
-                # If the class has no children, just check the type directly
-                check = '(Py_TYPE({}) == {})'.format(
-                    src, self.type_struct_name(typ.class_ir))
+                concrete_lst = sorted(concrete, key=lambda c: len(c.children))  # start from leafs
+                full_str = '((Py_TYPE({src}) == {targets[0]})'
+                for i in range(1, n_types):
+                    full_str += ' || (Py_TYPE({src}) == {targets[%d]})' % i
+                full_str += ')'
+                check = full_str.format(
+                    src=src, targets=[self.type_struct_name(ir) for ir in concrete_lst])
             self.emit_arg_check(src, dest, typ, check, optional)
             self.emit_lines(
                 '    {} = {};'.format(dest, src),

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -444,7 +444,8 @@ class Emitter:
             'goto {};'.format(out_label),
             '}')
         for i, item in enumerate(typ.types):
-            self.emit_cast('PyTuple_GetItem({}, {})'.format(src, i),
+            # Since we did the checks above this should never fail
+            self.emit_cast('PyTuple_GET_ITEM({}, {})'.format(src, i),
                            dest,
                            item,
                            declare_dest=False,

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -368,10 +368,11 @@ class Emitter:
                     src, self.type_struct_name(typ.class_ir))
             else:
                 concrete_lst = sorted(concrete, key=lambda c: len(c.children))  # start from leafs
-                full_str = '((Py_TYPE({src}) == {targets[0]})'
+                full_str = '(Py_TYPE({src}) == {targets[0]})'
                 for i in range(1, n_types):
                     full_str += ' || (Py_TYPE({src}) == {targets[%d]})' % i
-                full_str += ')'
+                if n_types > 1:
+                    full_str = '(%s)' % full_str
                 check = full_str.format(
                     src=src, targets=[self.type_struct_name(ir) for ir in concrete_lst])
             self.emit_arg_check(src, dest, typ, check, optional)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -47,7 +47,7 @@ from mypy.checkexpr import map_actuals_to_formals
 
 from mypyc.common import (
     ENV_ATTR_NAME, NEXT_LABEL_ATTR_NAME, TEMP_ATTR_NAME, LAMBDA_NAME,
-    MAX_SHORT_INT, TOP_LEVEL_NAME, SELF_NAME, decorator_helper_name
+    MAX_SHORT_INT, TOP_LEVEL_NAME, SELF_NAME, decorator_helper_name, MAX_CHILDREN
 )
 from mypyc.prebuildvisitor import PreBuildVisitor
 from mypyc.ops import (
@@ -91,8 +91,6 @@ from mypyc.sametype import is_same_type, is_same_method_signature
 from mypyc.crash import catch_errors
 
 GenFunc = Callable[[], None]
-
-MAX_CHILDREN = 2
 
 
 def build_ir(modules: List[MypyFile],
@@ -2001,12 +1999,12 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             return self.primitive_op(fast_isinstance_op,
                                      [obj, self.get_native_type(class_ir)],
                                      line)
-        concrete_list = sorted(concrete, key=lambda c: len(c.children))  # start from leafs
-        if not concrete_list:
+        concrete_lst = sorted(concrete, key=lambda c: len(c.children))  # start from leafs
+        if not concrete_lst:
             assert False, "No concrete classes, something is wrong"
-        type_obj = self.get_native_type(concrete_list[0])
+        type_obj = self.get_native_type(concrete_lst[0])
         ret = self.primitive_op(type_is_op, [obj, type_obj], line)
-        for c in concrete_list[1:]:
+        for c in concrete_lst[1:]:
             ret = self.primitive_op(fast_or_op,
                                     [ret, self.primitive_op(type_is_op,
                                                             [obj, self.get_native_type(c)],

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -78,7 +78,7 @@ from mypyc.ops_misc import (
     py_getattr_op, py_setattr_op, py_delattr_op,
     py_call_op, py_call_with_kwargs_op, py_method_call_op,
     fast_isinstance_op, bool_op, new_slice_op,
-    type_op, pytype_from_template_op, import_op, ellipsis_op, method_new_op, type_is_op
+    type_op, pytype_from_template_op, import_op, ellipsis_op, method_new_op, type_is_op,
 )
 from mypyc.ops_exc import (
     no_err_occurred_op, raise_exception_op, raise_exception_with_tb_op, reraise_exception_op,
@@ -1983,7 +1983,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             return self.primitive_op(false_op, [], line)
         ret = self.isinstance_native(obj, class_irs[0], line)
         for class_ir in class_irs[1:]:
-            other = lambda: self.isinstance_native(obj, class_ir, line)
+            def other() -> Value:
+                return self.isinstance_native(obj, class_ir, line)
             ret = self.shortcircuit_helper('or', bool_rprimitive, lambda: ret, other, line)
         return ret
 
@@ -2004,7 +2005,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         type_obj = self.get_native_type(concrete[0])
         ret = self.primitive_op(type_is_op, [obj, type_obj], line)
         for c in concrete[1:]:
-            other = lambda: self.primitive_op(type_is_op, [obj,self.get_native_type(c)], line)
+            def other() -> Value:
+                return self.primitive_op(type_is_op, [obj, self.get_native_type(c)], line)
             ret = self.shortcircuit_helper('or', bool_rprimitive, lambda: ret, other, line)
         return ret
 

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1448,10 +1448,11 @@ class ClassIR:
     This also describes the runtime structure of native instances.
     """
     def __init__(self, name: str, module_name: str, is_trait: bool = False,
-                 is_generated: bool = True) -> None:
+                 is_generated: bool = True, is_abstract: bool = False) -> None:
         self.name = name
         self.module_name = module_name
         self.is_trait = is_trait
+        self.is_abstract = is_abstract
         self.is_generated = is_generated
         self.inherits_python = False
         # Default empty ctor
@@ -1565,6 +1566,18 @@ class ClassIR:
             if child.children:
                 result.update(child.subclasses())
         return result
+
+    def concrete_subclasses(self) -> List['ClassIR']:
+        """Return all concrete (i.e. non-trait and non-abstract) subclasses.
+
+        Include the class itself (if concrete), and both direct and indirect
+        subclasses. Place classes with no children first.
+        """
+        all_types = {self}.union(self.subclasses())
+        concrete = {c for c in all_types if not (c.is_trait or c.is_abstract)}
+        # We place classes with no children first because they are more likely
+        # to appear in various isinstance() checks.
+        return sorted(concrete, key=lambda c: len(c.children))
 
 
 LiteralsMap = Dict[Tuple[Type[object], Union[int, float, str, bytes]], str]

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -281,6 +281,7 @@ type_is_op = custom_op(
     error_kind=ERR_NEVER,
     emit=simple_emit('{dest} = Py_TYPE({args[0]}) == (PyTypeObject *){args[1]};'))
 
+# C-level "or" operator
 fast_or_op = custom_op(
     name='fast_or',
     arg_types=[bool_rprimitive, bool_rprimitive],

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -281,6 +281,13 @@ type_is_op = custom_op(
     error_kind=ERR_NEVER,
     emit=simple_emit('{dest} = Py_TYPE({args[0]}) == (PyTypeObject *){args[1]};'))
 
+fast_or_op = custom_op(
+    name='fast_or',
+    arg_types=[bool_rprimitive, bool_rprimitive],
+    result_type=bool_rprimitive,
+    error_kind=ERR_NEVER,
+    emit=simple_emit('{dest} = {args[0]} || {args[1]};'))
+
 bool_op = func_op(
     'builtins.bool',
     arg_types=[object_rprimitive],

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -281,14 +281,6 @@ type_is_op = custom_op(
     error_kind=ERR_NEVER,
     emit=simple_emit('{dest} = Py_TYPE({args[0]}) == (PyTypeObject *){args[1]};'))
 
-# C-level "or" operator
-fast_or_op = custom_op(
-    name='fast_or',
-    arg_types=[bool_rprimitive, bool_rprimitive],
-    result_type=bool_rprimitive,
-    error_kind=ERR_NEVER,
-    emit=simple_emit('{dest} = {args[0]} || {args[1]};'))
-
 bool_op = func_op(
     'builtins.bool',
     arg_types=[object_rprimitive],

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -544,19 +544,14 @@ L2:
     r6 = A()
     return r6
 
-[case testIsInstanceFewChildren]
-from typing import Union
-from mypy_extensions import trait
-
+[case testIsInstanceFewSubclasses]
 class R: pass
-@trait
 class A(R): pass
-class B(R): pass
 
 def f(x: object) -> R:
     if isinstance(x, R):
         return x
-    return B()
+    return A()
 [out]
 def f(x):
     x, r0 :: object
@@ -564,9 +559,9 @@ def f(x):
     r2 :: object
     r3, r4 :: bool
     r5 :: R
-    r6 :: B
+    r6 :: A
 L0:
-    r0 = __main__.B :: type
+    r0 = __main__.A :: type
     r1 = type_is x, r0
     r2 = __main__.R :: type
     r3 = type_is x, r2
@@ -576,8 +571,69 @@ L1:
     r5 = cast(R, x)
     return r5
 L2:
-    r6 = B()
+    r6 = A()
     return r6
+
+[case testIsInstanceFewSubclassesTrait]
+from mypy_extensions import trait
+class B: pass
+@trait
+class R: pass
+class A(B, R): pass
+class C(B, R): pass
+
+def f(x: object) -> R:
+    if isinstance(x, R):
+        return x
+    return A()
+[out]
+def f(x):
+    x, r0 :: object
+    r1 :: bool
+    r2 :: object
+    r3, r4 :: bool
+    r5 :: R
+    r6 :: A
+L0:
+    r0 = __main__.A :: type
+    r1 = type_is x, r0
+    r2 = __main__.C :: type
+    r3 = type_is x, r2
+    r4 = fast_or r1, r3
+    if r4 goto L1 else goto L2 :: bool
+L1:
+    r5 = cast(R, x)
+    return r5
+L2:
+    r6 = A()
+    return r6
+
+[case testIsInstanceManySubclasses]
+class R: pass
+class A(R): pass
+class B(R): pass
+class C(R): pass
+
+def f(x: object) -> R:
+    if isinstance(x, R):
+        return x
+    return B()
+[out]
+def f(x):
+    x, r0 :: object
+    r1 :: bool
+    r2 :: R
+    r3 :: B
+L0:
+    r0 = __main__.R :: type
+    r1 = isinstance x, r0
+    if r1 goto L1 else goto L2 :: bool
+L1:
+    r2 = cast(R, x)
+    return r2
+L2:
+    r3 = B()
+    return r3
 
 [case testFakeSuper]
 class A:

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -525,22 +525,28 @@ def f(x: R) -> Union[A, B]:
 def f(x):
     x :: R
     r0 :: object
-    r1 :: bool
-    r2 :: object
-    r3, r4 :: bool
+    r1, r2 :: bool
+    r3 :: object
+    r4 :: bool
     r5 :: union[A, B]
     r6 :: A
 L0:
     r0 = __main__.A :: type
     r1 = type_is x, r0
-    r2 = __main__.B :: type
-    r3 = type_is x, r2
-    r4 = fast_or r1, r3
-    if r4 goto L1 else goto L2 :: bool
+    if r1 goto L1 else goto L2 :: bool
 L1:
+    r2 = r1
+    goto L3
+L2:
+    r3 = __main__.B :: type
+    r4 = type_is x, r3
+    r2 = r4
+L3:
+    if r2 goto L4 else goto L5 :: bool
+L4:
     r5 = cast(union[A, B], x)
     return r5
-L2:
+L5:
     r6 = A()
     return r6
 
@@ -555,22 +561,28 @@ def f(x: object) -> R:
 [out]
 def f(x):
     x, r0 :: object
-    r1 :: bool
-    r2 :: object
-    r3, r4 :: bool
+    r1, r2 :: bool
+    r3 :: object
+    r4 :: bool
     r5 :: R
     r6 :: A
 L0:
     r0 = __main__.A :: type
     r1 = type_is x, r0
-    r2 = __main__.R :: type
-    r3 = type_is x, r2
-    r4 = fast_or r1, r3
-    if r4 goto L1 else goto L2 :: bool
+    if r1 goto L1 else goto L2 :: bool
 L1:
+    r2 = r1
+    goto L3
+L2:
+    r3 = __main__.R :: type
+    r4 = type_is x, r3
+    r2 = r4
+L3:
+    if r2 goto L4 else goto L5 :: bool
+L4:
     r5 = cast(R, x)
     return r5
-L2:
+L5:
     r6 = A()
     return r6
 
@@ -589,24 +601,31 @@ def f(x: object) -> R:
 [out]
 def f(x):
     x, r0 :: object
-    r1 :: bool
-    r2 :: object
-    r3, r4 :: bool
+    r1, r2 :: bool
+    r3 :: object
+    r4 :: bool
     r5 :: R
     r6 :: A
 L0:
     r0 = __main__.A :: type
     r1 = type_is x, r0
-    r2 = __main__.C :: type
-    r3 = type_is x, r2
-    r4 = fast_or r1, r3
-    if r4 goto L1 else goto L2 :: bool
+    if r1 goto L1 else goto L2 :: bool
 L1:
+    r2 = r1
+    goto L3
+L2:
+    r3 = __main__.C :: type
+    r4 = type_is x, r3
+    r2 = r4
+L3:
+    if r2 goto L4 else goto L5 :: bool
+L4:
     r5 = cast(R, x)
     return r5
-L2:
+L5:
     r6 = A()
     return r6
+
 
 [case testIsInstanceManySubclasses]
 class R: pass

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -510,6 +510,75 @@ L2:
     r3 = B()
     return r3
 
+[case testIsInstanceTuple]
+from typing import Union
+class R: pass
+class A(R): pass
+class B(R): pass
+class C(R): pass
+
+def f(x: R) -> Union[A, B]:
+    if isinstance(x, (A, B)):
+        return x
+    return A()
+[out]
+def f(x):
+    x :: R
+    r0 :: object
+    r1 :: bool
+    r2 :: object
+    r3, r4 :: bool
+    r5 :: union[A, B]
+    r6 :: A
+L0:
+    r0 = __main__.A :: type
+    r1 = type_is x, r0
+    r2 = __main__.B :: type
+    r3 = type_is x, r2
+    r4 = fast_or r1, r3
+    if r4 goto L1 else goto L2 :: bool
+L1:
+    r5 = cast(union[A, B], x)
+    return r5
+L2:
+    r6 = A()
+    return r6
+
+[case testIsInstanceFewChildren]
+from typing import Union
+from mypy_extensions import trait
+
+class R: pass
+@trait
+class A(R): pass
+class B(R): pass
+
+def f(x: object) -> R:
+    if isinstance(x, R):
+        return x
+    return B()
+[out]
+def f(x):
+    x, r0 :: object
+    r1 :: bool
+    r2 :: object
+    r3, r4 :: bool
+    r5 :: R
+    r6 :: B
+L0:
+    r0 = __main__.B :: type
+    r1 = type_is x, r0
+    r2 = __main__.R :: type
+    r3 = type_is x, r2
+    r4 = fast_or r1, r3
+    if r4 goto L1 else goto L2 :: bool
+L1:
+    r5 = cast(R, x)
+    return r5
+L2:
+    r6 = B()
+    return r6
+
 [case testFakeSuper]
 class A:
     def __init__(self, x: int) -> None:

--- a/test-data/genops-optional.test
+++ b/test-data/genops-optional.test
@@ -336,7 +336,7 @@ def get(o):
     r8 :: None
 L0:
     r1 = __main__.A :: type
-    r2 = isinstance o, r1
+    r2 = type_is o, r1
     if r2 goto L1 else goto L2 :: bool
 L1:
     r3 = cast(A, o)
@@ -414,7 +414,7 @@ def g(o):
 L0:
     r0 = 1
     r2 = __main__.A :: type
-    r3 = isinstance o, r2
+    r3 = type_is o, r2
     if r3 goto L1 else goto L2 :: bool
 L1:
     r4 = cast(A, o)
@@ -424,7 +424,7 @@ L1:
     goto L5
 L2:
     r7 = __main__.B :: type
-    r8 = isinstance o, r7
+    r8 = type_is o, r7
     if r8 goto L3 else goto L4 :: bool
 L3:
     r9 = cast(B, o)
@@ -475,7 +475,7 @@ def f(o):
     r9 :: None
 L0:
     r1 = __main__.A :: type
-    r2 = isinstance o, r1
+    r2 = type_is o, r1
     if r2 goto L1 else goto L2 :: bool
 L1:
     r3 = cast(A, o)
@@ -505,7 +505,7 @@ def g(o):
     r9 :: None
 L0:
     r1 = __main__.A :: type
-    r2 = isinstance o, r1
+    r2 = type_is o, r1
     if r2 goto L1 else goto L2 :: bool
 L1:
     r3 = cast(A, o)


### PR DESCRIPTION
Fixes #413 

This PR refactors `isinstance()` and `cast()` and adds the following speed improvements:
* Add fast path if the target class has few children
* Add fast path if there are a tuple of target classes
* Use all `isinstance()` fast paths also in union destructuring and casts.

This speeds up self-check by 110ms.