### PR TITLE
Fix problems in the test suite that caused compile errors to be silent

### DIFF
--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -171,11 +171,7 @@ def heading(text: str) -> None:
     print('=' * 20 + ' ' + text + ' ' + '=' * 20)
 
 
-def show_c_error(cpath: str, output: bytes) -> None:
+def show_c(ctext: str) -> None:
     heading('Generated C')
-    with open(cpath) as f:
-        print_with_line_numbers(f.read().rstrip())
+    print_with_line_numbers(ctext)
     heading('End C')
-    heading('Build output')
-    print(output.decode('utf8').rstrip('\n'))
-    heading('End output')


### PR DESCRIPTION
Unfortunately `run_setup` ignores errors. We could go back to using
subprocess but that slows down the tests by 30s on my machine, which
is real bad. (It is worse now that it used to be, I think, since
the setup.py needs to import most of mypy and mypyc.)