### PR TITLE
Set inherits_python when subclassing Generic

### DIFF
--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -142,7 +142,11 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
         base_size = 'sizeof(PyObject)'
     else:
         base_size = 'sizeof({})'.format(struct_name)
-    if cl.inherits_python:
+    # Since our types aren't allocated using type() we need to
+    # populate these fields ourselves if we want them to have correct
+    # values. PyType_Ready will inherit the offsets from tp_base but
+    # that isn't what we want.
+    if any(x.inherits_python for x in cl.mro):
         fields['tp_basicsize'] = '{} + 2*sizeof(PyObject *)'.format(base_size)
         fields['tp_dictoffset'] = base_size
         fields['tp_weaklistoffset'] = '{} + sizeof(PyObject *)'.format(base_size)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -420,6 +420,10 @@ def prepare_class_def(module_name: str, cdef: ClassDef, mapper: Mapper) -> None:
             base_mro.append(base_ir)
         mro.append(base_ir)
 
+    # Generic and similar are python base classes
+    if cdef.removed_base_type_exprs:
+        ir.inherits_python = True
+
     base_idx = 1 if not ir.is_trait else 0
     if len(base_mro) > base_idx:
         ir.base = base_mro[base_idx]


### PR DESCRIPTION
This fixes a nasty segfault that I observed on 3.5.2, though I don't
see a clear reason why it wouldn't be possible in other versions also.