### PR TITLE
Elide range checks when indexing into a list in a for loop

### DIFF
--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -603,6 +603,13 @@ static inline bool CPyTagged_IsLe(CPyTagged left, CPyTagged right) {
     }
 }
 
+static PyObject *CPyList_GetItemUnsafe(PyObject *list, CPyTagged index) {
+    long long n = CPyTagged_ShortAsLongLong(index);
+    PyObject *result = PyList_GET_ITEM(list, n);
+    Py_INCREF(result);
+    return result;
+}
+
 static PyObject *CPyList_GetItemShort(PyObject *list, CPyTagged index) {
     long long n = CPyTagged_ShortAsLongLong(index);
     Py_ssize_t size = PyList_GET_SIZE(list);

--- a/mypyc/genops_for.py
+++ b/mypyc/genops_for.py
@@ -13,7 +13,7 @@ from mypyc.ops import (
     AssignmentTarget
 )
 from mypyc.ops_int import unsafe_short_add
-from mypyc.ops_list import list_len_op
+from mypyc.ops_list import list_len_op, list_get_item_unsafe_op
 from mypyc.ops_misc import iter_op, next_op
 from mypyc.ops_exc import no_err_occurred_op
 import mypyc.genops
@@ -144,9 +144,10 @@ class ForList(ForGenerator):
         builder = self.builder
         line = self.line
         # Read the next list item.
-        value_box = builder.translate_special_method_call(
-            builder.read(self.expr_target, line), '__getitem__',
-            [builder.read(self.index_target, line)], None, line)
+        value_box = builder.primitive_op(
+            list_get_item_unsafe_op,
+            [builder.read(self.expr_target, line), builder.read(self.index_target, line)],
+            line)
         assert value_box
         builder.assign(builder.get_assignment_target(self.index),
                        builder.unbox_or_cast(value_box, self.target_type, line), line)

--- a/mypyc/ops_list.py
+++ b/mypyc/ops_list.py
@@ -59,6 +59,7 @@ list_get_item_unsafe_op = custom_op(
     arg_types=[list_rprimitive, short_int_rprimitive],
     result_type=object_rprimitive,
     error_kind=ERR_NEVER,
+    format_str='{dest} = {args[0]}[{args[1]}] :: unsafe list',
     emit=simple_emit('{dest} = CPyList_GetItemUnsafe({args[0]}, {args[1]});'))
 
 

--- a/mypyc/ops_list.py
+++ b/mypyc/ops_list.py
@@ -54,6 +54,13 @@ method_op(
     emit=simple_emit('{dest} = CPyList_GetItemShort({args[0]}, {args[1]});'),
     priority=2)
 
+list_get_item_unsafe_op = custom_op(
+    name='__getitem__',
+    arg_types=[list_rprimitive, short_int_rprimitive],
+    result_type=object_rprimitive,
+    error_kind=ERR_NEVER,
+    emit=simple_emit('{dest} = CPyList_GetItemUnsafe({args[0]}, {args[1]});'))
+
 
 list_set_item_op = method_op(
     name='__setitem__',

--- a/mypyc/ops_list.py
+++ b/mypyc/ops_list.py
@@ -54,6 +54,8 @@ method_op(
     emit=simple_emit('{dest} = CPyList_GetItemShort({args[0]}, {args[1]});'),
     priority=2)
 
+# This is unsafe because it assumes that the index is a non-negative short integer
+# that is in-bounds for the list.
 list_get_item_unsafe_op = custom_op(
     name='__getitem__',
     arg_types=[list_rprimitive, short_int_rprimitive],

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -1819,7 +1819,7 @@ L1:
     r11 = r9 < r10 :: short_int
     if r11 goto L2 else goto L8 :: bool
 L2:
-    r12 = r7[r9] :: list
+    r12 = r7[r9] :: unsafe list
     r13 = unbox(int, r12)
     x = r13
     r14 = 2
@@ -1883,7 +1883,7 @@ L1:
     r11 = r9 < r10 :: short_int
     if r11 goto L2 else goto L8 :: bool
 L2:
-    r12 = r7[r9] :: list
+    r12 = r7[r9] :: unsafe list
     r13 = unbox(int, r12)
     x = r13
     r14 = 2
@@ -1944,7 +1944,7 @@ L1:
     r3 = r1 < r2 :: short_int
     if r3 goto L2 else goto L4 :: bool
 L2:
-    r4 = l[r1] :: list
+    r4 = l[r1] :: unsafe list
     r5 = unbox(tuple[int, int, int], r4)
     r6 = r5[0]
     x = r6
@@ -1966,7 +1966,7 @@ L5:
     r15 = r13 < r14 :: short_int
     if r15 goto L6 else goto L8 :: bool
 L6:
-    r16 = l[r13] :: list
+    r16 = l[r13] :: unsafe list
     r17 = unbox(tuple[int, int, int], r16)
     r18 = r17[0]
     x0 = r18

--- a/test-data/genops-generators.test
+++ b/test-data/genops-generators.test
@@ -372,7 +372,7 @@ L4:
 L5:
     r21 = r0.__mypyc_temp__0
     r22 = r0.__mypyc_temp__1
-    r23 = r21[r22] :: list
+    r23 = r21[r22] :: unsafe list
     r24 = cast(object, r23)
     r0.i = r24; r25 = is_error
 L6:

--- a/test-data/genops-statements.test
+++ b/test-data/genops-statements.test
@@ -238,7 +238,7 @@ L1:
     r4 = r2 < r3 :: short_int
     if r4 goto L2 else goto L4 :: bool
 L2:
-    r5 = ls[r2] :: list
+    r5 = ls[r2] :: unsafe list
     r6 = unbox(int, r5)
     x = r6
     r7 = y + x :: int
@@ -809,7 +809,7 @@ L1:
     r4 = r2 < r3 :: short_int
     if r4 goto L2 else goto L4 :: bool
 L2:
-    r5 = a[r2] :: list
+    r5 = a[r2] :: unsafe list
     r6 = unbox(int, r5)
     x = r6
     r7 = i + x :: int
@@ -892,7 +892,7 @@ L2:
     r5 = next r2 :: object
     if is_error(r5) goto L7 else goto L3
 L3:
-    r6 = a[r1] :: list
+    r6 = a[r1] :: unsafe list
     r7 = unbox(int, r6)
     x = r7
     r8 = unbox(bool, r5)
@@ -948,7 +948,7 @@ L3:
 L4:
     r9 = unbox(bool, r5)
     x = r9
-    r10 = b[r2] :: list
+    r10 = b[r2] :: unsafe list
     r11 = unbox(int, r10)
     y = r11
     r12 = False


### PR DESCRIPTION
Gets a bit of a win in a microbenchmark