### PR TITLE
Implement native support for 3-op range() and reversed() on lists

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1757,8 +1757,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                 and isinstance(expr.callee, RefExpr)):
             if (expr.callee.fullname == 'builtins.range'
                     and (len(expr.args) <= 2
-                             or (len(expr.args) == 2
-                                 and self.extract_int(expr.args[2]) is not None))
+                         or (len(expr.args) == 2
+                             and self.extract_int(expr.args[2]) is not None))
                     and set(expr.arg_kinds) == {ARG_POS}):
                 # Special case "for x in range(...)".
                 # We support the 3 arg form but only for int literals, since it doesn't

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -62,6 +62,7 @@ from mypyc.ops import (
     MethodCall, INVALID_FUNC_DEF, int_rprimitive, float_rprimitive, bool_rprimitive,
     list_rprimitive, is_list_rprimitive, dict_rprimitive, set_rprimitive, str_rprimitive,
     tuple_rprimitive, none_rprimitive, is_none_rprimitive, object_rprimitive, exc_rtuple,
+    is_tuple_rprimitive,
     PrimitiveOp, ControlOp, LoadErrorValue, ERR_FALSE, OpDescription, RegisterOp,
     is_object_rprimitive, LiteralsMap, FuncSignature, VTableAttr, VTableMethod, VTableEntries,
     NAMESPACE_TYPE, RaiseStandardError, LoadErrorValue, NO_TRACEBACK_LINE_NO, FuncDecl,
@@ -1721,6 +1722,14 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
 
         self.activate_block(exit_block)
 
+    def extract_int(self, e: Expression) -> Optional[int]:
+        if isinstance(e, IntExpr):
+            return e.value
+        elif isinstance(e, UnaryExpr) and e.op == '-' and isinstance(e.expr, IntExpr):
+            return -e.expr.value
+        else:
+            return None
+
     def make_for_loop_generator(self,
                                 index: Lvalue,
                                 expr: Expression,
@@ -1741,25 +1750,34 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             target_type = self.type_to_rtype(target_list_type.args[0])
 
             for_list = ForList(self, index, body_block, loop_exit, line, nested)
-            for_list.init(expr_reg, target_type)
+            for_list.init(expr_reg, target_type, reverse=False)
             return for_list
 
         if (isinstance(expr, CallExpr)
                 and isinstance(expr.callee, RefExpr)):
             if (expr.callee.fullname == 'builtins.range'
-                    and len(expr.args) <= 2
+                    and (len(expr.args) <= 2
+                             or (len(expr.args) == 2
+                                 and self.extract_int(expr.args[2]) is not None))
                     and set(expr.arg_kinds) == {ARG_POS}):
                 # Special case "for x in range(...)".
-                # Only support 1 and 2 arg forms for now.
+                # We support the 3 arg form but only for int literals, since it doesn't
+                # seem worth the hassle of supporting dynamically determining which
+                # direction of comparison to do.
                 if len(expr.args) == 1:
                     start_reg = self.add(LoadInt(0))
                     end_reg = self.accept(expr.args[0])
                 else:
                     start_reg = self.accept(expr.args[0])
                     end_reg = self.accept(expr.args[1])
+                if len(expr.args) == 3:
+                    step = self.extract_int(expr.args[2])
+                    assert step, "range() step can't be zero"
+                else:
+                    step = 1
 
                 for_range = ForRange(self, index, body_block, loop_exit, line, nested)
-                for_range.init(start_reg, end_reg)
+                for_range.init(start_reg, end_reg, step)
                 return for_range
 
             elif (expr.callee.fullname == 'builtins.enumerate'
@@ -1784,6 +1802,20 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                 for_zip = ForZip(self, index, body_block, loop_exit, line, nested)
                 for_zip.init(index.items, expr.args)
                 return for_zip
+
+            if (expr.callee.fullname == 'builtins.reversed'
+                    and len(expr.args) == 1
+                    and expr.arg_kinds == [ARG_POS]
+                    and is_list_rprimitive(self.node_type(expr.args[0]))):
+                # Special case "for x in <list>".
+                expr_reg = self.accept(expr.args[0])
+                target_list_type = self.types[expr.args[0]]
+                assert isinstance(target_list_type, Instance)
+                target_type = self.type_to_rtype(target_list_type.args[0])
+
+                for_list = ForList(self, index, body_block, loop_exit, line, nested)
+                for_list.init(expr_reg, target_type, reverse=True)
+                return for_list
 
         # Default to a generic for loop.
         expr_reg = self.accept(expr)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1807,7 +1807,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                     and len(expr.args) == 1
                     and expr.arg_kinds == [ARG_POS]
                     and is_list_rprimitive(self.node_type(expr.args[0]))):
-                # Special case "for x in <list>".
+                # Special case "for x in reversed(<list>)".
                 expr_reg = self.accept(expr.args[0])
                 target_list_type = self.types[expr.args[0]]
                 assert isinstance(target_list_type, Instance)

--- a/mypyc/genops_for.py
+++ b/mypyc/genops_for.py
@@ -117,26 +117,47 @@ class ForIterable(ForGenerator):
         self.builder.primitive_op(no_err_occurred_op, [], self.line)
 
 
+# TODO: Generalize to support other sequences (tuples at least) with
+# different length and indexing ops.
 class ForList(ForGenerator):
-    """Generate optimized IR for a for loop over a list."""
+    """Generate optimized IR for a for loop over a list.
 
-    def init(self, expr_reg: Value, target_type: RType) -> None:
+    Supports iterating in both forward and reverse."""
+
+    def init(self, expr_reg: Value, target_type: RType, reverse: bool) -> None:
         builder = self.builder
+        self.reverse = reverse
         # Define target to contain the expression, along with the index that will be used
         # for the for-loop. If we are inside of a generator function, spill these into the
         # environment class.
-        index_reg = builder.add(LoadInt(0))
         self.expr_target = builder.maybe_spill(expr_reg)
+        if not reverse:
+            index_reg = builder.add(LoadInt(0))
+        else:
+            index_reg = builder.binary_op(self.load_len(), builder.add(LoadInt(1)), '-', self.line)
         self.index_target = builder.maybe_spill_assignable(index_reg)
         self.target_type = target_type
+
+    def load_len(self) -> Value:
+        return self.builder.add(PrimitiveOp([self.builder.read(self.expr_target, self.line)],
+                                            list_len_op, self.line))
 
     def gen_condition(self) -> None:
         builder = self.builder
         line = self.line
+        if self.reverse:
+            # If we are iterating in reverse order, we obviously need
+            # to check that the index is still positive. Somewhat less
+            # obviously we still need to check against the length,
+            # since it could shrink out from under us.
+            comparison = builder.binary_op(builder.read(self.index_target, line),
+                                           builder.add(LoadInt(0)), '>=', line)
+            second_check = BasicBlock()
+            builder.add_bool_branch(comparison, second_check, self.loop_exit)
+            builder.activate_block(second_check)
         # For compatibility with python semantics we recalculate the length
         # at every iteration.
-        len_reg = builder.add(PrimitiveOp([builder.read(self.expr_target, line)],
-                                          list_len_op, line))
+        len_reg = self.load_len()
         comparison = builder.binary_op(builder.read(self.index_target, line), len_reg, '<', line)
         builder.add_bool_branch(comparison, self.body_block, self.loop_exit)
 
@@ -155,10 +176,11 @@ class ForList(ForGenerator):
         # Step to the next item.
         builder = self.builder
         line = self.line
+        step = 1 if not self.reverse else -1
         builder.assign(self.index_target, builder.primitive_op(
             unsafe_short_add,
             [builder.read(self.index_target, line),
-             builder.add(LoadInt(1))], line), line)
+             builder.add(LoadInt(step))], line), line)
 
 
 class ForRange(ForGenerator):
@@ -166,10 +188,11 @@ class ForRange(ForGenerator):
 
     # TODO: Use a separate register for the index to allow safe index mutation.
 
-    def init(self, start_reg: Value, end_reg: Value) -> None:
+    def init(self, start_reg: Value, end_reg: Value, step: int) -> None:
         builder = self.builder
         self.start_reg = start_reg
         self.end_reg = end_reg
+        self.step = step
         self.end_target = builder.maybe_spill(end_reg)
         # Initialize loop index to 0. Assert that the index target is assignable.
         self.index_target = builder.get_assignment_target(
@@ -180,8 +203,9 @@ class ForRange(ForGenerator):
         builder = self.builder
         line = self.line
         # Add loop condition check.
+        cmp = '<' if self.step > 0 else '>'
         comparison = builder.binary_op(builder.read(self.index_target, line),
-                                       builder.read(self.end_target, line), '<', line)
+                                       builder.read(self.end_target, line), cmp, line)
         builder.add_bool_branch(comparison, self.body_block, self.loop_exit)
 
     def gen_step(self) -> None:
@@ -197,7 +221,7 @@ class ForRange(ForGenerator):
                                    builder.add(LoadInt(1))], line)
         else:
             new_val = builder.binary_op(
-                builder.read(self.index_target, line), builder.add(LoadInt(1)), '+', line)
+                builder.read(self.index_target, line), builder.add(LoadInt(self.step)), '+', line)
         builder.assign(self.index_target, new_val, line)
 
 

--- a/mypyc/genops_for.py
+++ b/mypyc/genops_for.py
@@ -169,6 +169,9 @@ class ForList(ForGenerator):
             builder.read(self.expr_target, line), '__getitem__',
             [builder.read(self.index_target, line)], None, line)
         assert value_box
+        # We coerce to the type of list elements here so that
+        # iterating with tuple unpacking generates a tuple based
+        # unpack instead of an iterator based one.
         builder.assign(builder.get_assignment_target(self.index),
                        builder.unbox_or_cast(value_box, self.target_type, line), line)
 

--- a/test-data/fixtures/ir.py
+++ b/test-data/fixtures/ir.py
@@ -3,7 +3,7 @@
 
 from typing import (
     TypeVar, Generic, List, Iterator, Iterable, Sized, Dict, Optional, Tuple, Any, Set,
-    overload, Mapping, Union, Callable
+    overload, Mapping, Union, Callable, Sequence,
 )
 
 T = TypeVar('T')
@@ -77,7 +77,7 @@ class tuple(Generic[T_co], Sized):
 
 class function: pass
 
-class list(Generic[T], Iterable[T], Sized):
+class list(Generic[T], Sequence[T], Iterable[T], Sized):
     def __init__(self, i: Optional[Iterable[T]] = None) -> None: pass
     @overload
     def __getitem__(self, i: int) -> T: ...
@@ -156,6 +156,7 @@ class NotImplementedError(RuntimeError): pass
 
 def any(i: Iterable[T]) -> bool: pass
 def all(i: Iterable[T]) -> bool: pass
+def reversed(object: Sequence[T]) -> Iterator[T]: ...
 def id(o: object) -> int: pass
 def len(o: Sized) -> int: pass
 def print(*object) -> None: pass

--- a/test-data/genops-generators.test
+++ b/test-data/genops-generators.test
@@ -314,8 +314,9 @@ def yield_for_loop_list__gen.__mypyc_generator_helper__(__mypyc_self__, type, va
     r11 :: list
     r12 :: bool
     r13 :: list
-    r14 :: short_int
-    r15, r16 :: bool
+    r14 :: bool
+    r15 :: short_int
+    r16 :: bool
     r17 :: list
     r18, r19 :: short_int
     r20 :: bool
@@ -360,9 +361,9 @@ L3:
     r11 = [r10]
     r0.l = r11; r12 = is_error
     r13 = r0.l
-    r14 = 0
-    r0.__mypyc_temp__0 = r13; r15 = is_error
-    r0.__mypyc_temp__1 = r14; r16 = is_error
+    r0.__mypyc_temp__0 = r13; r14 = is_error
+    r15 = 0
+    r0.__mypyc_temp__1 = r15; r16 = is_error
 L4:
     r17 = r0.__mypyc_temp__0
     r18 = len r17 :: list

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -51,15 +51,37 @@ def count(n: int) -> None:
 def count_between(n: int, k: int) -> None:
     for i in range(n, k):
         print(i)
+def count_down(n: int, k: int) -> None:
+    for i in range(n, k, -1):
+        print(i)
+def count_double(n: int, k: int) -> None:
+    for i in range(n, k, 2):
+        print(i)
 def list_iter(l: List[int]) -> None:
     for i in l:
         print(i)
+def list_rev_iter(l: List[int]) -> None:
+    for i in reversed(l):
+        print(i)
+def list_rev_iter_lol(l: List[int]) -> None:
+    for i in reversed(l):
+        print(i)
+        if i == 3:
+            while l:
+                l.pop()
 [file driver.py]
-from native import count, list_iter, count_between
+from native import (
+    count, list_iter, list_rev_iter, list_rev_iter_lol, count_between, count_down, count_double,
+)
 count(5)
 list_iter(list(reversed(range(5))))
+list_rev_iter(list(reversed(range(5))))
 count_between(11, 15)
 count_between(10**20, 10**20+3)
+count_down(20, 10)
+count_double(10, 15)
+print('==')
+list_rev_iter_lol(list(reversed(range(5))))
 [out]
 0
 1
@@ -71,6 +93,11 @@ count_between(10**20, 10**20+3)
 2
 1
 0
+0
+1
+2
+3
+4
 11
 12
 13
@@ -78,6 +105,24 @@ count_between(10**20, 10**20+3)
 100000000000000000000
 100000000000000000001
 100000000000000000002
+20
+19
+18
+17
+16
+15
+14
+13
+12
+11
+10
+12
+14
+==
+0
+1
+2
+3
 
 [case testLoopElse]
 from typing import Iterator


### PR DESCRIPTION
Boths ops showed up pretty prominently in the getattr profiles.