### PR TITLE
Add a collection of higher level simple emit functions

### DIFF
--- a/mypyc/ops_dict.py
+++ b/mypyc/ops_dict.py
@@ -8,7 +8,9 @@ from mypyc.ops import (
     ERR_FALSE, ERR_MAGIC, ERR_NEVER,
 )
 from mypyc.ops_primitive import (
-    name_ref_op, method_op, binary_op, func_op, simple_emit, negative_int_emit,
+    name_ref_op, method_op, binary_op, func_op,
+    simple_emit, negative_int_emit,
+    call_emit, call_negative_bool_emit, call_negative_magic_emit,
 )
 
 
@@ -23,7 +25,7 @@ dict_get_item_op = method_op(
     arg_types=[dict_rprimitive, object_rprimitive],
     result_type=object_rprimitive,
     error_kind=ERR_MAGIC,
-    emit=simple_emit('{dest} = CPyDict_GetItem({args[0]}, {args[1]});'))
+    emit=call_emit('CPyDict_GetItem'))
 
 
 dict_set_item_op = method_op(
@@ -31,7 +33,7 @@ dict_set_item_op = method_op(
     arg_types=[dict_rprimitive, object_rprimitive, object_rprimitive],
     result_type=bool_rprimitive,
     error_kind=ERR_FALSE,
-    emit=simple_emit('{dest} = CPyDict_SetItem({args[0]}, {args[1]}, {args[2]}) >= 0;'))
+    emit=call_negative_bool_emit('CPyDict_SetItem'))
 
 
 binary_op(op='in',
@@ -46,7 +48,7 @@ dict_update_op = method_op(
     arg_types=[dict_rprimitive, dict_rprimitive],
     result_type=bool_rprimitive,
     error_kind=ERR_FALSE,
-    emit=simple_emit('{dest} = CPyDict_Update({args[0]}, {args[1]}) != -1;'),
+    emit=call_negative_bool_emit('CPyDict_Update'),
     priority=2)
 
 method_op(
@@ -62,7 +64,7 @@ new_dict_op = func_op(
     result_type=dict_rprimitive,
     error_kind=ERR_MAGIC,
     format_str='{dest} = {{}}',
-    emit=simple_emit('{dest} = PyDict_New();'))
+    emit=call_emit('PyDict_New'))
 
 
 def emit_len(emitter: EmitterInterface, args: List[str], dest: str) -> None:

--- a/mypyc/ops_int.py
+++ b/mypyc/ops_int.py
@@ -6,7 +6,11 @@ from mypyc.ops import (
     RType, EmitterInterface, OpDescription,
     ERR_NEVER, ERR_MAGIC,
 )
-from mypyc.ops_primitive import name_ref_op, binary_op, unary_op, func_op, custom_op, simple_emit
+from mypyc.ops_primitive import (
+    name_ref_op, binary_op, unary_op, func_op, custom_op,
+    simple_emit,
+    call_emit,
+)
 
 # These int constructors produce object_rprimitives that then need to be unboxed
 # I guess unboxing ourselves would save a check and branch though?
@@ -24,7 +28,7 @@ func_op(
     arg_types=[float_rprimitive],
     result_type=object_rprimitive,
     error_kind=ERR_MAGIC,
-    emit=simple_emit('{dest} = CPyLong_FromFloat({args[0]});'),
+    emit=call_emit('CPyLong_FromFloat'),
     priority=1)
 
 
@@ -34,7 +38,7 @@ def int_binary_op(op: str, c_func_name: str, result_type: RType = int_rprimitive
               result_type=result_type,
               error_kind=ERR_NEVER,
               format_str='{dest} = {args[0]} %s {args[1]} :: int' % op,
-              emit=simple_emit('{dest} = %s({args[0]}, {args[1]});' % c_func_name))
+              emit=call_emit(c_func_name))
 
 
 def int_compare_op(op: str, c_func_name: str) -> None:
@@ -86,7 +90,7 @@ def int_unary_op(op: str, c_func_name: str) -> OpDescription:
                     result_type=int_rprimitive,
                     error_kind=ERR_NEVER,
                     format_str='{dest} = %s{args[0]} :: int' % op,
-                    emit=simple_emit('{dest} = %s({args[0]});' % c_func_name))
+                    emit=call_emit(c_func_name))
 
 
 int_neg_op = int_unary_op('-', 'CPyTagged_Negate')

--- a/mypyc/ops_list.py
+++ b/mypyc/ops_list.py
@@ -9,6 +9,7 @@ from mypyc.ops import (
 )
 from mypyc.ops_primitive import (
     name_ref_op, binary_op, func_op, method_op, custom_op, simple_emit,
+    call_emit, call_negative_bool_emit,
 )
 
 
@@ -42,7 +43,7 @@ list_get_item_op = method_op(
     arg_types=[list_rprimitive, int_rprimitive],
     result_type=object_rprimitive,
     error_kind=ERR_MAGIC,
-    emit=simple_emit('{dest} = CPyList_GetItem({args[0]}, {args[1]});'))
+    emit=call_emit('CPyList_GetItem'))
 
 
 # Version with no int bounds check for when it is known to be short
@@ -51,7 +52,7 @@ method_op(
     arg_types=[list_rprimitive, short_int_rprimitive],
     result_type=object_rprimitive,
     error_kind=ERR_MAGIC,
-    emit=simple_emit('{dest} = CPyList_GetItemShort({args[0]}, {args[1]});'),
+    emit=call_emit('CPyList_GetItemShort'),
     priority=2)
 
 # This is unsafe because it assumes that the index is a non-negative short integer
@@ -71,7 +72,7 @@ list_set_item_op = method_op(
     steals=[False, False, True],
     result_type=bool_rprimitive,
     error_kind=ERR_FALSE,
-    emit=simple_emit('{dest} = CPyList_SetItem({args[0]}, {args[1]}, {args[2]}) != 0;'))
+    emit=call_emit('CPyList_SetItem'))
 
 
 list_append_op = method_op(
@@ -79,7 +80,7 @@ list_append_op = method_op(
     arg_types=[list_rprimitive, object_rprimitive],
     result_type=bool_rprimitive,
     error_kind=ERR_FALSE,
-    emit=simple_emit('{dest} = PyList_Append({args[0]}, {args[1]}) != -1;'))
+    emit=call_negative_bool_emit('PyList_Append'))
 
 list_extend_op = method_op(
     name='extend',

--- a/mypyc/ops_set.py
+++ b/mypyc/ops_set.py
@@ -1,5 +1,8 @@
 """Primitive set ops."""
-from mypyc.ops_primitive import func_op, method_op, binary_op, simple_emit, negative_int_emit
+from mypyc.ops_primitive import (
+    func_op, method_op, binary_op,
+    simple_emit, negative_int_emit, call_emit, call_negative_bool_emit,
+)
 from mypyc.ops import (
     object_rprimitive, bool_rprimitive, set_rprimitive, int_rprimitive, ERR_MAGIC, ERR_FALSE,
     ERR_NEVER, EmitterInterface
@@ -20,7 +23,7 @@ func_op(
     arg_types=[object_rprimitive],
     result_type=set_rprimitive,
     error_kind=ERR_MAGIC,
-    emit=simple_emit('{dest} = PySet_New({args[0]});')
+    emit=call_emit('PySet_New')
 )
 
 func_op(
@@ -28,7 +31,7 @@ func_op(
     arg_types=[object_rprimitive],
     result_type=object_rprimitive,
     error_kind=ERR_MAGIC,
-    emit=simple_emit('{dest} = PyFrozenSet_New({args[0]});')
+    emit=call_emit('PyFrozenSet_New')
 )
 
 
@@ -63,7 +66,7 @@ method_op(
     arg_types=[set_rprimitive, object_rprimitive],
     result_type=bool_rprimitive,
     error_kind=ERR_FALSE,
-    emit=simple_emit('{dest} = CPySet_Remove({args[0]}, {args[1]});')
+    emit=call_emit('CPySet_Remove')
 )
 
 
@@ -72,7 +75,7 @@ method_op(
     arg_types=[set_rprimitive, object_rprimitive],
     result_type=bool_rprimitive,
     error_kind=ERR_FALSE,
-    emit=simple_emit('{dest} = PySet_Discard({args[0]}, {args[1]}) >= 0;')
+    emit=call_negative_bool_emit('PySet_Discard')
 )
 
 
@@ -81,7 +84,7 @@ set_add_op = method_op(
     arg_types=[set_rprimitive, object_rprimitive],
     result_type=bool_rprimitive,
     error_kind=ERR_FALSE,
-    emit=simple_emit('{dest} = PySet_Add({args[0]}, {args[1]}) == 0;')
+    emit=call_negative_bool_emit('PySet_Add')
 )
 
 
@@ -90,7 +93,7 @@ method_op(
     arg_types=[set_rprimitive],
     result_type=bool_rprimitive,
     error_kind=ERR_FALSE,
-    emit=simple_emit('{dest} = PySet_Clear({args[0]}) == 0;')
+    emit=call_negative_bool_emit('PySet_Clear')
 )
 
 
@@ -99,5 +102,5 @@ method_op(
     arg_types=[set_rprimitive],
     result_type=object_rprimitive,
     error_kind=ERR_MAGIC,
-    emit=simple_emit('{dest} = PySet_Pop({args[0]});')
+    emit=call_emit('PySet_Pop')
 )

--- a/mypyc/ops_tuple.py
+++ b/mypyc/ops_tuple.py
@@ -10,7 +10,9 @@ from mypyc.ops import (
     EmitterInterface, PrimitiveOp, tuple_rprimitive, int_rprimitive, list_rprimitive,
     object_rprimitive, ERR_NEVER, ERR_MAGIC
 )
-from mypyc.ops_primitive import method_op, func_op, simple_emit
+from mypyc.ops_primitive import (
+    func_op, method_op, call_emit,
+)
 
 
 tuple_get_item_op = method_op(
@@ -18,7 +20,7 @@ tuple_get_item_op = method_op(
     arg_types=[tuple_rprimitive, int_rprimitive],
     result_type=object_rprimitive,
     error_kind=ERR_MAGIC,
-    emit=simple_emit('{dest} = CPySequenceTuple_GetItem({args[0]}, {args[1]});'))
+    emit=call_emit('CPySequenceTuple_GetItem'))
 
 
 def emit_len(emitter: EmitterInterface, args: List[str], dest: str) -> None:
@@ -41,4 +43,4 @@ list_tuple_op = func_op(
     arg_types=[list_rprimitive],
     result_type=tuple_rprimitive,
     error_kind=ERR_MAGIC,
-    emit=simple_emit('{dest} = PyList_AsTuple({args[0]});'))
+    emit=call_emit('PyList_AsTuple'))

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -162,7 +162,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
 
     def test_list_set_item(self) -> None:
         self.assert_emit(PrimitiveOp([self.l, self.n, self.o], list_set_item_op, 55),
-                         """cpy_r_r0 = CPyList_SetItem(cpy_r_l, cpy_r_n, cpy_r_o) != 0;""")
+                         """cpy_r_r0 = CPyList_SetItem(cpy_r_l, cpy_r_n, cpy_r_o);""")
 
     def test_box(self) -> None:
         self.assert_emit(Box(self.n),
@@ -189,7 +189,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
 
     def test_list_append(self) -> None:
         self.assert_emit(PrimitiveOp([self.l, self.o], list_append_op, 1),
-                         """cpy_r_r0 = PyList_Append(cpy_r_l, cpy_r_o) != -1;""")
+                         """cpy_r_r0 = PyList_Append(cpy_r_l, cpy_r_o) >= 0;""")
 
     def test_get_attr(self) -> None:
         self.assert_emit(
@@ -211,7 +211,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
 
     def test_dict_update(self) -> None:
         self.assert_emit(PrimitiveOp([self.d, self.o], dict_update_op, 1),
-                        """cpy_r_r0 = CPyDict_Update(cpy_r_d, cpy_r_o) != -1;""")
+                        """cpy_r_r0 = CPyDict_Update(cpy_r_d, cpy_r_o) >= 0;""")
 
     def test_new_dict(self) -> None:
         self.assert_emit(PrimitiveOp([], new_dict_op, 1),


### PR DESCRIPTION
Most simple_emit calls are just a straightforward function call, maybe
with some special handling of negative values. Expose primitives that
take advantage of this.

I like this, and moves us a tiny bit in the direction of the deeply unlikely hypothetical
where we would be capable of targeting a different backend (LLVM), but maybe it isn't
worth adding all the new emit functions?