### PR TITLE
Optimize int unboxing

### DIFF
--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -293,8 +293,7 @@ static CPyTagged CPyTagged_FromLongLong(long long value) {
 
 static CPyTagged CPyTagged_FromObject(PyObject *object) {
     int overflow;
-    // TODO: This may call __int__ and raise exceptions.
-    PY_LONG_LONG value = PyLong_AsLongLongAndOverflow(object, &overflow);
+    PY_LONG_LONG value = CPyLong_AsLongLongAndOverflow(object, &overflow);
     // We use a Python object if the value shifted left by 1 is too
     // large for long long.
     if (overflow != 0 || CPyTagged_LongLongTooBig(value)) {
@@ -307,8 +306,7 @@ static CPyTagged CPyTagged_FromObject(PyObject *object) {
 
 static CPyTagged CPyTagged_StealFromObject(PyObject *object) {
     int overflow;
-    // TODO: This may call __int__ and raise exceptions.
-    PY_LONG_LONG value = PyLong_AsLongLongAndOverflow(object, &overflow);
+    PY_LONG_LONG value = CPyLong_AsLongLongAndOverflow(object, &overflow);
     // We use a Python object if the value shifted left by 1 is too
     // large for long long.
     if (overflow != 0 || CPyTagged_LongLongTooBig(value)) {
@@ -321,8 +319,7 @@ static CPyTagged CPyTagged_StealFromObject(PyObject *object) {
 
 static CPyTagged CPyTagged_BorrowFromObject(PyObject *object) {
     int overflow;
-    // TODO: This may call __int__ and raise exceptions.
-    PY_LONG_LONG value = PyLong_AsLongLongAndOverflow(object, &overflow);
+    PY_LONG_LONG value = CPyLong_AsLongLongAndOverflow(object, &overflow);
     // We use a Python object if the value shifted left by 1 is too
     // large for long long.  The latter check is micro-optimized where
     // the common case where long long is small enough.

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -6,6 +6,7 @@
 #include <frameobject.h>
 #include <assert.h>
 #include "pythonsupport.h"
+#include "mypyc_util.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,10 +14,6 @@ extern "C" {
 #if 0
 } // why isn't emacs smart enough to not indent this
 #endif
-
-#define likely(x)       __builtin_expect((x),1)
-#define unlikely(x)     __builtin_expect((x),0)
-#define CPy_Unreachable() __builtin_unreachable()
 
 // Naming conventions:
 //
@@ -39,14 +36,6 @@ static void CPyDebug_Print(const char *msg) {
     printf("%s\n", msg);
     fflush(stdout);
 }
-
-// INCREF and DECREF that assert the pointer is not NULL.
-// asserts are disabled in release builds so there shouldn't be a perf hit.
-// I'm honestly kind of surprised that this isn't done by default.
-#define CPy_INCREF(p) do { assert(p); Py_INCREF(p); } while (0)
-#define CPy_DECREF(p) do { assert(p); Py_DECREF(p); } while (0)
-// Here just for consistency
-#define CPy_XDECREF(p) Py_XDECREF(p)
 
 // Search backwards through the trait part of a vtable (which sits *before*
 // the start of the vtable proper) looking for the subvtable describing a trait

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -293,10 +293,9 @@ static CPyTagged CPyTagged_FromLongLong(long long value) {
 
 static CPyTagged CPyTagged_FromObject(PyObject *object) {
     int overflow;
+    // The overflow check knows about CPyTagged's width
     PY_LONG_LONG value = CPyLong_AsLongLongAndOverflow(object, &overflow);
-    // We use a Python object if the value shifted left by 1 is too
-    // large for long long.
-    if (overflow != 0 || CPyTagged_LongLongTooBig(value)) {
+    if (overflow != 0) {
         Py_INCREF(object);
         return ((CPyTagged)object) | CPY_INT_TAG;
     } else {
@@ -306,10 +305,9 @@ static CPyTagged CPyTagged_FromObject(PyObject *object) {
 
 static CPyTagged CPyTagged_StealFromObject(PyObject *object) {
     int overflow;
+    // The overflow check knows about CPyTagged's width
     PY_LONG_LONG value = CPyLong_AsLongLongAndOverflow(object, &overflow);
-    // We use a Python object if the value shifted left by 1 is too
-    // large for long long.
-    if (overflow != 0 || CPyTagged_LongLongTooBig(value)) {
+    if (overflow != 0) {
         return ((CPyTagged)object) | CPY_INT_TAG;
     } else {
         Py_DECREF(object);
@@ -319,12 +317,9 @@ static CPyTagged CPyTagged_StealFromObject(PyObject *object) {
 
 static CPyTagged CPyTagged_BorrowFromObject(PyObject *object) {
     int overflow;
+    // The overflow check knows about CPyTagged's width
     PY_LONG_LONG value = CPyLong_AsLongLongAndOverflow(object, &overflow);
-    // We use a Python object if the value shifted left by 1 is too
-    // large for long long.  The latter check is micro-optimized where
-    // the common case where long long is small enough.
-    if (overflow != 0 || (((unsigned long long)value >= (1LL << 62)) &&
-                          (value >= 0 || value < -(1LL << 62)))) {
+    if (overflow != 0) {
         return ((CPyTagged)object) | CPY_INT_TAG;
     } else {
         return value << 1;

--- a/lib-rt/Makefile
+++ b/lib-rt/Makefile
@@ -14,7 +14,7 @@ CFLAGS += -fPIC
 
 LDFLAGS += $(shell $(PYTHONCONFIG) --ldflags)
 
-test_capi.o: test_capi.cc CPy.h pythonsupport.h Makefile ../mypyc/test/test_external.py
+test_capi.o: test_capi.cc CPy.h pythonsupport.h mypyc_util.h Makefile ../mypyc/test/test_external.py
 	c++ -c -o test_capi.o $(CFLAGS) test_capi.cc
 
 test_capi: test_capi.o

--- a/lib-rt/Makefile
+++ b/lib-rt/Makefile
@@ -14,7 +14,7 @@ CFLAGS += -fPIC
 
 LDFLAGS += $(shell $(PYTHONCONFIG) --ldflags)
 
-test_capi.o: test_capi.cc CPy.h Makefile ../mypyc/test/test_external.py
+test_capi.o: test_capi.cc CPy.h pythonsupport.h Makefile ../mypyc/test/test_external.py
 	c++ -c -o test_capi.o $(CFLAGS) test_capi.cc
 
 test_capi: test_capi.o

--- a/lib-rt/mypyc_util.h
+++ b/lib-rt/mypyc_util.h
@@ -1,0 +1,24 @@
+#ifndef MYPYC_UTIL_H
+#define MYPYC_UTIL_H
+
+#include <Python.h>
+#include <frameobject.h>
+#include <assert.h>
+
+#define likely(x)       __builtin_expect((x),1)
+#define unlikely(x)     __builtin_expect((x),0)
+#define CPy_Unreachable() __builtin_unreachable()
+
+#define CPY_TAGGED_MAX ((1LL << 62) - 1)
+#define CPY_TAGGED_MIN (-(1LL << 62))
+#define CPY_TAGGED_ABS_MIN (0-(unsigned long long)CPY_TAGGED_MIN)
+
+// INCREF and DECREF that assert the pointer is not NULL.
+// asserts are disabled in release builds so there shouldn't be a perf hit.
+// I'm honestly kind of surprised that this isn't done by default.
+#define CPy_INCREF(p) do { assert(p); Py_INCREF(p); } while (0)
+#define CPy_DECREF(p) do { assert(p); Py_DECREF(p); } while (0)
+// Here just for consistency
+#define CPy_XDECREF(p) Py_XDECREF(p)
+
+#endif

--- a/lib-rt/test_capi.cc
+++ b/lib-rt/test_capi.cc
@@ -56,6 +56,7 @@ static PyObject *eval(std::string expr) {
 
 static CPyTagged eval_int(std::string expr) {
     auto o = eval(expr);
+    EXPECT_TRUE(PyLong_Check(o));
     return CPyTagged_FromObject(o);
 }
 
@@ -329,7 +330,7 @@ TEST_F(CAPITest, test_floor_divide_short_int) {
 TEST_F(CAPITest, test_floor_divide_long_int) {
     ASSERT_FLOOR_DIV("2**100", "3", "2**100 // 3");
     ASSERT_FLOOR_DIV("3", "2**100", "0");
-    ASSERT_FLOOR_DIV("2**100", "2**70 / 3", "2**100 // (2**70 / 3)");
+    ASSERT_FLOOR_DIV("2**100", "2**70 // 3", "2**100 // (2**70 // 3)");
 }
 
 #define ASSERT_REMAINDER(x, y, result) \
@@ -360,7 +361,7 @@ TEST_F(CAPITest, test_remainder_short_int) {
 TEST_F(CAPITest, test_remainder_long_int) {
     ASSERT_REMAINDER("2**100", "3", "2**100 % 3");
     ASSERT_REMAINDER("3", "2**100", "3");
-    ASSERT_REMAINDER("2**100", "2**70 / 3", "2**100 % (2**70 / 3)");
+    ASSERT_REMAINDER("2**100", "2**70 // 3", "2**100 % (2**70 // 3)");
 }
 
 #define INT_EQ(x, y) \


### PR DESCRIPTION
Optimize int unboxing by copying `PyLong_AsLongLongAndOverflow` from cpython and modifying it for our use cases by stripping out support for non-int arguments and specializing it for our weird integer range.

This gave a > 2x speedup on an unboxing microbenchmark and 20-30ms on a self-check on my laptop.