### PR TITLE
Add some more primitive builtins

### DIFF
--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -754,6 +754,20 @@ static PyObject *CPyDict_GetItem(PyObject *dict, PyObject *key) {
     }
 }
 
+static PyObject *CPyDict_Get(PyObject *dict, PyObject *key, PyObject *fallback) {
+    // We are dodgily assuming that get on a subclass doesn't have
+    // different behavior.
+    PyObject *res = PyDict_GetItemWithError(dict, key);
+    if (!res) {
+        if (PyErr_Occurred()) {
+            return NULL;
+        }
+        res = fallback;
+    }
+    Py_INCREF(res);
+    return res;
+}
+
 static int CPyDict_SetItem(PyObject *dict, PyObject *key, PyObject *value) {
     if (PyDict_CheckExact(dict)) {
         return PyDict_SetItem(dict, key, value);

--- a/lib-rt/mypyc_util.h
+++ b/lib-rt/mypyc_util.h
@@ -21,4 +21,20 @@
 // Here just for consistency
 #define CPy_XDECREF(p) Py_XDECREF(p)
 
+typedef unsigned long long CPyTagged;
+typedef long long CPySignedInt;
+typedef PyObject CPyModule;
+
+#define CPY_INT_TAG 1
+
+typedef void (*CPyVTableItem)(void);
+
+static inline CPyTagged CPyTagged_ShortFromInt(int x) {
+    return x << 1;
+}
+
+static inline CPyTagged CPyTagged_ShortFromLongLong(long long x) {
+    return x << 1;
+}
+
 #endif

--- a/mypyc/ops_dict.py
+++ b/mypyc/ops_dict.py
@@ -58,6 +58,20 @@ method_op(
     error_kind=ERR_FALSE,
     emit=simple_emit('{dest} = CPyDict_UpdateFromSeq({args[0]}, {args[1]}) != -1;'))
 
+method_op(
+    name='get',
+    arg_types=[dict_rprimitive, object_rprimitive, object_rprimitive],
+    result_type=object_rprimitive,
+    error_kind=ERR_MAGIC,
+    emit=call_emit('CPyDict_Get'))
+
+method_op(
+    name='get',
+    arg_types=[dict_rprimitive, object_rprimitive],
+    result_type=object_rprimitive,
+    error_kind=ERR_MAGIC,
+    emit=simple_emit('{dest} = CPyDict_Get({args[0]}, {args[1]}, Py_None);'))
+
 new_dict_op = func_op(
     name='builtins.dict',
     arg_types=[],

--- a/mypyc/ops_list.py
+++ b/mypyc/ops_list.py
@@ -89,6 +89,27 @@ list_extend_op = method_op(
     error_kind=ERR_MAGIC,
     emit=simple_emit('{dest} = _PyList_Extend((PyListObject *) {args[0]}, {args[1]});'))
 
+method_op(
+    name='pop',
+    arg_types=[list_rprimitive],
+    result_type=object_rprimitive,
+    error_kind=ERR_MAGIC,
+    emit=call_emit('CPyList_PopLast'))
+
+method_op(
+    name='pop',
+    arg_types=[list_rprimitive, int_rprimitive],
+    result_type=object_rprimitive,
+    error_kind=ERR_MAGIC,
+    emit=call_emit('CPyList_Pop'))
+
+method_op(
+    name='count',
+    arg_types=[list_rprimitive, object_rprimitive],
+    result_type=short_int_rprimitive,
+    error_kind=ERR_MAGIC,
+    emit=call_emit('CPyList_Count'))
+
 
 def emit_multiply_helper(emitter: EmitterInterface, dest: str, lst: str, num: str) -> None:
     temp = emitter.temp_name()

--- a/mypyc/ops_set.py
+++ b/mypyc/ops_set.py
@@ -88,6 +88,16 @@ set_add_op = method_op(
 )
 
 
+# This is not a public API but looks like it should be fine.
+method_op(
+    name='update',
+    arg_types=[set_rprimitive, object_rprimitive],
+    result_type=bool_rprimitive,
+    error_kind=ERR_FALSE,
+    emit=call_negative_bool_emit('_PySet_Update')
+)
+
+
 method_op(
     name='clear',
     arg_types=[set_rprimitive],

--- a/test-data/fixtures/ir.py
+++ b/test-data/fixtures/ir.py
@@ -90,7 +90,8 @@ class list(Generic[T], Sequence[T], Iterable[T], Sized):
     def __iter__(self) -> Iterator[T]: pass
     def __len__(self) -> int: pass
     def append(self, x: T) -> None: pass
-    def pop(self) -> T: pass
+    def pop(self, i: int = -1) -> T: pass
+    def count(self, T) -> int: pass
     def extend(self, l: Iterable[T]) -> None: pass
     def insert(self, i: int, x: T) -> None: pass
     def sort(self) -> None: pass

--- a/test-data/fixtures/ir.py
+++ b/test-data/fixtures/ir.py
@@ -115,6 +115,7 @@ class set(Generic[T]):
     def discard(self, x: T) -> None: pass
     def clear(self) -> None: pass
     def pop(self) -> T: pass
+    def update(self, x: Iterable[S]) -> None: pass
     def __or__(self, s: Set[S]) -> Set[Union[T, S]]: ...
 
 class slice: pass

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -673,16 +673,16 @@ L0:
     return r1
 
 [case testPyMethodCall1]
-from typing import List
-def f(x: List[int]) -> int:
-    y = x.pop()
+from typing import Any
+def f(x: Any) -> int:
+    y: int = x.pop()
     return x.pop()
 [out]
 def f(x):
-    x :: list
+    x :: object
     r0 :: str
     r1 :: object
-    r2, y :: int
+    y, r2 :: int
     r3 :: str
     r4 :: object
     r5 :: int

--- a/test-data/genops-set.test
+++ b/test-data/genops-set.test
@@ -15,7 +15,7 @@ def f():
     r8 :: object
     r9 :: bool
 L0:
-    r0 = set 
+    r0 = set
     r1 = 1
     r2 = box(short_int, r1)
     r3 = r0.add(r2) :: set
@@ -35,7 +35,7 @@ def f() -> Set[int]:
 def f():
     r0 :: set
 L0:
-    r0 = set 
+    r0 = set
     return r0
 
 [case testNewSetFromIterable]
@@ -68,7 +68,7 @@ def f():
     r9 :: bool
     r10 :: int
 L0:
-    r0 = set 
+    r0 = set
     r1 = 1
     r2 = box(short_int, r1)
     r3 = r0.add(r2) :: set
@@ -100,7 +100,7 @@ def f():
     r8 :: object
     r9 :: bool
 L0:
-    r0 = set 
+    r0 = set
     r1 = 3
     r2 = box(short_int, r1)
     r3 = r0.add(r2) :: set
@@ -127,7 +127,7 @@ def f():
     r3 :: bool
     r4 :: None
 L0:
-    r0 = set 
+    r0 = set
     x = r0
     r1 = 1
     r2 = box(short_int, r1)
@@ -149,7 +149,7 @@ def f():
     r3 :: bool
     r4 :: None
 L0:
-    r0 = set 
+    r0 = set
     x = r0
     r1 = 1
     r2 = box(short_int, r1)
@@ -171,7 +171,7 @@ def f():
     r3 :: bool
     r4 :: None
 L0:
-    r0 = set 
+    r0 = set
     x = r0
     r1 = 1
     r2 = box(short_int, r1)
@@ -191,7 +191,7 @@ def f():
     r1 :: bool
     r2 :: None
 L0:
-    r0 = set 
+    r0 = set
     x = r0
     r1 = x.clear() :: set
     r2 = None
@@ -210,3 +210,19 @@ L0:
     r0 = s.pop() :: set
     r1 = unbox(int, r0)
     return r1
+
+[case testSetUpdate]
+from typing import Set, List
+def update(s: Set[int], x: List[int]) -> None:
+    s.update(x)
+[out]
+def update(s, x):
+    s :: set
+    x :: list
+    r0 :: bool
+    r1, r2 :: None
+L0:
+    r0 = s.update(x) :: set
+    r1 = None
+    r2 = None
+    return r2

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -334,19 +334,34 @@ print(primes(13))
 -- argh ]]
 
 
-[case testListAppend]
+[case testListPrims]
 from typing import List
-def f(x: List[int], n: int) -> None:
+def append(x: List[int], n: int) -> None:
     x.append(n)
+def pop_last(x: List[int]) -> int:
+    return x.pop()
+def pop(x: List[int], i: int) -> int:
+    return x.pop(i)
+def count(x: List[int], i: int) -> int:
+    return x.count(i)
 [file driver.py]
-from native import f
+from native import append, pop_last, pop, count
 l = [1, 2]
-f(l, 10)
+append(l, 10)
 assert l == [1, 2, 10]
-f(l, 3)
-f(l, 4)
-f(l, 5)
+append(l, 3)
+append(l, 4)
+append(l, 5)
 assert l == [1, 2, 10, 3, 4, 5]
+pop_last(l)
+pop_last(l)
+assert l == [1, 2, 10, 3]
+pop(l, 2)
+assert l == [1, 2, 3]
+pop(l, -2)
+assert l == [1, 3]
+assert count(l, 1) == 1
+assert count(l, 2) == 0
 
 [case testTrue]
 def f() -> bool:

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -715,6 +715,9 @@ def discard1(s: Set[int]) -> None:
 def pop(s : Set[int]) -> int:
     return s.pop()
 
+def update(s: Set[int], x: List[int]) -> None:
+    s.update(x)
+
 [file driver.py]
 from native import instantiateLiteral
 val = instantiateLiteral()
@@ -784,6 +787,11 @@ try:
     w = pop(s)
 except KeyError as e:
     print(e)
+
+from native import update
+s = {1, 2, 3}
+update(s, [5, 4, 3])
+assert s == {1, 2, 3, 4, 5}
 
 [out]
 1


### PR DESCRIPTION
Add builtin support for dict.get, set.update, list.pop, and list.count, which all showed up 
pretty high in the python method call profiles.

Some of these don't have an exposed API so we copy some code.

Gave me about 80ms speedup on a self check (which is a little more than 2%).

Closes #475.