### PR TITLE
Treat all dict subclasses as a dict_rprimitive

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -278,7 +278,10 @@ class Mapper:
                 return bool_rprimitive
             elif typ.type.fullname() == 'builtins.list':
                 return list_rprimitive
-            elif typ.type.fullname() == 'builtins.dict':
+            # Dict subclasses are at least somewhat common and we
+            # specifically support them, so make sure that dict operations
+            # get optimized on them.
+            elif any(cls.fullname() == 'builtins.dict' for cls in typ.type.mro):
                 return dict_rprimitive
             elif typ.type.fullname() == 'builtins.set':
                 return set_rprimitive

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -860,3 +860,21 @@ L0:
     __mypyc_self__.x = r10; r11 = is_error
     r12 = True
     return r12
+
+[case testSubclassDictSpecalized]
+from typing import Dict
+class WelpDict(Dict[str, int]):
+    pass
+def foo(x: WelpDict) -> None:
+    # we care that the specalized op gets used
+    x.update(x)
+[out]
+def foo(x):
+    x :: dict
+    r0 :: bool
+    r1, r2 :: None
+L0:
+    r0 = x.update(x) :: dict
+    r1 = None
+    r2 = None
+    return r2


### PR DESCRIPTION
This allows us to use optimized dict operations on them.